### PR TITLE
feat: add frame perf samples and phase 2 benchmark baseline

### DIFF
--- a/docs/high-throughput-rendering.md
+++ b/docs/high-throughput-rendering.md
@@ -297,7 +297,7 @@ type FramePerf = {
     candidates?: number;
   }>;
   droppedUpdates: number;
-  coalescedEvents: number;
+  coalescedInvalidates: number;
   heapUsed?: number;
 };
 ```
@@ -309,7 +309,7 @@ type FramePerf = {
 - `scannedNodes`
 - `paintedNodes`
 - `queueDepth`
-- `coalescedEvents`
+- `coalescedInvalidates`
 - `droppedUpdates`
 
 验收测试：
@@ -324,18 +324,18 @@ type FramePerf = {
 
 目标是降低滚动卡顿和一帧延迟，尽量少改公共 API。
 
-| 项目                                                                | 状态       |
-| ------------------------------------------------------------------- | ---------- |
-| DOM renderer `commit({ sync: true })` same-frame flush              | ✅ done    |
-| RenderManager row buckets (partial repaint)                         | ✅ done    |
-| `TVirtualList` data-source API (`itemCount/getItem/itemVersion`)    | ✅ done    |
-| Headless/CLI full-row `rowScrollMode` exposed rows                  | ✅ done    |
-| DOM `TVirtualList` slow wheel exposed rows                          | 🔲 Phase 2 |
-| DOM sync flush scoped to current commit rows/planes                 | ✅ done    |
-| Row bucket degradation threshold (50%/60%)                          | ✅ done    |
-| `TVirtualList.rowScrollMode` opt-in for unsafe row-scroll fast path | ✅ done    |
-| `TList` wheel 行为修改（不再同步更新 active/modelValue）            | 🔲 planned |
-| Debug overlay 展示 `scannedNodes/paintedNodes/dirtyRows/frameMs`    | 🔲 planned |
+| 项目                                                                | 状态         |
+| ------------------------------------------------------------------- | ------------ |
+| DOM renderer `commit({ sync: true })` same-frame flush              | ✅ done      |
+| RenderManager row buckets (partial repaint)                         | ✅ done      |
+| `TVirtualList` data-source API (`itemCount/getItem/itemVersion`)    | ✅ done      |
+| Headless/CLI full-row `rowScrollMode` exposed rows                  | ✅ done      |
+| DOM `TVirtualList` slow wheel exposed rows                          | 🔲 Phase 2   |
+| DOM sync flush scoped to current commit rows/planes                 | ✅ done      |
+| Row bucket degradation threshold (50%/60%)                          | ✅ done      |
+| `TVirtualList.rowScrollMode` opt-in for unsafe row-scroll fast path | ✅ done      |
+| `TList` wheel 行为修改（不再同步更新 active/modelValue）            | 🔲 planned   |
+| Debug overlay 展示 `scannedNodes/paintedNodes/dirtyRows/frameMs`    | ✅ Phase 2.0 |
 
 > **注意**：`TVirtualList` 的 `rowScrollMode` 默认为 `"off"`。这是危险优化开关，只有显式设置 `rowScrollMode: "unsafe-full-row"` 的 headless/CLI full-row 且独占这些 plane rows 的场景才会使用 `unsafeScrollPlaneRows()` + exposed dirty rows。DOM 端慢滚仍然 repaint viewport，真正 DOM exposed rows 要等 DomRenderer 支持 `scrollOperations`。
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -7,9 +7,10 @@
 - 某个局部更新意外带动了整轮 redraw
 - plane 本来应该隔离，却在同一帧里一起刷新了
 
-这个仓库现在提供 3 类轻量 observability 能力：
+这个仓库现在提供 4 类轻量 observability 能力：
 
 - **Frame trace**：按 commit 记录 `dirtyRows`、`planes` 和 `focusedId`
+- **FramePerf samples**：按 scheduler frame 记录 `frameMs`、`renderManagerMs`、`commitMs`、renderer flush 和 dirty row/node 统计
 - **TUI profiler**：按时间窗口统计 invalidates / renders / writes，并拆分 plane 维度
 - **Debug overlay**：可视化 focus ring 和 rect outlines
 
@@ -63,6 +64,27 @@ DIMCODE_PROFILE_TUI=1
 - `chrome` 更新时 `transcript` 是否仍被拉进了 render
 - stdout 最坏一次写出是否在变大
 
+## FramePerf
+
+`createFramePerfStore()` 使用 bounded ring buffer 保存最近 frame samples。默认不开启；设置 `globalThis.__VT_DEBUG_PERF__ = true` 或挂载 `TDebugOverlay` 后开始采样。
+
+每个 sample 包含：
+
+- `durationMs`
+- `renderManagerMs`
+- `commitMs`
+- `domFlushMs` / `stdoutFlushMs`
+- `dirtyRows`
+- `activePlanes`
+- `scannedNodes` / `paintedNodes`
+- `rowBucketFallbacks`
+- `coalescedInvalidates`
+- `queueDepth`
+
+Phase 2.0 里 `droppedUpdates` 保留为后续 scheduler backpressure 指标，当前恒为 `0`。`coalescedInvalidates` 只统计 scheduler invalidate coalescing，不包含组件本地 wheel/input coalescer。`domFlushMs` 只记录与本 scheduler frame 同调用栈完成的 DOM flush；普通 rAF-deferred DOM flush 会体现在 `renderer.debugStats.flush.last`，不会 retroactively 更新已经 push 的 frame sample。DOM renderer flush stats 里的 `planeRows` 是 flushed plane-row line elements，不是去重后的 terminal rows。
+
+这让高频输入、滚动和 streaming 输出可以用同一组指标比较，而不是只看体感。
+
 ## Debug Overlay
 
 `TDebugOverlay` 适合看：
@@ -70,11 +92,13 @@ DIMCODE_PROFILE_TUI=1
 - focus 现在落在哪个 node
 - 命中矩形是否偏移
 - 哪块区域的交互边界和视觉边界不一致
+- 最近一帧的 `frameMs`、dirty rows、RenderManager nodes 和 DOM flush 数据
 
 这类问题通常和性能问题一起出现，因为“错误的 rect”经常也意味着“错误的重绘范围”。
 
 ## 推荐排查顺序
 
 1. 先开 trace，看 `commit.planes` 是否符合预期
-2. 再开 profiler，看 `planes.invalidate` / `planes.render` 是否收敛
-3. 如果是点击、焦点、hover 这类问题，再用 `TDebugOverlay` 看 rect 和 focus
+2. 再看 FramePerf，确认瓶颈在 scheduler frame、RenderManager、commit 还是 renderer flush
+3. 再开 profiler，看 `planes.invalidate` / `planes.render` 是否收敛
+4. 如果是点击、焦点、hover 这类问题，再用 `TDebugOverlay` 看 rect 和 focus

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -47,6 +47,7 @@ Vue TUI 的性能瓶颈通常来自三部分：
 
 - 关注 `dirtyRows`：是否明显偏大（接近全屏）
 - 关注 `planes`：一次很小的交互是否错误地带上了 `transcript + chrome + overlay`
+- 关注 FramePerf：`frameMs`、`renderManagerMs`、`commitMs`、`domFlushMs`、`scannedNodes` 和 `paintedNodes`
 - stdout 模式：是否频繁输出大量 `\u001B[row;colH` + 多行文本（说明 repaint 行多）
 - DOM 模式：是否每次交互都重建大量 span（说明 repaint 范围大或节点过多）
 - 开启 `DIMCODE_PROFILE_TUI=1` 后，重点看：
@@ -55,3 +56,21 @@ Vue TUI 的性能瓶颈通常来自三部分：
   - `avgNodes`
   - `maxMs`
   - `maxWriteMs`
+
+## Benchmark baseline
+
+Phase 2 baseline 使用：
+
+```bash
+pnpm run bench:phase2
+```
+
+脚本输出 JSON，覆盖：
+
+- 1000 render nodes / dirty 1 row
+- `TVirtualList` 10k / 100k rows spaced wheel 100 ticks
+- `TVirtualList` 10k / 100k rows burst wheel 100 ticks with manual rAF flush
+- DOM sync flush 1 / 5 / 20 / 40 dirty rows
+- append-only 1000 lines simulated path
+
+`bench:phase2` 使用 happy-dom synthetic baseline，适合做相同环境下的回归对比，不代表真实浏览器 FPS。

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "test:package-exports": "pnpm run build && VUE_TUI_REQUIRE_DIST_EXPORTS=1 vitest run test/package-exports.test.ts",
     "typecheck": "tsc --noEmit",
     "e2e": "playwright test",
-    "bench:vfor": "tsx scripts/bench-vfor.ts"
+    "bench:vfor": "tsx scripts/bench-vfor.ts",
+    "bench:phase2": "tsx scripts/bench-phase2.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/scripts/bench-phase2.ts
+++ b/scripts/bench-phase2.ts
@@ -1,0 +1,371 @@
+import { Window } from "happy-dom";
+
+function setGlobal(key: string, value: unknown): void {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+const win = new Window();
+setGlobal("window", win);
+setGlobal("document", win.document);
+setGlobal("navigator", win.navigator);
+setGlobal("Node", win.Node);
+setGlobal("Element", win.Element);
+setGlobal("HTMLElement", win.HTMLElement);
+setGlobal("SVGElement", win.SVGElement);
+setGlobal("Event", win.Event);
+setGlobal("EventTarget", win.EventTarget);
+setGlobal("CustomEvent", win.CustomEvent);
+setGlobal("MouseEvent", win.MouseEvent);
+setGlobal("KeyboardEvent", win.KeyboardEvent);
+setGlobal("WheelEvent", win.WheelEvent);
+setGlobal("getComputedStyle", win.getComputedStyle.bind(win));
+setGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+  cb(0);
+  return 1;
+});
+setGlobal("cancelAnimationFrame", () => {});
+
+type RafHarness = Readonly<{
+  scheduledRafFrames: () => number;
+  pendingRafFrames: () => number;
+  flushOneFrame: (time?: number) => number;
+  restore: () => void;
+}>;
+
+function now(): number {
+  return typeof performance !== "undefined" ? performance.now() : Date.now();
+}
+
+function installCountingSyncRaf(): RafHarness {
+  const previousRaf = globalThis.requestAnimationFrame;
+  const previousCancel = globalThis.cancelAnimationFrame;
+  let scheduled = 0;
+
+  setGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    scheduled++;
+    cb(now());
+    return scheduled;
+  });
+  setGlobal("cancelAnimationFrame", () => {});
+
+  return {
+    scheduledRafFrames: () => scheduled,
+    pendingRafFrames: () => 0,
+    flushOneFrame: () => 0,
+    restore: () => {
+      setGlobal("requestAnimationFrame", previousRaf);
+      setGlobal("cancelAnimationFrame", previousCancel);
+    },
+  };
+}
+
+function installManualRaf(): RafHarness {
+  const previousRaf = globalThis.requestAnimationFrame;
+  const previousCancel = globalThis.cancelAnimationFrame;
+  const callbacks = new Map<number, FrameRequestCallback>();
+  let id = 0;
+  let scheduled = 0;
+
+  setGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    const nextId = ++id;
+    scheduled++;
+    callbacks.set(nextId, cb);
+    return nextId;
+  });
+  setGlobal("cancelAnimationFrame", (rafId: number) => {
+    callbacks.delete(rafId);
+  });
+
+  return {
+    scheduledRafFrames: () => scheduled,
+    pendingRafFrames: () => callbacks.size,
+    flushOneFrame: (time = now()) => {
+      const pending = Array.from(callbacks.entries());
+      callbacks.clear();
+      for (const [, cb] of pending) cb(time);
+      return pending.length;
+    },
+    restore: () => {
+      setGlobal("requestAnimationFrame", previousRaf);
+      setGlobal("cancelAnimationFrame", previousCancel);
+    },
+  };
+}
+
+const { defineComponent, h, nextTick, ref } = await import("vue");
+const { createDomRenderer, createTerminal, createTerminalApp, TText, useTerminal } =
+  await import("../src/index.js");
+const { TVirtualList } = await import("../src/experimental.js");
+const { createRenderManager } = await import("../src/vue/render/render-manager.js");
+
+function round(n: number): number {
+  return Number(n.toFixed(3));
+}
+
+function summarizeSamples(samples: any[]): Record<string, number> {
+  if (!samples.length) {
+    return {
+      frames: 0,
+      avgFrameMs: 0,
+      maxFrameMs: 0,
+      avgRenderManagerMs: 0,
+      avgCommitMs: 0,
+      avgDirtyRows: 0,
+      avgScannedNodes: 0,
+      avgPaintedNodes: 0,
+      avgCoalescedInvalidates: 0,
+    };
+  }
+  const total = samples.reduce(
+    (acc, sample) => {
+      acc.frame += sample.durationMs;
+      acc.render += sample.renderManagerMs;
+      acc.commit += sample.commitMs;
+      acc.dirty += sample.dirtyRows ?? 0;
+      acc.scanned += sample.scannedNodes;
+      acc.painted += sample.paintedNodes;
+      acc.coalescedInvalidates += sample.coalescedInvalidates ?? 0;
+      if (sample.durationMs > acc.maxFrame) acc.maxFrame = sample.durationMs;
+      return acc;
+    },
+    {
+      frame: 0,
+      render: 0,
+      commit: 0,
+      dirty: 0,
+      scanned: 0,
+      painted: 0,
+      coalescedInvalidates: 0,
+      maxFrame: 0,
+    },
+  );
+  return {
+    frames: samples.length,
+    avgFrameMs: round(total.frame / samples.length),
+    maxFrameMs: round(total.maxFrame),
+    avgRenderManagerMs: round(total.render / samples.length),
+    avgCommitMs: round(total.commit / samples.length),
+    avgDirtyRows: round(total.dirty / samples.length),
+    avgScannedNodes: round(total.scanned / samples.length),
+    avgPaintedNodes: round(total.painted / samples.length),
+    avgCoalescedInvalidates: round(total.coalescedInvalidates / samples.length),
+  };
+}
+
+async function benchRenderManagerDirtyRow(): Promise<Record<string, unknown>> {
+  const rows = 1000;
+  const cols = 80;
+  const terminal = createTerminal({ cols, rows });
+  const render = createRenderManager(terminal);
+  const nodes = Array.from({ length: rows }, (_, y) =>
+    render.register({
+      stack: render.rootStack,
+      rect: { x: 0, y, w: cols, h: 1 },
+      paint: () => terminal.write(`row ${y}`, { x: 0, y }),
+    }),
+  );
+  render.render();
+  terminal.commit();
+
+  const target = nodes[500]!;
+  const startedAt = now();
+  render.update(target.id, { dirtyRowsHint: [500] });
+  const stats = render.render();
+  const dirtyRows = terminal.commit({ sync: true });
+  const durationMs = now() - startedAt;
+
+  return {
+    name: "render-manager-1000-nodes-dirty-1-row",
+    durationMs: round(durationMs),
+    dirtyRows: dirtyRows === null ? null : dirtyRows.length,
+    scannedNodes: stats?.scannedNodes ?? 0,
+    paintedNodes: stats?.paintedNodes ?? 0,
+  };
+}
+
+async function benchVirtualList(
+  itemCount: number,
+  mode: "spaced" | "burst",
+): Promise<Record<string, unknown>> {
+  let framePerf: any = null;
+  let finalTop = 0;
+  const dispatchedEvents = 100;
+  const acceptedTickGapMs = 10;
+  const getItem = (index: number) => `item-${index}`;
+  const raf = mode === "burst" ? installManualRaf() : installCountingSyncRaf();
+
+  const App = defineComponent({
+    name: `BenchVirtualList${itemCount}${mode}`,
+    setup() {
+      const ctx = useTerminal();
+      framePerf = ctx.observability.framePerf;
+      framePerf.enabled.value = true;
+      return () =>
+        h(TVirtualList, {
+          x: 0,
+          y: 0,
+          w: 80,
+          h: 20,
+          itemCount,
+          itemVersion: 1,
+          getItem,
+          autoFocus: true,
+          onScroll: (top: number) => {
+            finalTop = top;
+          },
+        });
+    },
+  });
+
+  const app = createTerminalApp({ cols: 80, rows: 24, component: App as any });
+  try {
+    app.mount();
+    await nextTick();
+    app.scheduler.flushNow();
+    framePerf.clear();
+
+    const startedAt = now();
+    for (let i = 0; i < dispatchedEvents; i++) {
+      app.events.dispatch({
+        type: "wheel",
+        cellX: 0,
+        cellY: 0,
+        deltaY: 100,
+        time: startedAt + i * acceptedTickGapMs,
+      });
+      if (mode === "spaced") await nextTick();
+    }
+    const framesBeforeRafFlush = framePerf.list().length;
+    const pendingRafFramesBeforeFlush = raf.pendingRafFrames();
+    const flushedRafCallbacks =
+      mode === "burst" ? raf.flushOneFrame(startedAt + dispatchedEvents * acceptedTickGapMs) : 0;
+    if (mode === "burst") await nextTick();
+    const durationMs = now() - startedAt;
+    const samples = framePerf.list();
+    const acceptedScrollFrames = samples.filter((sample: any) => sample.reason === "scroll").length;
+
+    return {
+      name: `virtual-list-${itemCount}-rows-wheel-${mode}-100`,
+      dispatchedEvents,
+      acceptedTickGapMs,
+      scheduledRafFrames: raf.scheduledRafFrames(),
+      pendingRafFramesBeforeFlush,
+      flushedRafCallbacks,
+      framesBeforeRafFlush,
+      acceptedScrollFrames,
+      coalescingRatio: round(dispatchedEvents / Math.max(1, acceptedScrollFrames)),
+      finalTop,
+      durationMs: round(durationMs),
+      ...summarizeSamples(samples),
+    };
+  } finally {
+    app.dispose();
+    raf.restore();
+  }
+}
+
+function benchDomSyncFlush(dirtyRowCount: number): Record<string, unknown> {
+  const terminal = createTerminal({ cols: 80, rows: 40 });
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const renderer = createDomRenderer(terminal, container);
+
+  try {
+    for (let y = 0; y < dirtyRowCount; y++) terminal.write(`row ${y}`, { x: 0, y });
+    const startedAt = now();
+    const dirtyRows = terminal.commit({ sync: true });
+    const durationMs = now() - startedAt;
+    const flush = renderer.debugStats.flush.last;
+
+    return {
+      name: `dom-sync-flush-${dirtyRowCount}-dirty-rows`,
+      durationMs: round(durationMs),
+      dirtyRows: dirtyRows === null ? null : dirtyRows.length,
+      domFlushMs: flush ? round(flush.durationMs) : null,
+      domFlushPlaneRows: flush?.planeRows ?? 0,
+      syncPerformed: renderer.debugStats.syncFlush.last?.performed ?? false,
+    };
+  } finally {
+    renderer.dispose();
+    container.remove();
+  }
+}
+
+async function benchAppendOnly(): Promise<Record<string, unknown>> {
+  const lines = ref<string[]>([]);
+  let framePerf: any = null;
+
+  const App = defineComponent({
+    name: "BenchAppendOnly",
+    setup() {
+      const ctx = useTerminal();
+      framePerf = ctx.observability.framePerf;
+      framePerf.enabled.value = true;
+      return () => {
+        const tail = lines.value.slice(-20);
+        return tail.map((line, index) =>
+          h(TText, { key: index, x: 0, y: index, w: 80, value: line }),
+        );
+      };
+    },
+  });
+
+  const app = createTerminalApp({ cols: 80, rows: 24, component: App as any });
+  try {
+    app.mount();
+    await nextTick();
+    app.scheduler.flushNow();
+    framePerf.clear();
+
+    const startedAt = now();
+    for (let i = 0; i < 1000; i++) {
+      lines.value = [...lines.value, `line ${i}`];
+      await nextTick();
+      app.scheduler.flushNow();
+    }
+    const durationMs = now() - startedAt;
+
+    return {
+      name: "append-only-1000-lines-simulated",
+      durationMs: round(durationMs),
+      ...summarizeSamples(framePerf.list()),
+    };
+  } finally {
+    app.dispose();
+  }
+}
+
+async function main(): Promise<void> {
+  const scenarios = [
+    await benchRenderManagerDirtyRow(),
+    await benchVirtualList(10_000, "spaced"),
+    await benchVirtualList(10_000, "burst"),
+    await benchVirtualList(100_000, "spaced"),
+    await benchVirtualList(100_000, "burst"),
+    ...[1, 5, 20, 40].map((rows) => benchDomSyncFlush(rows)),
+    await benchAppendOnly(),
+  ];
+
+  // eslint-disable-next-line no-console
+  console.log(
+    JSON.stringify(
+      {
+        tag: "vue-tui-phase2-benchmark",
+        generatedAt: new Date().toISOString(),
+        scenarios,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((error) => {
+  // eslint-disable-next-line no-console
+  console.error(error);
+  process.exit(1);
+});

--- a/src/create-terminal-app.ts
+++ b/src/create-terminal-app.ts
@@ -20,6 +20,8 @@ import { createNodePathPickerProvider } from "./cli/path-provider.js";
 import { createTerminal } from "./core/index.js";
 import { createCliEventManager } from "./events/index.js";
 import { getCliLatencyProfiler } from "./observability/cli-latency.js";
+import { framePerfNow, mergeFramePerfReason } from "./observability/frame-perf.js";
+import { createFramePerfStore } from "./observability/frame-perf-store.js";
 import { createTraceStore } from "./observability/trace.js";
 import { createTuiProfiler } from "./observability/tui-profiler.js";
 import { HEADLESS_RENDERER_CAPABILITIES } from "./renderer/index.js";
@@ -115,6 +117,9 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
   const trace = createTraceStore({
     enabled: Boolean((globalThis as any).__VT_DEBUG_TRACE__),
   });
+  const framePerf = createFramePerfStore(120, {
+    enabled: Boolean((globalThis as any).__VT_DEBUG_PERF__),
+  });
   const latency = getCliLatencyProfiler();
   const profiler = createTuiProfiler("cli-scheduler");
   const events = createCliEventManager({
@@ -151,6 +156,9 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
   let pendingInvalidateAfterFlush = false;
   let pendingInvalidateAllPlanes = false;
   const pendingInvalidatePlanes = new Set<TerminalRenderPlane>();
+  let frameId = 0;
+  let pendingFrameReason: TerminalSchedulerInvalidateOptions["reason"] = "unknown";
+  let pendingCoalescedInvalidates = 0;
   const env = (process?.env ?? {}) as Record<string, unknown>;
   const throttleMs = (() => {
     const raw = env.DIMCODE_TUI_THROTTLE_MS;
@@ -185,6 +193,15 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
     return activePlanes;
   }
 
+  function queueDepth(): number {
+    return (scheduled ? 1 : 0) + (timer ? 1 : 0) + (pendingInvalidateAfterFlush ? 1 : 0);
+  }
+
+  function noteFrameReason(reason: TerminalSchedulerInvalidateOptions["reason"]): void {
+    if (!reason || reason === "unknown") return;
+    pendingFrameReason = mergeFramePerfReason(pendingFrameReason, reason);
+  }
+
   function flush(sync?: boolean): void {
     if (disposed) return;
 
@@ -193,15 +210,63 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
 
     const activePlanes = takeActivePlanes();
     latency?.recordFlushStart({ sync, activePlanes });
+    if (!framePerf.enabled.value) {
+      try {
+        render.render({ activePlanes });
+        terminal.commit({ planes: activePlanes, sync });
+      } finally {
+        latency?.recordFlushEnd();
+        flushing = false;
+        lastFlushAtMs = Date.now();
+        scheduledAtMs = 0;
+      }
+
+      if (pendingInvalidateAfterFlush) {
+        pendingInvalidateAfterFlush = false;
+        flush(true);
+      }
+      return;
+    }
+
+    const startedAt = framePerfNow();
+    const currentFrameId = ++frameId;
+    const reason = pendingFrameReason ?? "unknown";
+    const coalescedInvalidates = pendingCoalescedInvalidates;
+    pendingFrameReason = "unknown";
+    pendingCoalescedInvalidates = 0;
+    let stats: ReturnType<typeof render.render> = null;
+    let dirtyRows: readonly number[] | null = [];
+    let renderManagerMs = 0;
+    let commitMs = 0;
     try {
-      render.render({ activePlanes });
-      terminal.commit({ planes: activePlanes, sync });
+      const renderStartedAt = framePerfNow();
+      stats = render.render({ activePlanes });
+      renderManagerMs = framePerfNow() - renderStartedAt;
+      const commitStartedAt = framePerfNow();
+      dirtyRows = terminal.commit({ planes: activePlanes, sync });
+      commitMs = framePerfNow() - commitStartedAt;
     } finally {
       latency?.recordFlushEnd();
       flushing = false;
       lastFlushAtMs = Date.now();
       scheduledAtMs = 0;
     }
+    framePerf.push({
+      frameId: currentFrameId,
+      reason,
+      startedAt,
+      durationMs: framePerfNow() - startedAt,
+      renderManagerMs,
+      commitMs,
+      dirtyRows: dirtyRows === null ? null : dirtyRows.length,
+      activePlanes: activePlanes ? [...activePlanes] : null,
+      scannedNodes: stats?.scannedNodes ?? 0,
+      paintedNodes: stats?.paintedNodes ?? 0,
+      rowBucketFallbacks: stats?.rowBucketFallbacks,
+      coalescedInvalidates,
+      droppedUpdates: 0,
+      queueDepth: queueDepth(),
+    });
 
     if (pendingInvalidateAfterFlush) {
       pendingInvalidateAfterFlush = false;
@@ -260,6 +325,7 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
   function invalidate(options?: TerminalSchedulerInvalidateOptions): void {
     if (disposed) return;
     const priority = options?.priority ?? "normal";
+    noteFrameReason(options?.reason);
     latency?.recordSchedulerInvalidate({
       priority,
       plane: options?.plane ?? null,
@@ -294,6 +360,8 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
       scheduleFlushAt(desiredAtMs);
       return;
     }
+
+    pendingCoalescedInvalidates++;
 
     if (!scheduledAtMs) {
       scheduleFlushAt(desiredAtMs);
@@ -362,7 +430,7 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
   const offResize = terminal.on("resize", ({ cols, rows }) => {
     rootLayout.clipRect = { x: 0, y: 0, w: cols, h: rows };
     // Ensure resize triggers a re-render even if no other reactive state changes.
-    invalidate();
+    invalidate({ reason: "resize" });
   });
 
   const ctx: TerminalContext = {
@@ -372,7 +440,7 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
     events: shallowRef(events as any),
     scheduler: { invalidate, flush, flushNow },
     runtime,
-    observability: { trace },
+    observability: { trace, framePerf },
     defaultStyle: ref(options.defaultStyle ?? {}),
     render,
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,14 @@ export type {
 
 export { createCliEventManager, createEventManager } from "./events/index.js";
 export { getCliLatencyProfiler } from "./observability/cli-latency.js";
+export type {
+  FramePerfReason,
+  FramePerfRowBucketFallback,
+  FramePerfSample,
+} from "./observability/frame-perf.js";
+export { framePerfNow } from "./observability/frame-perf.js";
+export type { FramePerfStore } from "./observability/frame-perf-store.js";
+export { createFramePerfStore } from "./observability/frame-perf-store.js";
 export type { TraceRecord, TraceStore } from "./observability/trace.js";
 export { createTraceStore } from "./observability/trace.js";
 
@@ -81,6 +89,8 @@ export type {
   CellMetrics,
   DomRenderer,
   DomRendererDebugStats,
+  DomRendererFlushSample,
+  DomRendererFlushStats,
   DomRendererOptions,
   DomRendererSyncFlushDecision,
   DomRendererSyncFlushStats,

--- a/src/observability/frame-perf-store.ts
+++ b/src/observability/frame-perf-store.ts
@@ -1,0 +1,58 @@
+import type { Ref } from "vue";
+import type { FramePerfSample } from "./frame-perf.js";
+import { computed, ref } from "vue";
+
+export type FramePerfStore = Readonly<{
+  enabled: Ref<boolean>;
+  acquire: (reason?: string) => () => void;
+  push: (sample: FramePerfSample) => void;
+  latest: () => FramePerfSample | null;
+  list: () => FramePerfSample[];
+  clear: () => void;
+}>;
+
+export function createFramePerfStore(
+  limit = 120,
+  opts?: Readonly<{ enabled?: boolean }>,
+): FramePerfStore {
+  const max = Math.max(1, Math.floor(limit));
+  const manualEnabled = ref(Boolean(opts?.enabled));
+  const leaseCount = ref(0);
+  const enabled = computed({
+    get: () => manualEnabled.value || leaseCount.value > 0,
+    set: (next) => {
+      manualEnabled.value = Boolean(next);
+    },
+  });
+  const samples: FramePerfSample[] = [];
+
+  function acquire(_reason?: string): () => void {
+    leaseCount.value++;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      leaseCount.value = Math.max(0, leaseCount.value - 1);
+    };
+  }
+
+  function push(sample: FramePerfSample): void {
+    if (!enabled.value) return;
+    samples.push(sample);
+    if (samples.length > max) samples.splice(0, samples.length - max);
+  }
+
+  function latest(): FramePerfSample | null {
+    return samples.at(-1) ?? null;
+  }
+
+  function list(): FramePerfSample[] {
+    return samples.slice();
+  }
+
+  function clear(): void {
+    samples.length = 0;
+  }
+
+  return { enabled, acquire, push, latest, list, clear };
+}

--- a/src/observability/frame-perf.ts
+++ b/src/observability/frame-perf.ts
@@ -1,0 +1,60 @@
+export type FramePerfReason =
+  | "scroll"
+  | "input"
+  | "stream"
+  | "resize"
+  | "data"
+  | "manual"
+  | "unknown";
+
+const FRAME_PERF_REASON_PRIORITY: Record<FramePerfReason, number> = {
+  unknown: 0,
+  manual: 1,
+  data: 2,
+  stream: 3,
+  resize: 4,
+  scroll: 5,
+  input: 6,
+};
+
+export type FramePerfRowBucketFallback = Readonly<{
+  plane: string;
+  reason: "dirty-ratio" | "candidate-ratio";
+  dirtyRows: number;
+  planeNodes: number;
+  candidates?: number;
+}>;
+
+export type FramePerfSample = Readonly<{
+  frameId: number;
+  reason: FramePerfReason;
+  startedAt: number;
+  durationMs: number;
+  renderManagerMs: number;
+  commitMs: number;
+  domFlushMs?: number;
+  stdoutFlushMs?: number;
+  dirtyRows: number | null;
+  activePlanes: readonly string[] | null;
+  scannedNodes: number;
+  paintedNodes: number;
+  rowBucketFallbacks?: readonly FramePerfRowBucketFallback[];
+  coalescedInvalidates: number;
+  droppedUpdates: number;
+  queueDepth: number;
+}>;
+
+export function framePerfNow(): number {
+  const p = (globalThis as any).performance;
+  if (p && typeof p.now === "function") return p.now();
+  return Date.now();
+}
+
+export function mergeFramePerfReason(
+  prev: FramePerfReason | undefined,
+  next: FramePerfReason | undefined,
+): FramePerfReason {
+  const a = prev ?? "unknown";
+  const b = next ?? "unknown";
+  return FRAME_PERF_REASON_PRIORITY[b] > FRAME_PERF_REASON_PRIORITY[a] ? b : a;
+}

--- a/src/renderer/dom/dom-renderer.ts
+++ b/src/renderer/dom/dom-renderer.ts
@@ -25,8 +25,22 @@ export type DomRendererSyncFlushStats = Readonly<{
   last: DomRendererSyncFlushDecision | null;
 }>;
 
+export type DomRendererFlushSample = Readonly<{
+  mode: "sync" | "deferred";
+  startedAt: number;
+  durationMs: number;
+  planeRows: number;
+  planes: number;
+}>;
+
+export type DomRendererFlushStats = Readonly<{
+  count: number;
+  last: DomRendererFlushSample | null;
+}>;
+
 export type DomRendererDebugStats = Readonly<{
   syncFlush: DomRendererSyncFlushStats;
+  flush: DomRendererFlushStats;
 }>;
 
 export interface DomRenderer {
@@ -275,6 +289,12 @@ function computeRowSegments(terminal: Terminal, y: number): RowSegment[] {
 // Cache for row content comparison - avoids unnecessary DOM updates
 const rowCache = new WeakMap<HTMLElement, string>();
 
+function nowMs(): number {
+  const p = (globalThis as any).performance;
+  if (p && typeof p.now === "function") return p.now();
+  return Date.now();
+}
+
 function segmentsToKey(segments: RowSegment[]): string {
   return segments.map((s) => `${s.key}:${s.text}:${s.cols}:${s.wide}`).join("|");
 }
@@ -381,6 +401,8 @@ export function createDomRenderer(
   let syncFlushPerformed = 0;
   let syncFlushDeferred = 0;
   let lastSyncFlushDecision: DomRendererSyncFlushDecision | null = null;
+  let domFlushCount = 0;
+  let lastDomFlush: DomRendererFlushSample | null = null;
   const debugStats: DomRendererDebugStats = {
     get syncFlush() {
       return {
@@ -388,6 +410,12 @@ export function createDomRenderer(
         performed: syncFlushPerformed,
         deferred: syncFlushDeferred,
         last: lastSyncFlushDecision,
+      };
+    },
+    get flush() {
+      return {
+        count: domFlushCount,
+        last: lastDomFlush,
       };
     },
   };
@@ -616,11 +644,13 @@ export function createDomRenderer(
 
   function flushPending(
     scope?: Readonly<FlushScope>,
-    options?: Readonly<{ clearRaf?: boolean }>,
+    options?: Readonly<{ clearRaf?: boolean; mode?: "sync" | "deferred" }>,
   ): void {
     if (options?.clearRaf !== false) raf = 0;
     if (disposed) return;
+    const startedAt = nowMs();
     const planesToFlush = scope?.planes ?? TERMINAL_RENDER_PLANES;
+    let flushedRows = 0;
 
     for (const plane of planesToFlush) {
       const layer = planeLayers.get(plane);
@@ -632,6 +662,7 @@ export function createDomRenderer(
         const line = layer.lines[y];
         if (line) renderRow(layer.terminal, metrics, wideScaleX, y, line);
         deletePendingRow(plane, rows, y);
+        flushedRows++;
       };
 
       if (scope?.rows == null) {
@@ -643,6 +674,17 @@ export function createDomRenderer(
       if (rows.size === 0) pending.delete(plane);
     }
 
+    if (flushedRows > 0) {
+      domFlushCount++;
+      lastDomFlush = {
+        mode: options?.mode ?? "deferred",
+        startedAt,
+        durationMs: nowMs() - startedAt,
+        planeRows: flushedRows,
+        planes: planesToFlush.length,
+      };
+    }
+
     if (pending.size > 0) scheduleRafIfNeeded();
   }
 
@@ -652,7 +694,7 @@ export function createDomRenderer(
     // `raf = requestAnimationFrame(...)` assignment trap (cb runs before the assignment).
     raf = -1;
     const id = requestAnimationFrame(() => {
-      flushPending();
+      flushPending(undefined, { mode: "deferred" });
     });
     if (raf === -1) raf = id;
   }
@@ -698,7 +740,7 @@ export function createDomRenderer(
         cancelAnimationFrame(raf);
         raf = 0;
       }
-      flushPending(scope, { clearRaf: drainedAll });
+      flushPending(scope, { clearRaf: drainedAll, mode: "sync" });
       if (!drainedAll) scheduleRafIfNeeded();
     } else if (!raf) {
       scheduleRafIfNeeded();

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -7,6 +7,8 @@ export type {
   CellMetrics,
   DomRenderer,
   DomRendererDebugStats,
+  DomRendererFlushSample,
+  DomRendererFlushStats,
   DomRendererOptions,
   DomRendererSyncFlushDecision,
   DomRendererSyncFlushStats,

--- a/src/vue/components/TDebugOverlay.ts
+++ b/src/vue/components/TDebugOverlay.ts
@@ -1,6 +1,7 @@
 import type { PropType } from "vue";
+import type { FramePerfSample } from "../../observability/frame-perf.js";
 import type { Style } from "../../core/types.js";
-import { defineComponent, h } from "vue";
+import { defineComponent, h, onMounted, onUnmounted, shallowRef } from "vue";
 import { useTerminal } from "../composables/use-terminal.js";
 import { TBox } from "./TBox.js";
 import { TText } from "./TText.js";
@@ -15,8 +16,32 @@ export const TDebugOverlay = defineComponent({
     zIndex: { type: Number, default: 90 },
   },
   setup(props) {
-    const { terminal, events, observability } = useTerminal();
+    const { terminal, events, observability, scheduler } = useTerminal();
     const trace = observability.trace;
+    const framePerf = observability.framePerf;
+    const releasePerf = framePerf.acquire("debug-overlay");
+    const latestPerf = shallowRef<FramePerfSample | null>(framePerf.latest());
+    let timer: ReturnType<typeof setInterval> | null = null;
+
+    function refreshLatestPerf(): void {
+      const next = framePerf.latest();
+      if (!next) return;
+      if (next.reason === "manual") return;
+      if (latestPerf.value?.frameId === next.frameId) return;
+      latestPerf.value = next;
+      scheduler.invalidate({ priority: "low", reason: "manual" });
+    }
+
+    onMounted(() => {
+      refreshLatestPerf();
+      timer = setInterval(refreshLatestPerf, 250);
+    });
+
+    onUnmounted(() => {
+      releasePerf();
+      if (timer) clearInterval(timer);
+      timer = null;
+    });
 
     function boxStyle(kind: "panel" | "focus" | "rect"): Style {
       if (kind === "panel") return { fg: "whiteBright", bg: "black" };
@@ -41,16 +66,33 @@ export const TDebugOverlay = defineComponent({
         if (!props.panel) return "";
         const records = trace.records;
         const last = [...records].reverse().find((r) => r.type === "commit") as any;
+        const perf = latestPerf.value ?? framePerf.latest();
         const dirty = last
           ? last.dirtyRows === null
             ? "all"
             : String(last.dirtyRows?.length ?? 0)
           : "0";
-        return [
+        const lines = [
           `trace: ${trace.enabled.value ? "ON" : "OFF"}`,
           `focus: ${focused ?? "null"}`,
           last ? `last commit: dirtyRows=${dirty}` : "last commit: -",
-        ].join("\n");
+        ];
+        if (perf) {
+          lines.push(
+            `frame: ${perf.durationMs.toFixed(1)}ms`,
+            `reason: ${perf.reason}`,
+            `dirtyRows: ${perf.dirtyRows === null ? "all" : perf.dirtyRows}`,
+            `scannedNodes: ${perf.scannedNodes}`,
+            `paintedNodes: ${perf.paintedNodes}`,
+            `commit: ${perf.commitMs.toFixed(1)}ms`,
+            `domFlush: ${perf.domFlushMs == null ? "-" : `${perf.domFlushMs.toFixed(1)}ms`}`,
+            `coalescedInvalidates: ${perf.coalescedInvalidates}`,
+            `queueDepth: ${perf.queueDepth}`,
+          );
+        } else {
+          lines.push("frame: -");
+        }
+        return lines.join("\n");
       })();
 
       const children: any[] = [];
@@ -93,8 +135,8 @@ export const TDebugOverlay = defineComponent({
       }
 
       if (props.panel) {
-        const panelW = Math.min(cols, 34);
-        const panelH = Math.min(rows, 6);
+        const panelW = Math.min(cols, 42);
+        const panelH = rows >= 14 ? Math.min(rows, 14) : Math.min(rows, 6);
         children.push(
           h(
             TBox as any,

--- a/src/vue/components/TList.ts
+++ b/src/vue/components/TList.ts
@@ -107,7 +107,7 @@ export const TList = defineComponent({
         active.value = next;
         emit("update:modelValue", next);
         ensureActiveVisible();
-        scheduler.invalidate();
+        scheduler.invalidate({ reason: "input" });
         return;
       }
       if (e.key === "ArrowDown") {
@@ -116,7 +116,7 @@ export const TList = defineComponent({
         active.value = next;
         emit("update:modelValue", next);
         ensureActiveVisible();
-        scheduler.invalidate();
+        scheduler.invalidate({ reason: "input" });
         return;
       }
       if (e.key === "PageUp") {
@@ -125,7 +125,7 @@ export const TList = defineComponent({
         active.value = next;
         emit("update:modelValue", next);
         ensureActiveVisible();
-        scheduler.invalidate();
+        scheduler.invalidate({ reason: "input" });
         return;
       }
       if (e.key === "PageDown") {
@@ -134,7 +134,7 @@ export const TList = defineComponent({
         active.value = next;
         emit("update:modelValue", next);
         ensureActiveVisible();
-        scheduler.invalidate();
+        scheduler.invalidate({ reason: "input" });
         return;
       }
       if (e.key === "Home") {
@@ -142,7 +142,7 @@ export const TList = defineComponent({
         active.value = 0;
         emit("update:modelValue", 0);
         ensureActiveVisible();
-        scheduler.invalidate();
+        scheduler.invalidate({ reason: "input" });
         return;
       }
       if (e.key === "End") {
@@ -151,7 +151,7 @@ export const TList = defineComponent({
         active.value = last;
         emit("update:modelValue", last);
         ensureActiveVisible();
-        scheduler.invalidate();
+        scheduler.invalidate({ reason: "input" });
         return;
       }
       if (e.key === "Enter") {
@@ -177,7 +177,7 @@ export const TList = defineComponent({
           if (idx >= 0 && idx < props.items.length) {
             active.value = idx;
             emit("update:modelValue", idx);
-            scheduler.invalidate();
+            scheduler.invalidate({ reason: "input" });
           } else {
             emit("close");
           }
@@ -220,7 +220,7 @@ export const TList = defineComponent({
             }
           }
           emit("scroll", nextTop);
-          scheduler.invalidate();
+          scheduler.invalidate({ reason: "scroll" });
         },
         focus: () => {
           focused.value = true;

--- a/src/vue/components/TPathPicker.ts
+++ b/src/vue/components/TPathPicker.ts
@@ -472,7 +472,7 @@ export const TPathPicker = defineComponent({
             const newActive = dir > 0 ? visibleEnd : visibleStart;
             active.value = clamp(newActive, 0, Math.max(0, suggestions.value.length - 1));
           }
-          scheduler.invalidate();
+          scheduler.invalidate({ reason: "scroll" });
         },
       },
     }));

--- a/src/vue/components/TVirtualList.ts
+++ b/src/vue/components/TVirtualList.ts
@@ -2,6 +2,7 @@ import type { PropType } from "vue";
 import type { TerminalRenderPlane } from "../../core/render-plane.js";
 import type { Style } from "../../core/types.js";
 import type { Rect, TerminalKeyboardEvent, TerminalPointerEvent } from "../../events/index.js";
+import type { FramePerfReason } from "../../observability/frame-perf.js";
 import {
   computed,
   defineComponent,
@@ -120,7 +121,7 @@ export const TVirtualList = defineComponent({
     let warnedRenderItemIdentity = false;
     const wheelState = createWheelScrollState();
     const wheelFrame = createFrameCoalescer<number>((top) => {
-      applyScrollTop(top, "auto", { emitScroll: true, priority: "high" });
+      applyScrollTop(top, "auto", { emitScroll: true, priority: "high", reason: "scroll" });
     });
 
     const itemCount = computed(() => {
@@ -194,7 +195,11 @@ export const TVirtualList = defineComponent({
 
     function ensureActiveVisible(
       strategy: ScrollStrategy = "viewport-repaint",
-      options?: Readonly<{ emitScroll?: boolean; priority?: "low" | "normal" | "high" }>,
+      options?: Readonly<{
+        emitScroll?: boolean;
+        priority?: "low" | "normal" | "high";
+        reason?: FramePerfReason;
+      }>,
     ): boolean {
       const clip = normalizedRect();
       const full = normalizedFullRect();
@@ -297,8 +302,11 @@ export const TVirtualList = defineComponent({
       wheelFrame.request(nextTop);
     }
 
-    function invalidateSelf(priority: "low" | "normal" | "high" = "normal"): void {
-      scheduler.invalidate({ priority, plane: plane.value });
+    function invalidateSelf(
+      priority: "low" | "normal" | "high" = "normal",
+      reason?: FramePerfReason,
+    ): void {
+      scheduler.invalidate({ priority, plane: plane.value, reason });
     }
 
     function warnIgnoredRowScroll(reason: string): void {
@@ -325,7 +333,7 @@ export const TVirtualList = defineComponent({
       const scrolled = ensureActiveVisible("viewport-repaint");
       if (scrolled) emit("scroll", scrollTop.value);
       if (!scrolled || scrollTop.value === prevTop) markViewportDirty();
-      invalidateSelf("high");
+      invalidateSelf("high", "input");
     }
 
     function onKeydown(e: TerminalKeyboardEvent): void {
@@ -481,7 +489,11 @@ export const TVirtualList = defineComponent({
     function applyScrollTop(
       nextTop: number,
       strategy: ScrollStrategy = "auto",
-      options?: Readonly<{ emitScroll?: boolean; priority?: "low" | "normal" | "high" }>,
+      options?: Readonly<{
+        emitScroll?: boolean;
+        priority?: "low" | "normal" | "high";
+        reason?: FramePerfReason;
+      }>,
     ): boolean {
       const r = normalizedRect();
       const full = normalizedFullRect();
@@ -519,12 +531,12 @@ export const TVirtualList = defineComponent({
         render.unsafeScrollPlaneRows(plane.value, r.y, r.y + h, delta);
         markRowsDirty(exposedRowsForDelta(r.y, h, delta));
         if (options?.emitScroll) emit("scroll", scrollTop.value);
-        if (options?.priority) invalidateSelf(options.priority);
+        if (options?.priority) invalidateSelf(options.priority, options.reason ?? "scroll");
         return true;
       }
       markViewportDirty();
       if (options?.emitScroll) emit("scroll", scrollTop.value);
-      if (options?.priority) invalidateSelf(options.priority);
+      if (options?.priority) invalidateSelf(options.priority, options.reason ?? "scroll");
       return true;
     }
 

--- a/src/vue/components/TerminalProvider.ts
+++ b/src/vue/components/TerminalProvider.ts
@@ -31,6 +31,8 @@ import {
 } from "vue";
 import { createTerminal } from "../../core/index.js";
 import { createEventManager } from "../../events/index.js";
+import { framePerfNow, mergeFramePerfReason } from "../../observability/frame-perf.js";
+import { createFramePerfStore } from "../../observability/frame-perf-store.js";
 import { createTraceStore } from "../../observability/trace.js";
 import { createTuiProfiler } from "../../observability/tui-profiler.js";
 import { createDomRenderer, DOM_RENDERER_CAPABILITIES } from "../../renderer/index.js";
@@ -137,6 +139,9 @@ export const TerminalProvider = defineComponent({
     const trace = createTraceStore({
       enabled: props.debugTrace || Boolean((globalThis as any).__VT_DEBUG_TRACE__),
     });
+    const framePerf = createFramePerfStore(120, {
+      enabled: Boolean((globalThis as any).__VT_DEBUG_PERF__),
+    });
     const offCommit = terminal.on("commit", ({ dirtyRows, planes, sync }) => {
       if (!trace.enabled.value) return;
       // Avoid mutating Vue reactive state during the render/flush call stack.
@@ -171,6 +176,9 @@ export const TerminalProvider = defineComponent({
     let holdReleaseToken = 0;
     let pendingInvalidateAllPlanes = false;
     const pendingInvalidatePlanes = new Set<TerminalRenderPlane>();
+    let frameId = 0;
+    let pendingFrameReason: TerminalSchedulerInvalidateOptions["reason"] = "unknown";
+    let pendingCoalescedInvalidates = 0;
     let imeComposing = false;
     let unmounting = false;
     let updateImePositionAfterFlush: (() => void) | null = null;
@@ -200,11 +208,65 @@ export const TerminalProvider = defineComponent({
       return activePlanes;
     }
 
+    function queueDepth(): number {
+      return (raf ? 1 : 0) + (timer ? 1 : 0) + (pendingInvalidate ? 1 : 0);
+    }
+
+    function noteFrameReason(reason: TerminalSchedulerInvalidateOptions["reason"]): void {
+      if (!reason || reason === "unknown") return;
+      pendingFrameReason = mergeFramePerfReason(pendingFrameReason, reason);
+    }
+
+    function rendererFlushCount(): number {
+      return renderer.value?.debugStats.flush.count ?? 0;
+    }
+
+    function latestRendererFlushMs(previousCount: number): number | undefined {
+      const flush = renderer.value?.debugStats.flush;
+      if (!flush || flush.count === previousCount) return undefined;
+      return flush.last?.durationMs;
+    }
+
     function flush(sync = false): void {
       if (unmounting) return;
       const activePlanes = takeActivePlanes();
-      render.render({ activePlanes });
-      terminal.commit({ planes: activePlanes, sync });
+      if (!framePerf.enabled.value) {
+        render.render({ activePlanes });
+        terminal.commit({ planes: activePlanes, sync });
+        updateImePositionAfterFlush?.();
+        return;
+      }
+
+      const startedAt = framePerfNow();
+      const currentFrameId = ++frameId;
+      const reason = pendingFrameReason ?? "unknown";
+      const coalescedInvalidates = pendingCoalescedInvalidates;
+      pendingFrameReason = "unknown";
+      pendingCoalescedInvalidates = 0;
+      const renderStartedAt = framePerfNow();
+      const stats = render.render({ activePlanes });
+      const renderManagerMs = framePerfNow() - renderStartedAt;
+      const flushCountBeforeCommit = rendererFlushCount();
+      const commitStartedAt = framePerfNow();
+      const dirtyRows = terminal.commit({ planes: activePlanes, sync });
+      const commitMs = framePerfNow() - commitStartedAt;
+      framePerf.push({
+        frameId: currentFrameId,
+        reason,
+        startedAt,
+        durationMs: framePerfNow() - startedAt,
+        renderManagerMs,
+        commitMs,
+        domFlushMs: latestRendererFlushMs(flushCountBeforeCommit),
+        dirtyRows: dirtyRows === null ? null : dirtyRows.length,
+        activePlanes: activePlanes ? [...activePlanes] : null,
+        scannedNodes: stats?.scannedNodes ?? 0,
+        paintedNodes: stats?.paintedNodes ?? 0,
+        rowBucketFallbacks: stats?.rowBucketFallbacks,
+        coalescedInvalidates,
+        droppedUpdates: 0,
+        queueDepth: queueDepth(),
+      });
       updateImePositionAfterFlush?.();
     }
 
@@ -243,6 +305,7 @@ export const TerminalProvider = defineComponent({
       if (unmounting) return;
 
       const priority = options?.priority ?? "normal";
+      noteFrameReason(options?.reason);
       queueInvalidatePlane(options?.plane);
       if (priority === "high") {
         profiler?.recordInvalidate({ plane: options?.plane ?? null });
@@ -256,7 +319,10 @@ export const TerminalProvider = defineComponent({
       }
 
       if (priority === "low") {
-        if (timer || raf) return;
+        if (timer || raf) {
+          pendingCoalescedInvalidates++;
+          return;
+        }
         profiler?.recordInvalidate({ plane: options?.plane ?? null });
         timer = setTimeout(() => {
           timer = null;
@@ -267,6 +333,7 @@ export const TerminalProvider = defineComponent({
 
       if (raf) {
         pendingInvalidate = true;
+        pendingCoalescedInvalidates++;
         return;
       }
       profiler?.recordInvalidate({ plane: options?.plane ?? null });
@@ -359,7 +426,7 @@ export const TerminalProvider = defineComponent({
       events,
       scheduler: { invalidate, flush, flushNow },
       runtime,
-      observability: { trace },
+      observability: { trace, framePerf },
       defaultStyle: toRef(props, "defaultStyle"),
       render,
     };
@@ -417,6 +484,7 @@ export const TerminalProvider = defineComponent({
           m.setMetrics(r.metrics);
           rootLayout.clipRect = { x: 0, y: 0, w: cols, h: rows };
           clearTextCaches();
+          invalidate({ reason: "resize" });
         });
         onScopeDispose(() => {
           offResize?.();

--- a/src/vue/context.ts
+++ b/src/vue/context.ts
@@ -5,6 +5,8 @@ import type { Style, Terminal } from "../core/types.js";
 import type { EventManager, Rect } from "../events/index.js";
 import type { RendererCapabilities, TerminalRendererLike } from "../renderer/index.js";
 import type { TraceStore } from "../observability/trace.js";
+import type { FramePerfReason } from "../observability/frame-perf.js";
+import type { FramePerfStore } from "../observability/frame-perf-store.js";
 import type { TInputPlugin } from "./components/input/plugins/types.js";
 import type { RenderManager } from "./render/render-manager.js";
 
@@ -19,6 +21,7 @@ export type TerminalSchedulerPriority = "high" | "normal" | "low";
 export type TerminalSchedulerInvalidateOptions = Readonly<{
   priority?: TerminalSchedulerPriority;
   plane?: TerminalRenderPlane;
+  reason?: FramePerfReason;
 }>;
 
 export type TerminalScheduler = Readonly<{
@@ -60,6 +63,7 @@ export type TerminalContext = Readonly<{
   runtime: TerminalRuntime;
   observability: Readonly<{
     trace: TraceStore;
+    framePerf: FramePerfStore;
   }>;
   defaultStyle: Ref<Style>;
   render: RenderManager;

--- a/test/debug-overlay.test.ts
+++ b/test/debug-overlay.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from "vitest";
+import { defineComponent, h, nextTick, ref } from "vue";
+import {
+  createTerminalApp,
+  TDebugOverlay,
+  useTerminal,
+  type FramePerfStore,
+} from "../src/index.js";
+
+describe("TDebugOverlay", () => {
+  it("shows the latest frame perf sample", () => {
+    const SeedFramePerf = defineComponent({
+      name: "SeedFramePerf",
+      setup() {
+        const { observability } = useTerminal();
+        observability.framePerf.enabled.value = true;
+        observability.framePerf.push({
+          frameId: 1,
+          reason: "scroll",
+          startedAt: 0,
+          durationMs: 6.4,
+          renderManagerMs: 2.1,
+          commitMs: 0.8,
+          domFlushMs: 1.2,
+          dirtyRows: 1,
+          activePlanes: ["default"],
+          scannedNodes: 3,
+          paintedNodes: 2,
+          coalescedInvalidates: 4,
+          droppedUpdates: 0,
+          queueDepth: 0,
+        });
+        return () => null;
+      },
+    });
+
+    const App = defineComponent({
+      name: "DebugOverlayFramePerfApp",
+      setup() {
+        return () => [h(SeedFramePerf), h(TDebugOverlay, { panel: true })];
+      },
+    });
+
+    const app = createTerminalApp({ cols: 52, rows: 16, component: App as any });
+    try {
+      app.mount();
+      app.scheduler.flushNow();
+      const text = app.terminal.snapshot().lines.join("\n");
+
+      expect(text).toContain("frame: 6.4ms");
+      expect(text).toContain("reason: scroll");
+      expect(text).toContain("dirtyRows: 1");
+      expect(text).toContain("scannedNodes: 3");
+      expect(text).toContain("paintedNodes: 2");
+      expect(text).toContain("domFlush: 1.2ms");
+      expect(text).toContain("coalescedInvalidates: 4");
+      expect(text).toContain("queueDepth: 0");
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("does not create a self-sustaining frame loop when showing frame perf", async () => {
+    vi.useFakeTimers();
+    let framePerf: FramePerfStore | null = null;
+
+    const ExposeFramePerf = defineComponent({
+      name: "ExposeFramePerf",
+      setup() {
+        framePerf = useTerminal().observability.framePerf;
+        return () => null;
+      },
+    });
+
+    const App = defineComponent({
+      name: "DebugOverlayNoLoopApp",
+      setup() {
+        return () => [h(ExposeFramePerf), h(TDebugOverlay, { panel: true })];
+      },
+    });
+
+    const app = createTerminalApp({ cols: 52, rows: 16, component: App as any });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      framePerf!.clear();
+
+      framePerf!.push({
+        frameId: 1,
+        reason: "scroll",
+        startedAt: 0,
+        durationMs: 6,
+        renderManagerMs: 2,
+        commitMs: 1,
+        dirtyRows: 1,
+        activePlanes: ["default"],
+        scannedNodes: 1,
+        paintedNodes: 1,
+        coalescedInvalidates: 0,
+        droppedUpdates: 0,
+        queueDepth: 0,
+      });
+
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+      await nextTick();
+      vi.advanceTimersByTime(50);
+      await Promise.resolve();
+      await nextTick();
+      const afterRefresh = framePerf!.list().length;
+      expect(afterRefresh).toBeGreaterThanOrEqual(1);
+      expect(afterRefresh).toBeLessThanOrEqual(2);
+
+      vi.advanceTimersByTime(1_000);
+      await Promise.resolve();
+      await nextTick();
+      expect(framePerf!.list().length).toBe(afterRefresh);
+    } finally {
+      app.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps frame perf enabled until all overlay leases are released", async () => {
+    const showA = ref(true);
+    const showB = ref(true);
+    let framePerf: FramePerfStore | null = null;
+
+    const ExposeFramePerf = defineComponent({
+      name: "ExposeFramePerf",
+      setup() {
+        framePerf = useTerminal().observability.framePerf;
+        return () => null;
+      },
+    });
+
+    const App = defineComponent({
+      name: "DebugOverlayLeaseApp",
+      setup() {
+        return () => [
+          h(ExposeFramePerf),
+          showA.value ? h(TDebugOverlay, { key: "a", panel: true }) : null,
+          showB.value ? h(TDebugOverlay, { key: "b", panel: true }) : null,
+        ];
+      },
+    });
+
+    const app = createTerminalApp({ cols: 52, rows: 16, component: App as any });
+    try {
+      app.mount();
+      await nextTick();
+      expect(framePerf!.enabled.value).toBe(true);
+
+      showA.value = false;
+      await nextTick();
+      expect(framePerf!.enabled.value).toBe(true);
+
+      showB.value = false;
+      await nextTick();
+      expect(framePerf!.enabled.value).toBe(false);
+    } finally {
+      app.dispose();
+    }
+  });
+});

--- a/test/frame-perf.test.ts
+++ b/test/frame-perf.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it } from "vitest";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
+import {
+  createDomRenderer,
+  createFramePerfStore,
+  createTerminal,
+  createTerminalApp,
+  TerminalProvider,
+  TList,
+  TText,
+  useTerminal,
+  type FramePerfStore,
+  type TerminalScheduler,
+} from "../src/index.js";
+import { TVirtualList } from "../src/experimental.js";
+
+function sample(frameId: number) {
+  return {
+    frameId,
+    reason: "unknown" as const,
+    startedAt: frameId,
+    durationMs: 1,
+    renderManagerMs: 0.5,
+    commitMs: 0.5,
+    dirtyRows: 1,
+    activePlanes: null,
+    scannedNodes: 1,
+    paintedNodes: 1,
+    coalescedInvalidates: 0,
+    droppedUpdates: 0,
+    queueDepth: 0,
+  };
+}
+
+describe("FramePerfStore", () => {
+  it("keeps a bounded ring buffer when enabled", () => {
+    const store = createFramePerfStore(2, { enabled: true });
+
+    store.push(sample(1));
+    store.push(sample(2));
+    store.push(sample(3));
+
+    expect(store.list().map((s) => s.frameId)).toEqual([2, 3]);
+    expect(store.latest()?.frameId).toBe(3);
+
+    store.clear();
+    expect(store.list()).toEqual([]);
+  });
+
+  it("does not collect samples while disabled", () => {
+    const store = createFramePerfStore(2);
+
+    store.push(sample(1));
+    expect(store.latest()).toBeNull();
+
+    store.enabled.value = true;
+    store.push(sample(2));
+    expect(store.latest()?.frameId).toBe(2);
+  });
+
+  it("keeps frame perf enabled while any lease is active", () => {
+    const store = createFramePerfStore();
+    const releaseA = store.acquire("a");
+    const releaseB = store.acquire("b");
+
+    expect(store.enabled.value).toBe(true);
+    releaseA();
+    expect(store.enabled.value).toBe(true);
+    releaseB();
+    expect(store.enabled.value).toBe(false);
+  });
+
+  it("does not disable manually enabled frame perf after a lease release", () => {
+    const store = createFramePerfStore(120, { enabled: true });
+    const release = store.acquire("debug-overlay");
+
+    expect(store.enabled.value).toBe(true);
+    release();
+    expect(store.enabled.value).toBe(true);
+  });
+
+  it("preserves manual enable changes made while a lease is active", () => {
+    const store = createFramePerfStore();
+    const release = store.acquire("debug-overlay");
+
+    store.enabled.value = true;
+    release();
+
+    expect(store.enabled.value).toBe(true);
+  });
+});
+
+describe("frame perf sampling", () => {
+  it("records RenderManager stats for scheduler frames", async () => {
+    const value = ref("a");
+    let framePerf: FramePerfStore | null = null;
+
+    const App = defineComponent({
+      name: "FramePerfApp",
+      setup() {
+        const ctx = useTerminal();
+        framePerf = ctx.observability.framePerf;
+        framePerf.enabled.value = true;
+        return () => h(TText, { x: 0, y: 0, w: 10, value: value.value });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 4, component: App as any });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      framePerf!.clear();
+
+      value.value = "b";
+      await nextTick();
+      app.scheduler.invalidate({ priority: "high", reason: "data", plane: "default" });
+
+      const latest = framePerf!.latest();
+      expect(latest).toMatchObject({
+        reason: "data",
+        dirtyRows: 1,
+        scannedNodes: 1,
+        paintedNodes: 1,
+        activePlanes: ["default"],
+      });
+      expect(latest!.renderManagerMs).toBeGreaterThanOrEqual(0);
+      expect(latest!.commitMs).toBeGreaterThanOrEqual(0);
+      expect(latest!.durationMs).toBeGreaterThanOrEqual(latest!.renderManagerMs);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("records DOM flush duration for sync commits", () => {
+    const terminal = createTerminal({ cols: 4, rows: 1 });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const renderer = createDomRenderer(terminal, container);
+
+    try {
+      terminal.write("A", { x: 0, y: 0 });
+      terminal.commit({ sync: true });
+
+      expect(renderer.debugStats.flush.count).toBe(1);
+      expect(renderer.debugStats.flush.last).toMatchObject({
+        mode: "sync",
+        planeRows: 4,
+        planes: 4,
+      });
+      expect(renderer.debugStats.flush.last!.durationMs).toBeGreaterThanOrEqual(0);
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("records scroll reason for TVirtualList wheel frames", async () => {
+    let framePerf: FramePerfStore | null = null;
+    const items = Array.from({ length: 20 }, (_, index) => `item-${index}`);
+
+    const App = defineComponent({
+      name: "FramePerfVirtualListScrollApp",
+      setup() {
+        const ctx = useTerminal();
+        framePerf = ctx.observability.framePerf;
+        framePerf.enabled.value = true;
+        return () =>
+          h(TVirtualList, {
+            x: 0,
+            y: 0,
+            w: 12,
+            h: 4,
+            itemCount: items.length,
+            itemVersion: 1,
+            getItem: (index: number) => items[index],
+            autoFocus: true,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 8, component: App as any });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      framePerf!.clear();
+
+      app.events.dispatch({ type: "wheel", cellX: 0, cellY: 0, deltaY: 100, time: 1_000 });
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+      await nextTick();
+
+      expect(framePerf!.latest()?.reason).toBe("scroll");
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("records scroll reason for TList wheel frames", async () => {
+    let framePerf: FramePerfStore | null = null;
+    const items = Array.from({ length: 20 }, (_, index) => `item-${index}`);
+
+    const App = defineComponent({
+      name: "FramePerfListScrollApp",
+      setup() {
+        const ctx = useTerminal();
+        framePerf = ctx.observability.framePerf;
+        framePerf.enabled.value = true;
+        return () => h(TList, { x: 0, y: 0, w: 12, h: 4, items, autoFocus: true });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 8, component: App as any });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      framePerf!.clear();
+
+      app.events.dispatch({ type: "wheel", cellX: 0, cellY: 0, deltaY: 100, time: 1_000 });
+      app.scheduler.flushNow();
+
+      expect(framePerf!.latest()?.reason).toBe("scroll");
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("prefers higher-priority frame reason when invalidates coalesce", async () => {
+    let framePerf: FramePerfStore | null = null;
+
+    const App = defineComponent({
+      name: "FramePerfReasonPriorityApp",
+      setup() {
+        const ctx = useTerminal();
+        framePerf = ctx.observability.framePerf;
+        framePerf.enabled.value = true;
+        return () => h(TText, { x: 0, y: 0, w: 10, value: "reason" });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 4, component: App as any });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      framePerf!.clear();
+
+      app.scheduler.invalidate({ priority: "low", reason: "data" });
+      app.scheduler.invalidate({ priority: "normal", reason: "scroll" });
+      app.scheduler.flushNow();
+
+      expect(framePerf!.latest()?.reason).toBe("scroll");
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("records DOM flush duration on TerminalProvider sync frame samples", async () => {
+    const previousRaf = globalThis.requestAnimationFrame;
+    const previousCancel = globalThis.cancelAnimationFrame;
+    const callbacks = new Map<number, FrameRequestCallback>();
+    let rafId = 0;
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      const id = ++rafId;
+      callbacks.set(id, cb);
+      return id;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((id: number) => {
+      callbacks.delete(id);
+    }) as typeof cancelAnimationFrame;
+
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const value = ref("A");
+    let framePerf: FramePerfStore | null = null;
+    let scheduler: TerminalScheduler | null = null;
+
+    const Probe = defineComponent({
+      name: "FramePerfDomProviderProbe",
+      setup() {
+        const ctx = useTerminal();
+        framePerf = ctx.observability.framePerf;
+        framePerf.enabled.value = true;
+        scheduler = ctx.scheduler;
+        return () => null;
+      },
+    });
+
+    const App = defineComponent({
+      name: "FramePerfDomProviderApp",
+      setup() {
+        return () =>
+          h(
+            TerminalProvider,
+            {
+              cols: 20,
+              rows: 4,
+              domRendererOptions: { syncFlushMaxRows: 20, syncFlushCellBudget: 2_000 },
+            },
+            {
+              default: () => [h(Probe), h(TText, { x: 0, y: 0, w: 10, value: value.value })],
+            },
+          );
+      },
+    });
+
+    const app = createApp(App);
+    try {
+      app.mount(root);
+      await nextTick();
+      await Promise.resolve();
+      scheduler!.flushNow();
+      framePerf!.clear();
+
+      value.value = "B";
+      await nextTick();
+      scheduler!.flushNow();
+
+      const latest = framePerf!.latest();
+      expect(latest?.domFlushMs).toBeGreaterThanOrEqual(0);
+      expect(latest?.commitMs).toBeGreaterThanOrEqual(0);
+    } finally {
+      app.unmount();
+      root.remove();
+      globalThis.requestAnimationFrame = previousRaf;
+      globalThis.cancelAnimationFrame = previousCancel;
+    }
+  });
+});

--- a/test/package-exports.test.ts
+++ b/test/package-exports.test.ts
@@ -16,6 +16,8 @@ describe("package exports", () => {
     const experimental = await import("../src/experimental.js");
 
     expect("TVirtualList" in root).toBe(false);
+    expect(root.createFramePerfStore).toBeTruthy();
+    expect(root.framePerfNow).toBeTruthy();
     expect(experimental.TVirtualList).toBeTruthy();
   });
 
@@ -35,7 +37,11 @@ describe("package exports", () => {
 
       expect("TVirtualList" in root).toBe(false);
       expect(root.TerminalProvider).toBeTruthy();
+      expect(root.createFramePerfStore).toBeTruthy();
+      expect(root.framePerfNow).toBeTruthy();
       expect(rootCjs.TerminalProvider).toBeTruthy();
+      expect(rootCjs.createFramePerfStore).toBeTruthy();
+      expect(rootCjs.framePerfNow).toBeTruthy();
       expect(experimental.TVirtualList).toBeTruthy();
       expect(experimentalCjs.TVirtualList).toBeTruthy();
     },


### PR DESCRIPTION
## Summary
- add FramePerf sample types and a bounded non-reactive store, wired into DOM and headless scheduler frames
- add priority-based FramePerf reason merging so interaction reasons win over lower-priority invalidates
- rename the scheduler coalescing metric to `coalescedInvalidates` and document that it excludes component-local wheel/input coalescers
- add FramePerf acquire/release leases so debug overlays do not fight manual enablement
- record DOM renderer flush duration/debug stats with `planeRows` semantics and show latest frame metrics in TDebugOverlay without per-sample reactive feedback
- tag TVirtualList/TList/TPathPicker wheel frames with reason=scroll and TList/TVirtualList keyboard navigation with reason=input
- add Phase 2 benchmark baseline script with spaced and burst TVirtualList wheel scenarios, manual rAF burst flushing, accepted/finalTop counters, coalescingRatio, and DOM flush plane-row output
- add observability/performance docs and package-export coverage for new runtime exports

## Validation
- pnpm run format:check
- pnpm run lint
- pnpm run typecheck
- pnpm run test
- pnpm run test:package-exports
- pnpm run bench:phase2
- pnpm docs:build