### PR TITLE
feat: consume scrollOperations in DOM renderer

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -326,7 +326,7 @@ const app = createTerminalApp({
 - `modelValue` `(number)` + `update:modelValue`
 - `style` / `activeStyle` `(Style?)`
 - `autoFocus` `(boolean)`
-- `rowScrollMode` `("off" | "unsafe-full-row")`：headless/CLI full-row 场景的 opt-in unsafe row-scroll 优化
+- `rowScrollMode` `("off" | "unsafe-full-row")`：full-row 场景的 opt-in unsafe row-scroll 优化
 
 ### Data source
 
@@ -347,7 +347,7 @@ const renderItem = (item: Row) => item.title;
 
 ### Row scroll
 
-`rowScrollMode` 是危险优化开关，不是列表内部局部滚动。它会 shift 当前 render plane 的整行区域，只能用于该 plane 的这些 rows 被 `TVirtualList` 独占且列表没有被裁剪的场景；同 plane 其它内容会被一起移动。它是 headless/CLI 优化：当 DOM renderer 已挂载、列表没有占满终端整行、列表 rect 被裁剪或 rows 超出 terminal bounds 时，会退回 viewport repaint；debug perf 模式会对这些被忽略的场景发出一次 warning。DOM renderer 当前不消费 terminal `scrollOperations`，所以 DOM 慢滚即使设置 `rowScrollMode: "unsafe-full-row"` 仍会重绘可见窗口。
+`rowScrollMode` 是危险优化开关，不是列表内部局部滚动。它会 shift 当前 render plane 的整行区域，只能用于该 plane 的这些 rows 被 `TVirtualList` 独占且列表没有被裁剪的场景；同 plane 其它内容会被一起移动。DOM renderer 支持通过移动 line nodes 消费 terminal `scrollOperations`，但只有列表占满终端整行、列表 rect 未被裁剪、rows 在 terminal bounds 内且 renderer capability 开启时才会走 exposed-row repaint；其它场景会退回 viewport repaint。debug perf 模式会对这些被忽略的场景发出一次 warning。
 
 ### Selection model
 

--- a/docs/high-throughput-rendering.md
+++ b/docs/high-throughput-rendering.md
@@ -199,10 +199,10 @@ wheel 行为：
 - wheel 不 emit `update:modelValue`。
 - `scroll` event 每 frame 最多 emit 一次。
 - 小 delta 且 `abs(delta) < viewportHeight` 时，**仅当 `rowScrollMode: "unsafe-full-row"`**、当前 renderer capability 明确支持 `scrollOperations`、且 ownsFullRows 时使用 `render.unsafeScrollPlaneRows(plane, y, y + h, delta)`，只 dirty exposed rows。
-- 不满足 `rowScrollMode` 条件或 DOM 环境下，wheel 直接 repaint viewport。
+- 不满足 `rowScrollMode` 条件、DOM renderer 关闭 `enableScrollOperations`、list 非 full-row 或被 clip 时，wheel 直接 repaint viewport。
 - PageUp/PageDown/Home/End 或大跳转直接 repaint viewport。
 
-> **`rowScrollMode` 语义**：`unsafeScrollPlaneRows()` 会 shift 该 plane 的完整 row region，只适合 TVirtualList 独占这些 rows 的 CLI/headless 场景；如果同一 plane 上还有其它内容覆盖这些 rows，请保持默认 `rowScrollMode: "off"`（repaint viewport）。调用 `render.unsafeScrollPlaneRows()` 前也必须确认当前 renderer 会消费 terminal `scrollOperations`；DOM renderer 在 Phase 1 不支持该能力。
+> **`rowScrollMode` 语义**：`unsafeScrollPlaneRows()` 会 shift 该 plane 的完整 row region，只适合 TVirtualList 独占这些 rows 的 full-row 场景；如果同一 plane 上还有其它内容覆盖这些 rows，请保持默认 `rowScrollMode: "off"`（repaint viewport）。调用 `render.unsafeScrollPlaneRows()` 前也必须确认当前 renderer 会消费 terminal `scrollOperations`；DOM renderer 会通过移动 line nodes 消费该 hint，但这仍然不是组件内部的局部 rect scroll。
 
 键盘和点击行为：
 
@@ -332,8 +332,10 @@ type FramePerf = {
 | DOM renderer `commit({ sync: true })` same-frame flush              | ✅ done      |
 | RenderManager row buckets (partial repaint)                         | ✅ done      |
 | `TVirtualList` data-source API (`itemCount/getItem/itemVersion`)    | ✅ done      |
-| Headless/CLI full-row `rowScrollMode` exposed rows                  | ✅ done      |
-| DOM `TVirtualList` slow wheel exposed rows                          | 🔲 Phase 2   |
+| Full-row `rowScrollMode` exposed rows                               | ✅ done      |
+| DOM renderer consume `scrollOperations`                             | ✅ done      |
+| DOM `TVirtualList` full-row exposed rows                            | ✅ done      |
+| DOM non-full-row/clipped/disabled fallback                          | ✅ done      |
 | DOM sync flush scoped to current commit rows/planes                 | ✅ done      |
 | Row bucket degradation threshold (50%/60%)                          | ✅ done      |
 | `TVirtualList.rowScrollMode` opt-in for unsafe row-scroll fast path | ✅ done      |
@@ -341,7 +343,7 @@ type FramePerf = {
 | `TList` wheel 行为修改（不再同步更新 active/modelValue）            | 🔲 planned   |
 | Debug overlay 展示 `scannedNodes/paintedNodes/dirtyRows/frameMs`    | ✅ Phase 2.0 |
 
-> **注意**：`TVirtualList` 的 `rowScrollMode` 默认为 `"off"`。这是危险优化开关，只有显式设置 `rowScrollMode: "unsafe-full-row"` 的 headless/CLI full-row 且独占这些 plane rows 的场景才会使用 `unsafeScrollPlaneRows()` + exposed dirty rows。DOM 端慢滚仍然 repaint viewport，真正 DOM exposed rows 要等 DomRenderer 支持 `scrollOperations`。
+> **注意**：`TVirtualList` 的 `rowScrollMode` 默认为 `"off"`。这是危险优化开关，只有显式设置 `rowScrollMode: "unsafe-full-row"`、当前 renderer 支持 `scrollOperations`、且 list 是 unclipped full-row 并独占这些 plane rows 时，才会使用 `unsafeScrollPlaneRows()` + exposed dirty rows。DOM renderer 的优化只移动 line nodes 并 repaint exposed dirty rows，不改变 terminal buffer/compositor 语义。
 
 验收命令：
 
@@ -380,18 +382,19 @@ pnpm run typecheck
 
 ## 测试矩阵
 
-| 场景                                 | 断言                                                  | 文件                                            |
-| ------------------------------------ | ----------------------------------------------------- | ----------------------------------------------- |
-| dirty 一行但 plane 有大量节点        | `scannedNodes` 低于 plane 总节点数，paint 顺序不变    | `test/render-manager.test.ts`                   |
-| node rect 跨行更新                   | 旧行和新行 bucket 都正确更新                          | `test/render-manager.test.ts`                   |
-| headless/CLI full-row wheel 慢滚一行 | `dirtyRows` 等于 exposed row；DOM 仍 repaint viewport | 新增 `test/virtual-list.test.ts`                |
-| wheel 连续输入                       | 多个 wheel event 合成一次 frame update                | 新增 `test/virtual-list.test.ts`                |
-| wheel 不改 selection                 | 不触发 `update:modelValue`                            | 新增 `test/virtual-list.test.ts`                |
-| DOM sync commit                      | `commit({ sync: true })` 不排第二个 rAF               | 新增 `test/dom-renderer.test.ts`                |
-| high priority invalidate             | 仍同 tick flush                                       | `test/scheduler-priority.test.ts`               |
-| live mode 引用计数                   | 全部 drop 后停止 loop                                 | `test/scheduler-priority.test.ts`               |
-| stream append                        | 只 dirty tail rows，离底部不 auto-scroll              | 新增 `test/tlog-view.test.ts`                   |
-| debug stats                          | overlay 展示 `scannedNodes/paintedNodes/dirtyRows`    | `test/perf-budgets.test.ts` 或新增 overlay test |
+| 场景                          | 断言                                                   | 文件                                            |
+| ----------------------------- | ------------------------------------------------------ | ----------------------------------------------- |
+| dirty 一行但 plane 有大量节点 | `scannedNodes` 低于 plane 总节点数，paint 顺序不变     | `test/render-manager.test.ts`                   |
+| node rect 跨行更新            | 旧行和新行 bucket 都正确更新                           | `test/render-manager.test.ts`                   |
+| full-row wheel 慢滚一行       | `dirtyRows` 等于 exposed row；DOM 只 flush exposed row | `test/virtual-list.test.ts`                     |
+| DOM renderer scrollOperations | line nodes 被移动；pending overlap 回退 repaint        | `test/dom-renderer-scroll-operations.test.ts`   |
+| wheel 连续输入                | 多个 wheel event 合成一次 frame update                 | 新增 `test/virtual-list.test.ts`                |
+| wheel 不改 selection          | 不触发 `update:modelValue`                             | 新增 `test/virtual-list.test.ts`                |
+| DOM sync commit               | `commit({ sync: true })` 不排第二个 rAF                | `test/dom-renderer-sync-flush.test.ts`          |
+| high priority invalidate      | 仍同 tick flush                                        | `test/scheduler-priority.test.ts`               |
+| live mode 引用计数            | 全部 drop 后停止 loop                                  | `test/scheduler-priority.test.ts`               |
+| stream append                 | 只 dirty tail rows，离底部不 auto-scroll               | 新增 `test/tlog-view.test.ts`                   |
+| debug stats                   | overlay 展示 `scannedNodes/paintedNodes/dirtyRows`     | `test/perf-budgets.test.ts` 或新增 overlay test |
 
 ## 文档要求
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -87,6 +87,8 @@ DIMCODE_PROFILE_TUI=1
 
 Phase 2.0 里 `droppedUpdates` 保留为后续 scheduler backpressure 指标，当前恒为 `0`。`coalescedInvalidates` 只统计 scheduler invalidate coalescing；Phase 2.1 起 frame task coalescing 单独记录在 `coalescedFrameTasks`，`frameTaskCount` 是本帧实际执行的 scheduler-owned tasks。`domFlushMs` 只记录与本 scheduler frame 同调用栈完成的 DOM flush；普通 rAF-deferred DOM flush 会体现在 `renderer.debugStats.flush.last`，不会 retroactively 更新已经 push 的 frame sample。DOM renderer flush stats 里的 `planeRows` 是 flushed plane-row line elements，不是去重后的 terminal rows。
 
+DOM full-row scroll 优化生效时，FramePerf 的 `dirtyRows` 应接近 exposed rows，而不是 viewport height；`renderer.debugStats.flush.last.planeRows` 表示实际 repaint 的 plane-row line elements。`dirtyRows` 反映 terminal commit 语义，`planeRows` 反映 DOM renderer 实际刷新量；line-node shift 本身不会被计入 dirty row 数。
+
 FramePerf samples 只记录发生 render/commit 的 terminal frame；如果 frame task 只做预取或计算、没有调用 `ctx.invalidate()`，它可能被 drain 掉但不会产生 sample。
 
 这让高频输入、滚动和 streaming 输出可以用同一组指标比较，而不是只看体感。

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -13,7 +13,14 @@ Vue TUI 的性能瓶颈通常来自三部分：
 - **plane-local dirty rows**：RenderManager 按 `default/transcript/chrome/overlay` 分别维护 dirty rows。
 - **plane-scoped compositor**：Terminal commit 时从各 plane row buffer 合成最终可见 buffer，而不是共享一块渲染面反复清空。
 - **增量渲染**：RenderManager 会尽量只重绘被请求的 dirty plane，避免无关区域参与本轮 repaint。
+- **DOM scrollOperations**：DOM renderer 可消费 terminal commit 里的 `scrollOperations`，通过移动 line nodes 优化 full-row 慢滚；`dirtyRows` 仍由 terminal/compositor 决定。
 - **stdout 原子输出**：StdoutRenderer 单帧合成一次性输出，减少闪烁与撕裂。
+
+## DOM scrollOperations
+
+DOM renderer 的 `scrollOperations` 是输出层优化：terminal/compositor 先完成 buffer scroll、dirty rows 和 exposed rows 计算，DOM renderer 只按 commit hint 移动对应 plane 的整行 line nodes，然后 repaint commit 给出的 dirty rows。
+
+这不是组件局部 rect scroll。`TVirtualList rowScrollMode="unsafe-full-row"` 只有在 full-row、unclipped、rows 在 terminal bounds 内且 renderer capability 开启时才会使用；如果存在 pending rows overlap 或不安全条件，DOM 端会回退到 repaint affected rows / viewport。
 
 ## 性能“验收”建议（可量化）
 
@@ -41,6 +48,7 @@ Vue TUI 的性能瓶颈通常来自三部分：
 - 对于会频繁变化的文本：尽量把变化限制在小 rect 内（例如固定输入框区域）。
 - 避免在一个 tick 内创建/销毁大量节点（频繁 `v-if` / 动态 key 重建）。
 - 长列表用“视口”思路渲染（只渲染可见行），避免一次性生成上千 `TText`。
+- `TVirtualList rowScrollMode="unsafe-full-row"` 只用于 unclipped full-row 且独占 plane rows 的场景；DOM renderer 会只 repaint exposed dirty rows，pending rows 或不安全条件会回退到 viewport repaint。
 - `style`/`highlightStyle` 这类对象尽量复用（避免每次都创建新对象导致 watchEffect 触发）。
 
 ## 如何排查

--- a/scripts/bench-phase2.ts
+++ b/scripts/bench-phase2.ts
@@ -96,9 +96,15 @@ function installManualRaf(): RafHarness {
   };
 }
 
-const { defineComponent, h, nextTick, ref } = await import("vue");
-const { createDomRenderer, createTerminal, createTerminalApp, TText, useTerminal } =
-  await import("../src/index.js");
+const { createApp, defineComponent, h, nextTick, ref } = await import("vue");
+const {
+  createDomRenderer,
+  createTerminal,
+  createTerminalApp,
+  TerminalProvider,
+  TText,
+  useTerminal,
+} = await import("../src/index.js");
 const { TVirtualList } = await import("../src/experimental.js");
 const { createRenderManager } = await import("../src/vue/render/render-manager.js");
 
@@ -268,6 +274,106 @@ async function benchVirtualList(
   }
 }
 
+async function benchDomVirtualList(
+  itemCount: number,
+  rowScrollMode: "off" | "unsafe-full-row",
+): Promise<Record<string, unknown>> {
+  let framePerf: any = null;
+  let rendererRef: any = null;
+  let finalTop = 0;
+  let lastFlushCount = 0;
+  let domFlushPlaneRows = 0;
+  let domFlushSamples = 0;
+  const dispatchedEvents = 100;
+  const getItem = (index: number) => `item-${index}`;
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+
+  const Probe = defineComponent({
+    name: `BenchDomVirtualList${itemCount}${rowScrollMode}`,
+    setup() {
+      const ctx = useTerminal();
+      framePerf = ctx.observability.framePerf;
+      rendererRef = ctx.renderer;
+      framePerf.enabled.value = true;
+      return () =>
+        h(TVirtualList, {
+          x: 0,
+          y: 0,
+          w: 80,
+          h: 20,
+          itemCount,
+          itemVersion: 1,
+          getItem,
+          autoFocus: true,
+          rowScrollMode,
+          onScroll: (top: number) => {
+            finalTop = top;
+          },
+        });
+    },
+  });
+
+  const app = createApp({
+    name: "BenchDomVirtualListRoot",
+    render() {
+      return h(TerminalProvider, { cols: 80, rows: 24 }, { default: () => h(Probe) });
+    },
+  });
+
+  function collectDomFlush(): void {
+    const flush = rendererRef?.value?.debugStats?.flush;
+    if (!flush || flush.count === lastFlushCount || !flush.last) return;
+    lastFlushCount = flush.count;
+    domFlushPlaneRows += flush.last.planeRows;
+    domFlushSamples++;
+  }
+
+  try {
+    app.mount(root);
+    await nextTick();
+    framePerf.clear();
+    collectDomFlush();
+
+    const container = root.querySelector("[data-vt-container]") as HTMLElement | null;
+    if (!container) throw new Error("DOM terminal container not mounted");
+
+    const startedAt = now();
+    for (let i = 0; i < dispatchedEvents; i++) {
+      const wheel = new Event("wheel", {
+        bubbles: true,
+        cancelable: true,
+      }) as any;
+      Object.defineProperties(wheel, {
+        clientX: { value: 0 },
+        clientY: { value: 0 },
+        deltaY: { value: 100 },
+        deltaMode: { value: 0 },
+      });
+      container.dispatchEvent(wheel);
+      await nextTick();
+      collectDomFlush();
+    }
+    const durationMs = now() - startedAt;
+    const samples = framePerf.list();
+    const acceptedScrollFrames = samples.filter((sample: any) => sample.reason === "scroll").length;
+
+    return {
+      name: `dom-virtual-list-${itemCount}-rows-${rowScrollMode}-wheel-100`,
+      dispatchedEvents,
+      acceptedScrollFrames,
+      coalescingRatio: round(dispatchedEvents / Math.max(1, acceptedScrollFrames)),
+      finalTop,
+      durationMs: round(durationMs),
+      avgDomFlushPlaneRows: round(domFlushPlaneRows / Math.max(1, domFlushSamples)),
+      ...summarizeSamples(samples),
+    };
+  } finally {
+    app.unmount();
+    root.remove();
+  }
+}
+
 function benchDomSyncFlush(dirtyRowCount: number): Record<string, unknown> {
   const terminal = createTerminal({ cols: 80, rows: 40 });
   const container = document.createElement("div");
@@ -346,6 +452,8 @@ async function main(): Promise<void> {
     await benchVirtualList(10_000, "burst"),
     await benchVirtualList(100_000, "spaced"),
     await benchVirtualList(100_000, "burst"),
+    await benchDomVirtualList(100_000, "off"),
+    await benchDomVirtualList(100_000, "unsafe-full-row"),
     ...[1, 5, 20, 40].map((rows) => benchDomSyncFlush(rows)),
     await benchAppendOnly(),
   ];

--- a/src/renderer/capabilities.ts
+++ b/src/renderer/capabilities.ts
@@ -12,7 +12,7 @@ export type TerminalRendererLike = Readonly<{
 
 export const DOM_RENDERER_CAPABILITIES: RendererCapabilities = Object.freeze({
   syncFlush: true,
-  scrollOperations: false,
+  scrollOperations: true,
   domRows: true,
 });
 

--- a/src/renderer/dom/dom-renderer.ts
+++ b/src/renderer/dom/dom-renderer.ts
@@ -1,5 +1,5 @@
 import type { TerminalRenderPlane } from "../../core/render-plane.js";
-import type { Cell, Style, Terminal } from "../../core/types.js";
+import type { Cell, Style, Terminal, TerminalScrollOperation } from "../../core/types.js";
 import type { RendererCapabilities } from "../capabilities.js";
 import { ansiColorHex, ansiCssVar, installAnsiPaletteCssVars } from "../../core/ansi-palette.js";
 import { TERMINAL_RENDER_PLANES } from "../../core/render-plane.js";
@@ -67,6 +67,10 @@ export interface DomRendererOptions {
    * Maximum estimated cell work for sync DOM flush: dirtyRows * cols * activePlanes.
    */
   syncFlushCellBudget?: number;
+  /**
+   * Enables DOM line-node shifting for terminal scrollOperations.
+   */
+  enableScrollOperations?: boolean;
 }
 
 interface PlaneLayer {
@@ -396,7 +400,10 @@ export function createDomRenderer(
     0,
     Math.floor(options.syncFlushCellBudget ?? DEFAULT_SYNC_FLUSH_CELL_BUDGET),
   );
-  const capabilities: RendererCapabilities = DOM_RENDERER_CAPABILITIES;
+  const capabilities: RendererCapabilities = Object.freeze({
+    ...DOM_RENDERER_CAPABILITIES,
+    scrollOperations: options.enableScrollOperations !== false,
+  });
   let syncFlushRequested = 0;
   let syncFlushPerformed = 0;
   let syncFlushDeferred = 0;
@@ -579,6 +586,96 @@ export function createDomRenderer(
     else pendingRowCountsByPlane.delete(plane);
   }
 
+  function hasPendingRowsInRange(
+    plane: TerminalRenderPlane,
+    startY: number,
+    endY: number,
+  ): boolean {
+    const rows = pending.get(plane);
+    if (!rows?.size) return false;
+    for (const y of rows) {
+      if (y >= startY && y < endY) return true;
+    }
+    return false;
+  }
+
+  function addPendingRowRange(plane: TerminalRenderPlane, startY: number, endY: number): void {
+    let rows = pending.get(plane);
+    if (!rows) {
+      rows = new Set<number>();
+      pending.set(plane, rows);
+    }
+    for (let y = startY; y < endY; y++) addPendingRow(plane, rows, y);
+  }
+
+  function invalidateRowCacheRange(layer: PlaneLayer, startY: number, endY: number): void {
+    for (let y = startY; y < endY; y++) {
+      const line = layer.lines[y];
+      if (line) rowCache.delete(line);
+    }
+  }
+
+  function reorderLayerDomRows(layer: PlaneLayer, startY: number, endY: number): void {
+    const before = layer.lines[endY] ?? null;
+    const fragment = document.createDocumentFragment();
+    for (let y = startY; y < endY; y++) {
+      const line = layer.lines[y];
+      if (line) fragment.appendChild(line);
+    }
+    layer.contentEl.insertBefore(fragment, before);
+  }
+
+  function applyScrollOperationToLayer(
+    plane: TerminalRenderPlane,
+    layer: PlaneLayer,
+    op: TerminalScrollOperation,
+  ): void {
+    const { rows } = terminal.size();
+    const startY = Math.max(0, Math.min(rows, Math.floor(op.startY)));
+    const endY = Math.max(0, Math.min(rows, Math.floor(op.endY)));
+    const delta = Math.trunc(op.delta);
+    const height = endY - startY;
+
+    if (height <= 0 || delta === 0 || Math.abs(delta) >= height) {
+      invalidateRowCacheRange(layer, startY, endY);
+      addPendingRowRange(plane, startY, endY);
+      return;
+    }
+
+    if (hasPendingRowsInRange(plane, startY, endY)) {
+      invalidateRowCacheRange(layer, startY, endY);
+      addPendingRowRange(plane, startY, endY);
+      return;
+    }
+
+    const region = layer.lines.slice(startY, endY);
+    const nextRegion =
+      delta > 0
+        ? [...region.slice(delta), ...region.slice(0, delta)]
+        : [...region.slice(height + delta), ...region.slice(0, height + delta)];
+
+    for (let i = 0; i < height; i++) {
+      const line = nextRegion[i];
+      if (!line) continue;
+      layer.lines[startY + i] = line;
+      rowCache.delete(line);
+    }
+
+    reorderLayerDomRows(layer, startY, endY);
+  }
+
+  function applyScrollOperations(
+    planes: readonly TerminalRenderPlane[],
+    operations: readonly TerminalScrollOperation[] | null | undefined,
+  ): void {
+    if (!capabilities.scrollOperations || !operations?.length) return;
+    for (const plane of planes) {
+      const layer = planeLayers.get(plane);
+      if (!layer) continue;
+      for (const op of operations) applyScrollOperationToLayer(plane, layer, op);
+    }
+  }
+
   function estimateSyncFlushWork(scope: Readonly<FlushScope>): SyncFlushWork {
     const size = terminal.size();
     const rowCount = scope.rows == null ? size.rows : scope.rows.length;
@@ -699,8 +796,10 @@ export function createDomRenderer(
     if (raf === -1) raf = id;
   }
 
-  const offCommit = terminal.on("commit", ({ dirtyRows, planes, sync }) => {
+  const offCommit = terminal.on("commit", ({ dirtyRows, planes, sync, scrollOperations }) => {
     const activePlanes = planes?.length ? planes : TERMINAL_RENDER_PLANES;
+    applyScrollOperations(activePlanes, scrollOperations);
+
     // Track which rows this specific commit adds to pending, so scoped sync
     // flush can limit DOM work to just the high-priority update.
     const commitRows: number[] | null = dirtyRows === null ? null : [...dirtyRows];

--- a/src/renderer/dom/dom-renderer.ts
+++ b/src/renderer/dom/dom-renderer.ts
@@ -625,27 +625,54 @@ export function createDomRenderer(
     layer.contentEl.insertBefore(fragment, before);
   }
 
+  function scrollOperationRange(
+    op: TerminalScrollOperation,
+  ): Readonly<{ startY: number; endY: number }> {
+    const { rows } = terminal.size();
+    const startY = Math.max(0, Math.min(rows, Math.floor(op.startY)));
+    const endY = Math.max(0, Math.min(rows, Math.floor(op.endY)));
+    return { startY, endY };
+  }
+
+  function addFallbackRows(rows: Set<number>, startY: number, endY: number): void {
+    for (let y = startY; y < endY; y++) rows.add(y);
+  }
+
+  function unionRows(a: readonly number[] | null, b: readonly number[]): readonly number[] | null {
+    if (a === null) return null;
+    if (!b.length) return a;
+    const rows = new Set<number>(a);
+    for (const y of b) rows.add(y);
+    return Array.from(rows).sort((left, right) => left - right);
+  }
+
+  function invalidateAndRepaintScrollRange(
+    plane: TerminalRenderPlane,
+    layer: PlaneLayer,
+    startY: number,
+    endY: number,
+  ): void {
+    invalidateRowCacheRange(layer, startY, endY);
+    addPendingRowRange(plane, startY, endY);
+  }
+
   function applyScrollOperationToLayer(
     plane: TerminalRenderPlane,
     layer: PlaneLayer,
     op: TerminalScrollOperation,
-  ): void {
-    const { rows } = terminal.size();
-    const startY = Math.max(0, Math.min(rows, Math.floor(op.startY)));
-    const endY = Math.max(0, Math.min(rows, Math.floor(op.endY)));
+  ): readonly number[] {
+    const { startY, endY } = scrollOperationRange(op);
     const delta = Math.trunc(op.delta);
     const height = endY - startY;
 
     if (height <= 0 || delta === 0 || Math.abs(delta) >= height) {
-      invalidateRowCacheRange(layer, startY, endY);
-      addPendingRowRange(plane, startY, endY);
-      return;
+      invalidateAndRepaintScrollRange(plane, layer, startY, endY);
+      return height > 0 ? Array.from({ length: height }, (_, i) => startY + i) : [];
     }
 
     if (hasPendingRowsInRange(plane, startY, endY)) {
-      invalidateRowCacheRange(layer, startY, endY);
-      addPendingRowRange(plane, startY, endY);
-      return;
+      invalidateAndRepaintScrollRange(plane, layer, startY, endY);
+      return Array.from({ length: height }, (_, i) => startY + i);
     }
 
     const region = layer.lines.slice(startY, endY);
@@ -662,18 +689,37 @@ export function createDomRenderer(
     }
 
     reorderLayerDomRows(layer, startY, endY);
+    return [];
   }
 
   function applyScrollOperations(
     planes: readonly TerminalRenderPlane[],
     operations: readonly TerminalScrollOperation[] | null | undefined,
-  ): void {
-    if (!capabilities.scrollOperations || !operations?.length) return;
+  ): readonly number[] {
+    if (!operations?.length) return [];
+    const fallbackRows = new Set<number>();
+
+    if (!capabilities.scrollOperations || planes.length !== 1) {
+      for (const plane of planes) {
+        const layer = planeLayers.get(plane);
+        if (!layer) continue;
+        for (const op of operations) {
+          const { startY, endY } = scrollOperationRange(op);
+          invalidateAndRepaintScrollRange(plane, layer, startY, endY);
+          addFallbackRows(fallbackRows, startY, endY);
+        }
+      }
+      return Array.from(fallbackRows).sort((a, b) => a - b);
+    }
+
     for (const plane of planes) {
       const layer = planeLayers.get(plane);
       if (!layer) continue;
-      for (const op of operations) applyScrollOperationToLayer(plane, layer, op);
+      for (const op of operations) {
+        for (const y of applyScrollOperationToLayer(plane, layer, op)) fallbackRows.add(y);
+      }
     }
+    return Array.from(fallbackRows).sort((a, b) => a - b);
   }
 
   function estimateSyncFlushWork(scope: Readonly<FlushScope>): SyncFlushWork {
@@ -798,11 +844,11 @@ export function createDomRenderer(
 
   const offCommit = terminal.on("commit", ({ dirtyRows, planes, sync, scrollOperations }) => {
     const activePlanes = planes?.length ? planes : TERMINAL_RENDER_PLANES;
-    applyScrollOperations(activePlanes, scrollOperations);
+    const fallbackRows = applyScrollOperations(activePlanes, scrollOperations);
 
     // Track which rows this specific commit adds to pending, so scoped sync
     // flush can limit DOM work to just the high-priority update.
-    const commitRows: number[] | null = dirtyRows === null ? null : [...dirtyRows];
+    const commitRows = unionRows(dirtyRows === null ? null : [...dirtyRows], fallbackRows);
 
     if (dirtyRows === null) {
       const size = terminal.size();
@@ -821,7 +867,7 @@ export function createDomRenderer(
           rows = new Set<number>();
           pending.set(plane, rows);
         }
-        for (const y of dirtyRows) addPendingRow(plane, rows, y);
+        for (const y of commitRows ?? dirtyRows) addPendingRow(plane, rows, y);
       }
     }
     if (sync) {

--- a/src/renderer/dom/dom-renderer.ts
+++ b/src/renderer/dom/dom-renderer.ts
@@ -737,6 +737,31 @@ export function createDomRenderer(
     return { rowCount, planeCount, cellWork };
   }
 
+  function estimateScrollOperationWork(
+    planes: readonly TerminalRenderPlane[],
+    operations: readonly TerminalScrollOperation[] | null | undefined,
+  ): SyncFlushWork {
+    const size = terminal.size();
+    const planeCount = planes.length || TERMINAL_RENDER_PLANES.length;
+    let rowCount = 0;
+    for (const op of operations ?? []) {
+      const { startY, endY } = scrollOperationRange(op);
+      rowCount += Math.max(0, endY - startY);
+    }
+    return { rowCount, planeCount, cellWork: rowCount * size.cols * planeCount };
+  }
+
+  function combineSyncFlushWork(
+    repaintWork: SyncFlushWork,
+    scrollWork: SyncFlushWork,
+  ): SyncFlushWork {
+    return {
+      rowCount: Math.max(repaintWork.rowCount, scrollWork.rowCount),
+      planeCount: Math.max(repaintWork.planeCount, scrollWork.planeCount),
+      cellWork: repaintWork.cellWork + scrollWork.cellWork,
+    };
+  }
+
   function recordSyncFlushDecision(
     work: SyncFlushWork,
     performed: boolean,
@@ -856,9 +881,11 @@ export function createDomRenderer(
       planes: activePlanes,
       rows: dirtyCommitRows,
     });
+    const scrollWork = estimateScrollOperationWork(activePlanes, scrollOperations);
+    const combinedSyncWork = combineSyncFlushWork(initialSyncWork, scrollWork);
     const shouldApplyScrollOperations =
       Boolean(sync) &&
-      shouldSyncFlush(initialSyncWork) &&
+      shouldSyncFlush(combinedSyncWork) &&
       canApplyScrollOperations(activePlanes, scrollOperations);
     const fallbackRows = shouldApplyScrollOperations
       ? []

--- a/src/renderer/dom/dom-renderer.ts
+++ b/src/renderer/dom/dom-renderer.ts
@@ -656,24 +656,10 @@ export function createDomRenderer(
     addPendingRowRange(plane, startY, endY);
   }
 
-  function applyScrollOperationToLayer(
-    plane: TerminalRenderPlane,
-    layer: PlaneLayer,
-    op: TerminalScrollOperation,
-  ): readonly number[] {
+  function applyScrollOperationToLayer(layer: PlaneLayer, op: TerminalScrollOperation): void {
     const { startY, endY } = scrollOperationRange(op);
     const delta = Math.trunc(op.delta);
     const height = endY - startY;
-
-    if (height <= 0 || delta === 0 || Math.abs(delta) >= height) {
-      invalidateAndRepaintScrollRange(plane, layer, startY, endY);
-      return height > 0 ? Array.from({ length: height }, (_, i) => startY + i) : [];
-    }
-
-    if (hasPendingRowsInRange(plane, startY, endY)) {
-      invalidateAndRepaintScrollRange(plane, layer, startY, endY);
-      return Array.from({ length: height }, (_, i) => startY + i);
-    }
 
     const region = layer.lines.slice(startY, endY);
     const nextRegion =
@@ -689,36 +675,57 @@ export function createDomRenderer(
     }
 
     reorderLayerDomRows(layer, startY, endY);
-    return [];
+  }
+
+  function canApplyScrollOperations(
+    planes: readonly TerminalRenderPlane[],
+    operations: readonly TerminalScrollOperation[] | null | undefined,
+  ): boolean {
+    if (!capabilities.scrollOperations || planes.length !== 1 || !operations?.length) return false;
+    const plane = planes[0]!;
+    const layer = planeLayers.get(plane);
+    if (!layer) return false;
+
+    for (const op of operations) {
+      const { startY, endY } = scrollOperationRange(op);
+      const delta = Math.trunc(op.delta);
+      const height = endY - startY;
+      if (height <= 0 || delta === 0 || Math.abs(delta) >= height) return false;
+      if (hasPendingRowsInRange(plane, startY, endY)) return false;
+    }
+
+    return true;
   }
 
   function applyScrollOperations(
+    planes: readonly TerminalRenderPlane[],
+    operations: readonly TerminalScrollOperation[] | null | undefined,
+  ): void {
+    if (!operations?.length) return;
+    for (const plane of planes) {
+      const layer = planeLayers.get(plane);
+      if (!layer) continue;
+      for (const op of operations) applyScrollOperationToLayer(layer, op);
+    }
+  }
+
+  function markScrollOperationRangesPending(
     planes: readonly TerminalRenderPlane[],
     operations: readonly TerminalScrollOperation[] | null | undefined,
   ): readonly number[] {
     if (!operations?.length) return [];
     const fallbackRows = new Set<number>();
 
-    if (!capabilities.scrollOperations || planes.length !== 1) {
-      for (const plane of planes) {
-        const layer = planeLayers.get(plane);
-        if (!layer) continue;
-        for (const op of operations) {
-          const { startY, endY } = scrollOperationRange(op);
-          invalidateAndRepaintScrollRange(plane, layer, startY, endY);
-          addFallbackRows(fallbackRows, startY, endY);
-        }
-      }
-      return Array.from(fallbackRows).sort((a, b) => a - b);
-    }
-
     for (const plane of planes) {
       const layer = planeLayers.get(plane);
       if (!layer) continue;
       for (const op of operations) {
-        for (const y of applyScrollOperationToLayer(plane, layer, op)) fallbackRows.add(y);
+        const { startY, endY } = scrollOperationRange(op);
+        invalidateAndRepaintScrollRange(plane, layer, startY, endY);
+        addFallbackRows(fallbackRows, startY, endY);
       }
     }
+
     return Array.from(fallbackRows).sort((a, b) => a - b);
   }
 
@@ -844,11 +851,23 @@ export function createDomRenderer(
 
   const offCommit = terminal.on("commit", ({ dirtyRows, planes, sync, scrollOperations }) => {
     const activePlanes = planes?.length ? planes : TERMINAL_RENDER_PLANES;
-    const fallbackRows = applyScrollOperations(activePlanes, scrollOperations);
+    const dirtyCommitRows = dirtyRows === null ? null : [...dirtyRows];
+    const initialSyncWork = estimateSyncFlushWork({
+      planes: activePlanes,
+      rows: dirtyCommitRows,
+    });
+    const shouldApplyScrollOperations =
+      Boolean(sync) &&
+      shouldSyncFlush(initialSyncWork) &&
+      canApplyScrollOperations(activePlanes, scrollOperations);
+    const fallbackRows = shouldApplyScrollOperations
+      ? []
+      : markScrollOperationRangesPending(activePlanes, scrollOperations);
+    if (shouldApplyScrollOperations) applyScrollOperations(activePlanes, scrollOperations);
 
     // Track which rows this specific commit adds to pending, so scoped sync
     // flush can limit DOM work to just the high-priority update.
-    const commitRows = unionRows(dirtyRows === null ? null : [...dirtyRows], fallbackRows);
+    const commitRows = unionRows(dirtyCommitRows, fallbackRows);
 
     if (dirtyRows === null) {
       const size = terminal.size();

--- a/src/vue/render/render-manager.ts
+++ b/src/vue/render/render-manager.ts
@@ -42,9 +42,8 @@ export type RenderManager = Readonly<{
   invalidatePlane: (plane: TerminalRenderPlane) => void;
   /**
    * Dangerous escape hatch: shifts whole terminal rows for the target plane, not a
-   * component-local region. Do not call in DOM mode unless the caller also repaints
-   * the whole affected viewport; DOM rendering currently does not consume terminal
-   * scrollOperations.
+   * component-local region. Only call when the active renderer consumes terminal
+   * scrollOperations or when the caller repaints the whole affected viewport.
    */
   unsafeScrollPlaneRows: (
     plane: TerminalRenderPlane,

--- a/test/dom-renderer-scroll-operations.test.ts
+++ b/test/dom-renderer-scroll-operations.test.ts
@@ -78,6 +78,76 @@ describe("DomRenderer scrollOperations", () => {
     }
   });
 
+  it("shifts DOM line nodes downward for negative scroll delta", () => {
+    const terminal = createTerminal({ cols: 8, rows: 4 });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const renderer = createDomRenderer(terminal, container);
+
+    try {
+      for (let y = 0; y < 4; y++) terminal.write(`item-${y}`, { x: 0, y });
+      terminal.commit({ planes: ["default"], sync: true });
+      const before = lineEls(container);
+
+      scrollPlaneRows(terminal, "default", 0, 4, -1);
+      terminal.write("new", { x: 0, y: 0 });
+      const dirtyRows = terminal.commit({ planes: ["default"], sync: true });
+
+      expect(dirtyRows).toEqual([0]);
+      expect(lineEls(container)[1]).toBe(before[0]);
+      expect(lineEls(container)[3]).toBe(before[2]);
+      expect([0, 1, 2, 3].map((y) => rowText(container, y))).toEqual([
+        "new",
+        "item-0",
+        "item-1",
+        "item-2",
+      ]);
+      expect(renderer.debugStats.flush.last).toMatchObject({
+        mode: "sync",
+        planeRows: 1,
+        planes: 1,
+      });
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("falls back to repainting the scroll range when scrollOperations are disabled", () => {
+    const terminal = createTerminal({ cols: 8, rows: 4 });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const renderer = createDomRenderer(terminal, container, {
+      enableScrollOperations: false,
+    });
+
+    try {
+      expect(renderer.capabilities.scrollOperations).toBe(false);
+      for (let y = 0; y < 4; y++) terminal.write(`item-${y}`, { x: 0, y });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      scrollPlaneRows(terminal, "default", 0, 4, 1);
+      terminal.write("item-4", { x: 0, y: 3 });
+      const dirtyRows = terminal.commit({ planes: ["default"], sync: true });
+
+      expect(dirtyRows).toEqual([3]);
+      expect([0, 1, 2, 3].map((y) => rowText(container, y))).toEqual([
+        "item-1",
+        "item-2",
+        "item-3",
+        "item-4",
+      ]);
+      expect(renderer.debugStats.flush.last).toMatchObject({
+        mode: "sync",
+        planeRows: 4,
+        planes: 1,
+      });
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
   it("falls back to repainting the affected range when pending rows overlap", () => {
     const previousRaf = globalThis.requestAnimationFrame;
     const previousCancel = globalThis.cancelAnimationFrame;
@@ -112,7 +182,7 @@ describe("DomRenderer scrollOperations", () => {
       terminal.write("row-4", { x: 0, y: 3 });
       terminal.commit({ planes: ["default"], sync: true });
 
-      Array.from(callbacks.values())[0]?.(0);
+      expect(callbacks.size).toBe(0);
       expect([0, 1, 2, 3].map((y) => rowText(container, y))).toEqual([
         "pend-1",
         "row-2",
@@ -120,9 +190,9 @@ describe("DomRenderer scrollOperations", () => {
         "row-4",
       ]);
       expect(renderer.debugStats.flush.last).toMatchObject({
-        mode: "deferred",
-        planeRows: 3,
-        planes: 4,
+        mode: "sync",
+        planeRows: 4,
+        planes: 1,
       });
     } finally {
       renderer.dispose();
@@ -166,6 +236,47 @@ describe("DomRenderer scrollOperations", () => {
         "ovr-3",
         "ovr-4",
       ]);
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("keeps DOM output correct when commit omits planes and scrollOperations are present", () => {
+    const terminal = createTerminal({ cols: 8, rows: 4 });
+    const overlay = getPlaneTerminal(terminal, "overlay");
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const renderer = createDomRenderer(terminal, container);
+
+    try {
+      for (let y = 0; y < 4; y++) {
+        terminal.write(`def-${y}`, { x: 0, y });
+        overlay.write(`ovr-${y}`, { x: 0, y });
+      }
+      terminal.commit({ sync: true });
+
+      scrollPlaneRows(terminal, "overlay", 0, 4, 1);
+      overlay.write("ovr-4", { x: 0, y: 3 });
+      terminal.commit({ sync: true });
+
+      expect([0, 1, 2, 3].map((y) => rowText(container, y, "default"))).toEqual([
+        "def-0",
+        "def-1",
+        "def-2",
+        "def-3",
+      ]);
+      expect([0, 1, 2, 3].map((y) => rowText(container, y, "overlay"))).toEqual([
+        "ovr-1",
+        "ovr-2",
+        "ovr-3",
+        "ovr-4",
+      ]);
+      expect(renderer.debugStats.flush.last).toMatchObject({
+        mode: "sync",
+        planeRows: 16,
+        planes: 4,
+      });
     } finally {
       renderer.dispose();
       container.remove();

--- a/test/dom-renderer-scroll-operations.test.ts
+++ b/test/dom-renderer-scroll-operations.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import { getPlaneTerminal, scrollPlaneRows } from "../src/core/terminal/create-terminal.js";
+import { createDomRenderer, createTerminal } from "../src/index.js";
+
+function lineEls(container: HTMLElement, plane = "default"): HTMLElement[] {
+  const layer = container.querySelector(`[data-vt-plane="${plane}"]`);
+  const lines = layer?.children[0]?.children;
+  return lines ? (Array.from(lines) as HTMLElement[]) : [];
+}
+
+function rowText(container: HTMLElement, y: number, plane = "default"): string {
+  return lineEls(container, plane)[y]?.textContent?.trimEnd() ?? "";
+}
+
+describe("DomRenderer scrollOperations", () => {
+  it("shifts DOM line nodes and sync-flushes only exposed rows", () => {
+    const previousRaf = globalThis.requestAnimationFrame;
+    const previousCancel = globalThis.cancelAnimationFrame;
+    let rafCalls = 0;
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      rafCalls++;
+      cb(0);
+      return rafCalls;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = (() => {}) as typeof cancelAnimationFrame;
+
+    const terminal = createTerminal({ cols: 8, rows: 4 });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const renderer = createDomRenderer(terminal, container);
+
+    try {
+      for (let y = 0; y < 4; y++) terminal.write(`item-${y}`, { x: 0, y });
+      terminal.commit({ planes: ["default"], sync: true });
+      const before = lineEls(container);
+      rafCalls = 0;
+
+      scrollPlaneRows(terminal, "default", 0, 4, 1);
+      terminal.write("item-4", { x: 0, y: 3 });
+      const dirtyRows = terminal.commit({ planes: ["default"], sync: true });
+
+      expect(dirtyRows).toEqual([3]);
+      expect(rafCalls).toBe(0);
+      expect(lineEls(container)[0]).toBe(before[1]);
+      expect(lineEls(container)[3]).toBe(before[0]);
+      expect([0, 1, 2, 3].map((y) => rowText(container, y))).toEqual([
+        "item-1",
+        "item-2",
+        "item-3",
+        "item-4",
+      ]);
+      expect(renderer.debugStats.flush.last).toMatchObject({
+        mode: "sync",
+        planeRows: 1,
+        planes: 1,
+      });
+
+      scrollPlaneRows(terminal, "default", 0, 4, 1);
+      terminal.write("item-5", { x: 0, y: 3 });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      expect([0, 1, 2, 3].map((y) => rowText(container, y))).toEqual([
+        "item-2",
+        "item-3",
+        "item-4",
+        "item-5",
+      ]);
+      expect(renderer.debugStats.flush.last).toMatchObject({
+        mode: "sync",
+        planeRows: 1,
+        planes: 1,
+      });
+    } finally {
+      renderer.dispose();
+      container.remove();
+      globalThis.requestAnimationFrame = previousRaf;
+      globalThis.cancelAnimationFrame = previousCancel;
+    }
+  });
+
+  it("falls back to repainting the affected range when pending rows overlap", () => {
+    const previousRaf = globalThis.requestAnimationFrame;
+    const previousCancel = globalThis.cancelAnimationFrame;
+    const callbacks = new Map<number, FrameRequestCallback>();
+    let rafId = 0;
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      const id = ++rafId;
+      callbacks.set(id, cb);
+      return id;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((id: number) => {
+      callbacks.delete(id);
+    }) as typeof cancelAnimationFrame;
+
+    const terminal = createTerminal({ cols: 8, rows: 4 });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const renderer = createDomRenderer(terminal, container);
+
+    try {
+      Array.from(callbacks.values()).forEach((cb) => cb(0));
+      callbacks.clear();
+      for (let y = 0; y < 4; y++) terminal.write(`row-${y}`, { x: 0, y });
+      terminal.commit({ planes: ["default"], sync: true });
+      callbacks.clear();
+
+      terminal.write("pend-1", { x: 0, y: 1 });
+      terminal.commit({ planes: ["default"] });
+      expect(rowText(container, 1)).toBe("row-1");
+
+      scrollPlaneRows(terminal, "default", 0, 4, 1);
+      terminal.write("row-4", { x: 0, y: 3 });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      Array.from(callbacks.values())[0]?.(0);
+      expect([0, 1, 2, 3].map((y) => rowText(container, y))).toEqual([
+        "pend-1",
+        "row-2",
+        "row-3",
+        "row-4",
+      ]);
+      expect(renderer.debugStats.flush.last).toMatchObject({
+        mode: "deferred",
+        planeRows: 3,
+        planes: 4,
+      });
+    } finally {
+      renderer.dispose();
+      container.remove();
+      globalThis.requestAnimationFrame = previousRaf;
+      globalThis.cancelAnimationFrame = previousCancel;
+    }
+  });
+
+  it("only shifts active planes from the commit", () => {
+    const terminal = createTerminal({ cols: 8, rows: 4 });
+    const overlay = getPlaneTerminal(terminal, "overlay");
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const renderer = createDomRenderer(terminal, container);
+
+    try {
+      for (let y = 0; y < 4; y++) {
+        terminal.write(`def-${y}`, { x: 0, y });
+        overlay.write(`ovr-${y}`, { x: 0, y });
+      }
+      terminal.commit({ sync: true });
+      const defaultBefore = lineEls(container, "default");
+      const overlayBefore = lineEls(container, "overlay");
+
+      scrollPlaneRows(terminal, "overlay", 0, 4, 1);
+      overlay.write("ovr-4", { x: 0, y: 3 });
+      terminal.commit({ planes: ["overlay"], sync: true });
+
+      expect(lineEls(container, "default")[0]).toBe(defaultBefore[0]);
+      expect(lineEls(container, "overlay")[0]).toBe(overlayBefore[1]);
+      expect([0, 1, 2, 3].map((y) => rowText(container, y, "default"))).toEqual([
+        "def-0",
+        "def-1",
+        "def-2",
+        "def-3",
+      ]);
+      expect([0, 1, 2, 3].map((y) => rowText(container, y, "overlay"))).toEqual([
+        "ovr-1",
+        "ovr-2",
+        "ovr-3",
+        "ovr-4",
+      ]);
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+});

--- a/test/dom-renderer-scroll-operations.test.ts
+++ b/test/dom-renderer-scroll-operations.test.ts
@@ -148,6 +148,114 @@ describe("DomRenderer scrollOperations", () => {
     }
   });
 
+  it("keeps normal scrollOperation commits deferred until rAF", () => {
+    const previousRaf = globalThis.requestAnimationFrame;
+    const previousCancel = globalThis.cancelAnimationFrame;
+    const callbacks = new Map<number, FrameRequestCallback>();
+    let rafId = 0;
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      const id = ++rafId;
+      callbacks.set(id, cb);
+      return id;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((id: number) => {
+      callbacks.delete(id);
+    }) as typeof cancelAnimationFrame;
+
+    const terminal = createTerminal({ cols: 8, rows: 4 });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const renderer = createDomRenderer(terminal, container);
+
+    try {
+      Array.from(callbacks.values()).forEach((cb) => cb(0));
+      callbacks.clear();
+      for (let y = 0; y < 4; y++) terminal.write(`item-${y}`, { x: 0, y });
+      terminal.commit({ planes: ["default"], sync: true });
+      const before = [0, 1, 2, 3].map((y) => rowText(container, y));
+
+      scrollPlaneRows(terminal, "default", 0, 4, 1);
+      terminal.write("item-4", { x: 0, y: 3 });
+      terminal.commit({ planes: ["default"] });
+
+      expect([0, 1, 2, 3].map((y) => rowText(container, y))).toEqual(before);
+      expect(callbacks.size).toBe(1);
+      Array.from(callbacks.values())[0]?.(0);
+      expect([0, 1, 2, 3].map((y) => rowText(container, y))).toEqual([
+        "item-1",
+        "item-2",
+        "item-3",
+        "item-4",
+      ]);
+      expect(renderer.debugStats.flush.last).toMatchObject({
+        mode: "deferred",
+        planeRows: 4,
+        planes: 4,
+      });
+    } finally {
+      renderer.dispose();
+      container.remove();
+      globalThis.requestAnimationFrame = previousRaf;
+      globalThis.cancelAnimationFrame = previousCancel;
+    }
+  });
+
+  it("defers sync scrollOperation commits when the sync budget is insufficient", () => {
+    const previousRaf = globalThis.requestAnimationFrame;
+    const previousCancel = globalThis.cancelAnimationFrame;
+    const callbacks = new Map<number, FrameRequestCallback>();
+    let rafId = 0;
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      const id = ++rafId;
+      callbacks.set(id, cb);
+      return id;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((id: number) => {
+      callbacks.delete(id);
+    }) as typeof cancelAnimationFrame;
+
+    const terminal = createTerminal({ cols: 8, rows: 4 });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const renderer = createDomRenderer(terminal, container, {
+      syncFlushCellBudget: 0,
+    });
+
+    try {
+      Array.from(callbacks.values()).forEach((cb) => cb(0));
+      callbacks.clear();
+      for (let y = 0; y < 4; y++) terminal.write(`item-${y}`, { x: 0, y });
+      terminal.commit({ planes: ["default"], sync: true });
+      Array.from(callbacks.values())[0]?.(0);
+      callbacks.clear();
+      const before = [0, 1, 2, 3].map((y) => rowText(container, y));
+
+      scrollPlaneRows(terminal, "default", 0, 4, 1);
+      terminal.write("item-4", { x: 0, y: 3 });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      expect(renderer.debugStats.syncFlush.last).toMatchObject({
+        performed: false,
+        rows: 4,
+        planes: 1,
+      });
+      expect([0, 1, 2, 3].map((y) => rowText(container, y))).toEqual(before);
+      expect(callbacks.size).toBe(1);
+      Array.from(callbacks.values())[0]?.(0);
+      expect([0, 1, 2, 3].map((y) => rowText(container, y))).toEqual([
+        "item-1",
+        "item-2",
+        "item-3",
+        "item-4",
+      ]);
+    } finally {
+      renderer.dispose();
+      container.remove();
+      globalThis.requestAnimationFrame = previousRaf;
+      globalThis.cancelAnimationFrame = previousCancel;
+    }
+  });
+
   it("falls back to repainting the affected range when pending rows overlap", () => {
     const previousRaf = globalThis.requestAnimationFrame;
     const previousCancel = globalThis.cancelAnimationFrame;

--- a/test/dom-renderer-scroll-operations.test.ts
+++ b/test/dom-renderer-scroll-operations.test.ts
@@ -256,6 +256,60 @@ describe("DomRenderer scrollOperations", () => {
     }
   });
 
+  it("defers sync scrollOperations when the scroll region exceeds the sync budget", () => {
+    const previousRaf = globalThis.requestAnimationFrame;
+    const previousCancel = globalThis.cancelAnimationFrame;
+    const callbacks = new Map<number, FrameRequestCallback>();
+    let rafId = 0;
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      const id = ++rafId;
+      callbacks.set(id, cb);
+      return id;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((id: number) => {
+      callbacks.delete(id);
+    }) as typeof cancelAnimationFrame;
+
+    const terminal = createTerminal({ cols: 8, rows: 40 });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const renderer = createDomRenderer(terminal, container, {
+      syncFlushMaxRows: 4,
+      syncFlushCellBudget: 8 * 4,
+    });
+
+    try {
+      Array.from(callbacks.values()).forEach((cb) => cb(0));
+      callbacks.clear();
+      for (let y = 0; y < 40; y++) terminal.write(`r${y}`, { x: 0, y });
+      terminal.commit({ planes: ["default"], sync: true });
+      Array.from(callbacks.values())[0]?.(0);
+      callbacks.clear();
+      const before = [0, 1, 2, 39].map((y) => rowText(container, y));
+
+      scrollPlaneRows(terminal, "default", 0, 40, 1);
+      terminal.write("new", { x: 0, y: 39 });
+      const dirtyRows = terminal.commit({ planes: ["default"], sync: true });
+
+      expect(dirtyRows).toEqual([39]);
+      expect(renderer.debugStats.syncFlush.last).toMatchObject({
+        performed: false,
+        deferredReason: "budget",
+        rows: 40,
+        planes: 1,
+      });
+      expect([0, 1, 2, 39].map((y) => rowText(container, y))).toEqual(before);
+      expect(callbacks.size).toBe(1);
+      Array.from(callbacks.values())[0]?.(0);
+      expect([0, 1, 2, 39].map((y) => rowText(container, y))).toEqual(["r1", "r2", "r3", "new"]);
+    } finally {
+      renderer.dispose();
+      container.remove();
+      globalThis.requestAnimationFrame = previousRaf;
+      globalThis.cancelAnimationFrame = previousCancel;
+    }
+  });
+
   it("falls back to repainting the affected range when pending rows overlap", () => {
     const previousRaf = globalThis.requestAnimationFrame;
     const previousCancel = globalThis.cancelAnimationFrame;

--- a/test/dom-renderer-sync-flush.test.ts
+++ b/test/dom-renderer-sync-flush.test.ts
@@ -37,7 +37,7 @@ describe("DomRenderer sync flush", () => {
       expect(container.textContent).toContain("A");
       expect(renderer.capabilities).toEqual({
         syncFlush: true,
-        scrollOperations: false,
+        scrollOperations: true,
         domRows: true,
       });
       expect(renderer.debugStats.syncFlush).toMatchObject({

--- a/test/virtual-list.test.ts
+++ b/test/virtual-list.test.ts
@@ -94,7 +94,7 @@ describe("TVirtualList", () => {
     mounted.unmount();
   });
 
-  it("repaints the DOM viewport even when rowScrollMode is enabled", async () => {
+  it("uses DOM scrollOperations for full-row unsafe slow wheel scroll", async () => {
     const items = Array.from({ length: 20 }, (_, index) => `item-${index}`);
     const mounted = await mountTerminal(
       () =>
@@ -126,6 +126,53 @@ describe("TVirtualList", () => {
     await nextTick();
 
     off();
+    expect(commits).toContainEqual({
+      dirtyRows: [3],
+      scrollOperations: [{ startY: 0, endY: 4, delta: 1 }],
+    });
+    expect([0, 1, 2, 3].map((y) => rowText(mounted, y))).toEqual([
+      "item-1",
+      "item-2",
+      "item-3",
+      "item-4",
+    ]);
+    expect(mounted.container()!.textContent).not.toContain("item-0");
+    mounted.unmount();
+  });
+
+  it("repaints the DOM viewport when scrollOperations are disabled", async () => {
+    const items = Array.from({ length: 20 }, (_, index) => `item-${index}`);
+    const mounted = await mountTerminal(
+      () =>
+        h(TVirtualList, {
+          x: 0,
+          y: 0,
+          w: 20,
+          h: 4,
+          itemCount: items.length,
+          itemVersion: 1,
+          getItem: (index: number) => items[index],
+          autoFocus: true,
+          rowScrollMode: "unsafe-full-row",
+        }),
+      20,
+      8,
+      { domRendererOptions: { enableScrollOperations: false } },
+    );
+
+    const commits: Array<{
+      dirtyRows: readonly number[] | null;
+      scrollOperations: unknown;
+    }> = [];
+    const off = mounted.terminal.on("commit", ({ dirtyRows, scrollOperations }) => {
+      commits.push({ dirtyRows, scrollOperations: scrollOperations ?? null });
+    });
+
+    dispatchWheel(mounted.container()!);
+    await nextTick();
+    await nextTick();
+
+    off();
     expect(commits).toContainEqual({ dirtyRows: [0, 1, 2, 3], scrollOperations: null });
     expect([0, 1, 2, 3].map((y) => rowText(mounted, y))).toEqual([
       "item-1",
@@ -133,6 +180,45 @@ describe("TVirtualList", () => {
       "item-3",
       "item-4",
     ]);
+    mounted.unmount();
+  });
+
+  it("repaints the DOM viewport when unsafe row scroll does not own full rows", async () => {
+    const items = Array.from({ length: 20 }, (_, index) => `item-${index}`);
+    const mounted = await mountTerminal(
+      () => [
+        h(TVirtualList, {
+          x: 0,
+          y: 0,
+          w: 10,
+          h: 4,
+          itemCount: items.length,
+          itemVersion: 1,
+          getItem: (index: number) => items[index],
+          autoFocus: true,
+          rowScrollMode: "unsafe-full-row",
+        }),
+        h(TText, { x: 12, y: 1, w: 4, value: "SIDE" }),
+      ],
+      20,
+      8,
+    );
+
+    const commits: Array<{
+      dirtyRows: readonly number[] | null;
+      scrollOperations: unknown;
+    }> = [];
+    const off = mounted.terminal.on("commit", ({ dirtyRows, scrollOperations }) => {
+      commits.push({ dirtyRows, scrollOperations: scrollOperations ?? null });
+    });
+
+    dispatchWheel(mounted.container()!);
+    await nextTick();
+    await nextTick();
+
+    off();
+    expect(commits).toContainEqual({ dirtyRows: [0, 1, 2, 3], scrollOperations: null });
+    expect(rowText(mounted, 1)).toContain("SIDE");
     mounted.unmount();
   });
 


### PR DESCRIPTION
## Summary

- Enable DOM renderer scrollOperations capability with an enableScrollOperations opt-out.
- Consume terminal commit scrollOperations by shifting DOM line nodes before dirty-row flush, clearing shifted row cache entries, and falling back when pending rows overlap.
- Update TVirtualList rowScrollMode="unsafe-full-row" DOM coverage, docs, and phase 2 benchmark comparison.

## Validation

- pnpm vitest run test/dom-renderer-scroll-operations.test.ts test/dom-renderer-sync-flush.test.ts test/virtual-list.test.ts test/frame-perf.test.ts
- pnpm test
- pnpm run format:check
- pnpm run lint
- pnpm run typecheck
- pnpm run test:package-exports
- pnpm run bench:phase2
- pnpm run docs:build