### PR TITLE
feat: add TLogView component and append-only log store

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -393,6 +393,8 @@ log.appendChunk(" world\nnext line");
 
 `createAppendOnlyLogStore()` 使用普通 `string[]` 和单独的 `version` ref。不要把日志行做成 reactive array，也不要每次 append 都重建全文字符串。
 
+`TLogView` 假设数据源是 append-only 或 tail-only mutation。任意可见历史行会变化的 source 不适合只靠 `version` 驱动这个组件；这类浏览/选择场景应使用 `TVirtualList`，或者等后续显式 viewport refresh API。
+
 ### Scroll behavior
 
 - `appendLine` / `appendChunk` / `replaceTail` 通过 `scheduler.queueFrameTask()` 合并为 stream frame。

--- a/docs/components.md
+++ b/docs/components.md
@@ -14,7 +14,7 @@
 | Layout        | `TBox` `TView` `TAnchor` `TFlow` `TRenderLayer` `TRenderPlane` | 布局、裁剪、层级、分层组合                      | 通用，和 CLI 业务无关                              |
 | Text / Motion | `TText` `TTransition`                                          | 文本渲染、状态切换、动画插值                    | 通用                                               |
 | Input         | `TInput` `TInputBox` `TJsonEditor`                             | prompt、表单、结构化文本编辑                    | 通用，但推荐把补全/校验放到插件层                  |
-| Pickers       | `TList` `TVirtualList` `TSelect` `TPathPicker`                 | palette、列表、路径选择                         | `TPathPicker` 本体可复用，路径语义由 provider 注入 |
+| Pickers       | `TList` `TVirtualList` `TLogView` `TSelect` `TPathPicker`      | palette、列表、日志、路径选择                   | `TPathPicker` 本体可复用，路径语义由 provider 注入 |
 | Overlay       | `TDialog` `TMultilineModal` `TDebugOverlay`                    | 对话框、详情查看、调试覆盖层                    | 通用，适合多种宿主                                 |
 | Navigation    | `TRouterView` + `createTerminalRouter()`                       | 多页面 TUI / shell                              | 通用                                               |
 
@@ -293,7 +293,7 @@ const app = createTerminalApp({
 
 可滚动列表（单选）：支持点击/双击、键盘导航、滚轮滚动，`v-model` 维护选中 index。
 
-`TList` 适合小数据选择器。大数据选择/浏览场景请使用 `TVirtualList`，日志、streaming transcript、append-only output 场景应使用后续专用日志组件，避免把大数组直接传进 Vue deep reactivity。
+`TList` 适合小数据选择器。大数据选择/浏览场景请使用 `TVirtualList`，日志、streaming transcript、append-only output 场景请使用 experimental `TLogView`，避免把大数组直接传进 Vue deep reactivity。
 
 ### Props
 
@@ -312,7 +312,7 @@ const app = createTerminalApp({
 
 ## TVirtualList
 
-大数据选择/浏览列表：使用 `itemCount` / `itemVersion` / `getItem` 从外部数据源读取可见行，避免把大数组本体放进 Vue deep reactivity。它不是完整日志/streaming 组件；当前没有 bottom stickiness、append chunk 增量解析或 scroll anchor API。
+大数据选择/浏览列表：使用 `itemCount` / `itemVersion` / `getItem` 从外部数据源读取可见行，避免把大数组本体放进 Vue deep reactivity。它不是日志/streaming 组件；append-only 输出请使用 `TLogView`。
 
 > Phase 1 experimental API：当前从 `@simon_he/vue-tui/experimental` 导出，暂不进入 root 入口。API 仍可能在 scheduler frame task、controlled scrollTop、overscan、TLogView 等后续能力落地前调整。
 
@@ -357,6 +357,52 @@ const renderItem = (item: Row) => item.title;
 
 - `change`: `{ index, value }`
 - `scroll`: `scrollTop`（number）
+- `focus` / `blur` / `keydown`
+
+## TLogView
+
+Append-only / streaming 日志视图：从 `source` / `version` 数据源读取可见窗口，不接收大数组，也不把日志内容放进 Vue deep reactivity。
+
+> Experimental API：当前从 `@simon_he/vue-tui/experimental` 导出，暂不进入 root 入口。第一版只支持 fixed one-line rows；wrap、ANSI、高亮和 variable-height rows 是后续能力。
+
+### Props
+
+- `x`/`y`/`w`/`h` `(number, required)`
+- `source` `(TLogDataSource, required)`：只提供 `lineCount()` 和 `getLine(index)`
+- `version` `(number, required)`：数据变化版本号；template 里 `Ref<number>` 会自动 unwrap
+- `style` `(Style?)`
+- `autoFocus` `(boolean)`
+- `autoStickToBottom` `(boolean)`：在底部时 append 自动贴底，默认 `true`
+- `overscan` `(number)`：预留给后续 wrap/highlight，当前 fixed-row paint 不依赖它
+- `rowScrollMode` `("off" | "unsafe-full-row")`：full-row append 的 opt-in unsafe row-scroll 优化，默认 `"off"`
+
+### Data source
+
+```ts
+import { createAppendOnlyLogStore } from "@simon_he/vue-tui/experimental";
+
+const log = createAppendOnlyLogStore();
+
+log.appendChunk("hello");
+log.appendChunk(" world\nnext line");
+```
+
+```vue
+<TLogView :source="log.source" :version="log.version" :x="0" :y="0" :w="80" :h="20" />
+```
+
+`createAppendOnlyLogStore()` 使用普通 `string[]` 和单独的 `version` ref。不要把日志行做成 reactive array，也不要每次 append 都重建全文字符串。
+
+### Scroll behavior
+
+- `appendLine` / `appendChunk` / `replaceTail` 通过 `scheduler.queueFrameTask()` 合并为 stream frame。
+- `TLogView` 每次 paint 只调用当前 visible rows 的 `source.getLine()`。
+- 用户在底部时 append 会贴底；用户滚离底部后 append 不改变当前 `scrollTop`，也不会 repaint 当前 viewport。
+- `rowScrollMode="unsafe-full-row"` 只有在组件占满整行、未被裁剪、renderer 支持 `scrollOperations` 时才会用 exposed-row repaint；其它情况回退到 viewport repaint。
+
+### Events
+
+- `scroll`: `{ scrollTop, atBottom, lineCount }`
 - `focus` / `blur` / `keydown`
 
 ## TSelect

--- a/docs/components.md
+++ b/docs/components.md
@@ -395,6 +395,8 @@ log.appendChunk(" world\nnext line");
 
 `createAppendOnlyLogStore()` 保存 completed lines 和一个 mutable tail。`appendChunk()` 会追加到 tail，并按 `\n` 拆出 completed lines；`appendLine()` 如果存在 tail，会先完成 `tail + line`，否则追加一条 completed line；`replaceTail()` 只替换 mutable tail，不会修改最后一条 completed line。
 
+`appendLine()` / `appendLines()` 期望调用方传入单行文本；需要处理包含 newline 的 streaming 输入时，请使用 `appendChunk()`。
+
 `TLogView` 假设数据源是 append-only 或 tail-only mutation。任意可见历史行会变化的 source 不适合只靠 `version` 驱动这个组件；这类浏览/选择场景应使用 `TVirtualList`，或者等后续显式 viewport refresh API。
 
 当前 `TLogView` 只支持 fixed one-line rows。超出宽度的行会被 clip，不会 wrap。
@@ -403,6 +405,7 @@ log.appendChunk(" world\nnext line");
 
 - `appendLine` / `appendChunk` / `replaceTail` 通过 `scheduler.queueFrameTask()` 合并为 stream frame。
 - `TLogView` 每次 paint 只调用当前 visible rows 的 `source.getLine()`。
+- 初始 mount 默认显示当前底部；`autoStickToBottom=false` 只影响后续 append 是否继续贴底，不改变初始定位。
 - 用户在底部时 append 会贴底；用户滚离底部后 append 不改变当前 `scrollTop`，也不会 repaint 当前 viewport。
 - `rowScrollMode="unsafe-full-row"` 只有在组件占满整行、未被裁剪、renderer 支持 `scrollOperations` 时才会用 exposed-row repaint；其它情况回退到 viewport repaint。
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -393,7 +393,11 @@ log.appendChunk(" world\nnext line");
 
 `createAppendOnlyLogStore()` 使用普通 `string[]` 和单独的 `version` ref。不要把日志行做成 reactive array，也不要每次 append 都重建全文字符串。
 
+`createAppendOnlyLogStore()` 保存 completed lines 和一个 mutable tail。`appendChunk()` 会追加到 tail，并按 `\n` 拆出 completed lines；`appendLine()` 如果存在 tail，会先完成 `tail + line`，否则追加一条 completed line；`replaceTail()` 只替换 mutable tail，不会修改最后一条 completed line。
+
 `TLogView` 假设数据源是 append-only 或 tail-only mutation。任意可见历史行会变化的 source 不适合只靠 `version` 驱动这个组件；这类浏览/选择场景应使用 `TVirtualList`，或者等后续显式 viewport refresh API。
+
+当前 `TLogView` 只支持 fixed one-line rows。超出宽度的行会被 clip，不会 wrap。
 
 ### Scroll behavior
 

--- a/docs/generated/components-api.md
+++ b/docs/generated/components-api.md
@@ -14,6 +14,7 @@
 - [TInputBox](#tinputbox)
 - [TJsonEditor](#tjsoneditor)
 - [TList](#tlist)
+- [TLogView](#tlogview)
 - [TMultilineModal](#tmultilinemodal)
 - [TPathPicker](#tpathpicker)
 - [TRenderLayer](#trenderlayer)
@@ -380,6 +381,38 @@
 | <code>focus</code>             | —       | —    |
 | <code>blur</code>              | —       | —    |
 | <code>keydown</code>           | —       | —    |
+
+## TLogView
+
+源码：`src/vue/components/TLogView.ts`
+
+> Experimental import: `@simon_he/vue-tui/experimental`
+
+### Props
+
+| 名称                           | 类型                        | 默认值                       | 必填 | 说明 |
+| ------------------------------ | --------------------------- | ---------------------------- | ---- | ---- |
+| <code>x</code>                 | <code>number</code>         | —                            | 是   | —    |
+| <code>y</code>                 | <code>number</code>         | —                            | 是   | —    |
+| <code>w</code>                 | <code>number</code>         | —                            | 是   | —    |
+| <code>h</code>                 | <code>number</code>         | —                            | 是   | —    |
+| <code>zIndex</code>            | <code>number</code>         | <code>0</code>               | 否   | —    |
+| <code>source</code>            | <code>TLogDataSource</code> | —                            | 是   | —    |
+| <code>version</code>           | <code>number</code>         | —                            | 是   | —    |
+| <code>style</code>             | <code>Style</code>          | <code>undefined</code>       | 否   | —    |
+| <code>autoFocus</code>         | <code>boolean</code>        | <code>false</code>           | 否   | —    |
+| <code>autoStickToBottom</code> | <code>boolean</code>        | <code>true</code>            | 否   | —    |
+| <code>overscan</code>          | <code>number</code>         | <code>2</code>               | 否   | —    |
+| <code>rowScrollMode</code>     | <code>RowScrollMode</code>  | <code>&quot;off&quot;</code> | 否   | —    |
+
+### Events
+
+| 名称                 | Payload | 说明 |
+| -------------------- | ------- | ---- |
+| <code>scroll</code>  | —       | —    |
+| <code>focus</code>   | —       | —    |
+| <code>blur</code>    | —       | —    |
+| <code>keydown</code> | —       | —    |
 
 ## TMultilineModal
 

--- a/docs/high-throughput-rendering.md
+++ b/docs/high-throughput-rendering.md
@@ -221,38 +221,51 @@ wheel 行为：
 
 ### 5. `TLogView` streaming path
 
-实现位置：新增 `src/vue/components/TLogView.ts`，必要时先以内部实验组件落地。
+实现位置：`src/vue/components/TLogView.ts`、`src/vue/log/append-only-log-store.ts`。
+`TLogView` 当前通过 `@simon_he/vue-tui/experimental` 暴露，暂不进入 root export。
 
 数据接口：
 
 ```ts
-interface LogDataSource {
+interface TLogDataSource {
   lineCount(): number;
-  version(): number;
   getLine(index: number): string;
 }
 ```
 
-组件 API：
+append-only store：
 
 ```ts
-appendLine(line: string): void;
-appendChunk(chunk: string): void;
-replaceTail(text: string): void;
+const log = createAppendOnlyLogStore();
+
+log.appendLine("ready");
+log.appendChunk("hello");
+log.appendChunk(" world\nnext line");
+log.replaceTail("next line...");
+```
+
+组件 API：
+
+```vue
+<TLogView :source="log.source" :version="log.version" />
 ```
 
 策略：
 
+- `appendLine` / `appendLines` / `appendChunk` / `replaceTail` 只更新普通 store 和 `version` ref，不把日志数组放进 Vue deep reactivity。
 - chunk append 不重建全文字符串。
-- 每帧 drain pending chunks，受 `frameBudgetMs` 限制。
-- wrap、ANSI parse、highlight 只对 visible + overscan 范围执行。
-- 用户在底部时 stick-to-bottom；离开底部后新内容不抢 scrollTop。
+- `TLogView` paint 只读取 visible window；当前 fixed one-line rows 不做 wrap、ANSI parse 或 highlight。
+- `version` 不进入 render deps；source 变化通过 scheduler frame task 以 `reason: "stream"` 合并。
+- 用户在底部时 stick-to-bottom；离开底部后 append 不抢 scrollTop，也不 repaint 当前 viewport。
+- full-row 且 `rowScrollMode="unsafe-full-row"` 时，单行 append 可以使用 `unsafeScrollPlaneRows()` + exposed dirty rows；非 full-row、clipped 或 renderer 不支持 `scrollOperations` 时回退 viewport repaint。
 
 验收测试：
 
-- append chunk 只 dirty tail rows。
+- `getLine()` 调用量随 viewport 高度增长，不随总行数增长。
+- append at bottom 在 full-row unsafe 场景只 dirty exposed rows。
 - 用户离开底部后 append 不改变当前 visible top。
-- 每帧处理预算耗尽时保留 pending backlog，并用 low priority 继续调度。
+- clear/shrink 会 clamp scrollTop 并 repaint viewport。
+- stream frame 在 FramePerf 中记录 `reason: "stream"`、`frameTaskCount` 和 coalescing 数据。
 
 ### 6. Style interning
 
@@ -340,6 +353,7 @@ type FramePerf = {
 | Row bucket degradation threshold (50%/60%)                          | ✅ done      |
 | `TVirtualList.rowScrollMode` opt-in for unsafe row-scroll fast path | ✅ done      |
 | Scheduler-owned frame tasks / live mode                             | ✅ Phase 2.1 |
+| Experimental `TLogView` append-only streaming path                  | ✅ Phase 2.2 |
 | `TList` wheel 行为修改（不再同步更新 active/modelValue）            | 🔲 planned   |
 | Debug overlay 展示 `scannedNodes/paintedNodes/dirtyRows/frameMs`    | ✅ Phase 2.0 |
 
@@ -358,8 +372,8 @@ pnpm run lint
 目标是让大数据追加和 streaming 输出可控。
 
 1. scheduler 增加 `queueFrameTask/requestLive/dropLive/configure/isInsideFrame`，`TVirtualList` wheel 已迁移到 scheduler frame task。
-2. 新增 stream coalescer，按 `frameBudgetMs` drain。
-3. 新增 `TLogView`，只对 tail rows 和 visible window 做增量处理。
+2. 新增 `TLogView` append-only store + visible-window streaming path。
+3. 后续 stream coalescer 再按 `frameBudgetMs` drain 更复杂输入。
 4. 文本 wrap/width cache 拆到 line-level。
 5. 补 benchmark 脚本：10k/100k rows 滚动、500 lines/s log append。
 

--- a/docs/high-throughput-rendering.md
+++ b/docs/high-throughput-rendering.md
@@ -257,6 +257,7 @@ log.replaceTail("next line...");
 - `TLogView` paint 只读取 visible window；当前 fixed one-line rows 不做 wrap、ANSI parse 或 highlight。
 - `version` 不进入 render deps；source 变化通过 scheduler frame task 以 `reason: "stream"` 合并。
 - 用户在底部时 stick-to-bottom；离开底部后 append 不抢 scrollTop，也不 repaint 当前 viewport。
+- `TLogView` 假设 source 只做 append-only 或 tail-only mutation，不支持任意可见历史行变化的 repaint 语义。
 - full-row 且 `rowScrollMode="unsafe-full-row"` 时，单行 append 可以使用 `unsafeScrollPlaneRows()` + exposed dirty rows；非 full-row、clipped 或 renderer 不支持 `scrollOperations` 时回退 viewport repaint。
 
 验收测试：

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -48,7 +48,9 @@ DOM renderer 的 `scrollOperations` 是输出层优化：terminal/compositor 先
 - 对于会频繁变化的文本：尽量把变化限制在小 rect 内（例如固定输入框区域）。
 - 避免在一个 tick 内创建/销毁大量节点（频繁 `v-if` / 动态 key 重建）。
 - 长列表用“视口”思路渲染（只渲染可见行），避免一次性生成上千 `TText`。
+- append-only / streaming 日志用 experimental `TLogView` + `createAppendOnlyLogStore()`，不要把大数组传进组件，也不要每次 chunk 都重建全文字符串。
 - `TVirtualList rowScrollMode="unsafe-full-row"` 只用于 unclipped full-row 且独占 plane rows 的场景；DOM renderer 会只 repaint exposed dirty rows，pending rows 或不安全条件会回退到 viewport repaint。
+- `TLogView` 用户离底后 append 不会抢 `scrollTop`；如果需要实时 tail，按 End 回到底部后会恢复 stick-to-bottom。
 - `style`/`highlightStyle` 这类对象尽量复用（避免每次都创建新对象导致 watchEffect 触发）。
 
 ## 如何排查
@@ -80,5 +82,6 @@ pnpm run bench:phase2
 - `TVirtualList` 10k / 100k rows burst wheel 100 ticks through scheduler frame-task coalescing
 - DOM sync flush 1 / 5 / 20 / 40 dirty rows
 - append-only 1000 lines simulated path
+- `TLogView` append 1000 lines at bottom / while detached from bottom / burst append
 
 `bench:phase2` 使用 happy-dom synthetic baseline，适合做相同环境下的回归对比，不代表真实浏览器 FPS。

--- a/scripts/bench-phase2.ts
+++ b/scripts/bench-phase2.ts
@@ -105,7 +105,7 @@ const {
   TText,
   useTerminal,
 } = await import("../src/index.js");
-const { TVirtualList } = await import("../src/experimental.js");
+const { createAppendOnlyLogStore, TLogView, TVirtualList } = await import("../src/experimental.js");
 const { createRenderManager } = await import("../src/vue/render/render-manager.js");
 
 function round(n: number): number {
@@ -124,6 +124,8 @@ function summarizeSamples(samples: any[]): Record<string, number> {
       avgScannedNodes: 0,
       avgPaintedNodes: 0,
       avgCoalescedInvalidates: 0,
+      avgFrameTaskCount: 0,
+      avgCoalescedFrameTasks: 0,
     };
   }
   const total = samples.reduce(
@@ -135,6 +137,8 @@ function summarizeSamples(samples: any[]): Record<string, number> {
       acc.scanned += sample.scannedNodes;
       acc.painted += sample.paintedNodes;
       acc.coalescedInvalidates += sample.coalescedInvalidates ?? 0;
+      acc.frameTasks += sample.frameTaskCount ?? 0;
+      acc.coalescedFrameTasks += sample.coalescedFrameTasks ?? 0;
       if (sample.durationMs > acc.maxFrame) acc.maxFrame = sample.durationMs;
       return acc;
     },
@@ -146,6 +150,8 @@ function summarizeSamples(samples: any[]): Record<string, number> {
       scanned: 0,
       painted: 0,
       coalescedInvalidates: 0,
+      frameTasks: 0,
+      coalescedFrameTasks: 0,
       maxFrame: 0,
     },
   );
@@ -159,6 +165,8 @@ function summarizeSamples(samples: any[]): Record<string, number> {
     avgScannedNodes: round(total.scanned / samples.length),
     avgPaintedNodes: round(total.painted / samples.length),
     avgCoalescedInvalidates: round(total.coalescedInvalidates / samples.length),
+    avgFrameTaskCount: round(total.frameTasks / samples.length),
+    avgCoalescedFrameTasks: round(total.coalescedFrameTasks / samples.length),
   };
 }
 
@@ -445,6 +453,150 @@ async function benchAppendOnly(): Promise<Record<string, unknown>> {
   }
 }
 
+async function benchDomTLogView(
+  mode: "stick-bottom" | "not-bottom" | "burst",
+): Promise<Record<string, unknown>> {
+  let framePerf: any = null;
+  let rendererRef: any = null;
+  let finalTop = 0;
+  let atBottom = true;
+  let lastFlushCount = 0;
+  let domFlushPlaneRows = 0;
+  let domFlushSamples = 0;
+  let getLineCalls = 0;
+  const appendCount = 1000;
+  const log = createAppendOnlyLogStore();
+  log.appendLines(Array.from({ length: 1000 }, (_, index) => `seed ${index}`));
+  const source = {
+    lineCount: () => log.source.lineCount(),
+    getLine(index: number) {
+      getLineCalls++;
+      return log.source.getLine(index);
+    },
+  };
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  let raf = installCountingSyncRaf();
+
+  const Probe = defineComponent({
+    name: `BenchDomTLogView${mode}`,
+    setup() {
+      const ctx = useTerminal();
+      framePerf = ctx.observability.framePerf;
+      rendererRef = ctx.renderer;
+      framePerf.enabled.value = true;
+      return () =>
+        h(TLogView, {
+          x: 0,
+          y: 0,
+          w: 80,
+          h: 20,
+          source,
+          version: log.version.value,
+          autoFocus: true,
+          rowScrollMode: "unsafe-full-row",
+          onScroll: (payload: { scrollTop: number; atBottom: boolean }) => {
+            finalTop = payload.scrollTop;
+            atBottom = payload.atBottom;
+          },
+        });
+    },
+  });
+
+  const app = createApp({
+    name: "BenchDomTLogViewRoot",
+    render() {
+      return h(TerminalProvider, { cols: 80, rows: 24 }, { default: () => h(Probe) });
+    },
+  });
+
+  function collectDomFlush(): void {
+    const flush = rendererRef?.value?.debugStats?.flush;
+    if (!flush || flush.count === lastFlushCount || !flush.last) return;
+    lastFlushCount = flush.count;
+    domFlushPlaneRows += flush.last.planeRows;
+    domFlushSamples++;
+  }
+
+  try {
+    app.mount(root);
+    await nextTick();
+    collectDomFlush();
+
+    const container = root.querySelector("[data-vt-container]") as HTMLElement | null;
+    if (!container) throw new Error("DOM terminal container not mounted");
+
+    if (mode === "not-bottom") {
+      const wheel = new Event("wheel", { bubbles: true, cancelable: true }) as any;
+      Object.defineProperties(wheel, {
+        clientX: { value: 0 },
+        clientY: { value: 0 },
+        deltaY: { value: -300 },
+        deltaMode: { value: 0 },
+      });
+      container.dispatchEvent(wheel);
+      await nextTick();
+      collectDomFlush();
+    }
+
+    if (mode === "burst") {
+      raf.restore();
+      raf = installManualRaf();
+    }
+
+    framePerf.clear();
+    getLineCalls = 0;
+    lastFlushCount = rendererRef?.value?.debugStats?.flush.count ?? 0;
+    domFlushPlaneRows = 0;
+    domFlushSamples = 0;
+
+    const startedAt = now();
+    for (let i = 0; i < appendCount; i++) {
+      log.appendLine(`${mode} ${i}`);
+      if (mode === "burst") {
+        await nextTick();
+      } else {
+        await nextTick();
+        collectDomFlush();
+      }
+    }
+    const pendingRafFramesBeforeFlush = raf.pendingRafFrames();
+    const flushedRafCallbacks = mode === "burst" ? raf.flushOneFrame() : 0;
+    if (mode === "burst") {
+      await nextTick();
+      collectDomFlush();
+    }
+    const durationMs = now() - startedAt;
+    const samples = framePerf.list();
+
+    return {
+      name: `tlog-view-1000-lines-${mode}`,
+      appendCount,
+      scheduledRafFrames: raf.scheduledRafFrames(),
+      pendingRafFramesBeforeFlush,
+      flushedRafCallbacks,
+      durationMs: round(durationMs),
+      avgDomFlushPlaneRows: round(domFlushPlaneRows / Math.max(1, domFlushSamples)),
+      coalescedFrameTasks: samples.reduce(
+        (acc: number, sample: any) => acc + (sample.coalescedFrameTasks ?? 0),
+        0,
+      ),
+      frameTaskCount: samples.reduce(
+        (acc: number, sample: any) => acc + (sample.frameTaskCount ?? 0),
+        0,
+      ),
+      finalTop,
+      atBottom,
+      getLineCalls,
+      ...summarizeSamples(samples),
+    };
+  } finally {
+    app.unmount();
+    root.remove();
+    raf.restore();
+  }
+}
+
 async function main(): Promise<void> {
   const scenarios = [
     await benchRenderManagerDirtyRow(),
@@ -456,6 +608,9 @@ async function main(): Promise<void> {
     await benchDomVirtualList(100_000, "unsafe-full-row"),
     ...[1, 5, 20, 40].map((rows) => benchDomSyncFlush(rows)),
     await benchAppendOnly(),
+    await benchDomTLogView("stick-bottom"),
+    await benchDomTLogView("not-bottom"),
+    await benchDomTLogView("burst"),
   ];
 
   // eslint-disable-next-line no-console

--- a/scripts/generate-component-api-docs.ts
+++ b/scripts/generate-component-api-docs.ts
@@ -74,6 +74,51 @@ function formatTextCell(text: string | null): string {
   return escapeTableText(text);
 }
 
+function markdownCellWidth(text: string): number {
+  let width = 0;
+  for (const ch of text) {
+    const cp = ch.codePointAt(0)!;
+    width +=
+      cp >= 0x1100 &&
+      (cp <= 0x115f ||
+        cp === 0x2329 ||
+        cp === 0x232a ||
+        (cp >= 0x2e80 && cp <= 0xa4cf && cp !== 0x303f) ||
+        (cp >= 0xac00 && cp <= 0xd7a3) ||
+        (cp >= 0xf900 && cp <= 0xfaff) ||
+        (cp >= 0xfe10 && cp <= 0xfe19) ||
+        (cp >= 0xfe30 && cp <= 0xfe6f) ||
+        (cp >= 0xff00 && cp <= 0xff60) ||
+        (cp >= 0xffe0 && cp <= 0xffe6))
+        ? 2
+        : 1;
+  }
+  return width;
+}
+
+function padMarkdownCell(text: string, width: number): string {
+  return `${text}${" ".repeat(Math.max(0, width - markdownCellWidth(text)))}`;
+}
+
+function renderTable(headers: readonly string[], rows: readonly (readonly string[])[]): string[] {
+  const widths = headers.map((header, index) =>
+    Math.max(
+      3,
+      markdownCellWidth(header),
+      ...rows.map((row) => markdownCellWidth(row[index] ?? "")),
+    ),
+  );
+  const out: string[] = [];
+  out.push(
+    `| ${headers.map((cell, index) => padMarkdownCell(cell, widths[index]!)).join(" | ")} |`,
+  );
+  out.push(`| ${widths.map((width) => "-".repeat(width)).join(" | ")} |`);
+  for (const row of rows) {
+    out.push(`| ${row.map((cell, index) => padMarkdownCell(cell, widths[index]!)).join(" | ")} |`);
+  }
+  return out;
+}
+
 function isPropTypeRef(typeNode: ts.TypeNode): typeNode is ts.TypeReferenceNode {
   if (!ts.isTypeReferenceNode(typeNode)) return false;
   const name = typeNode.typeName;
@@ -424,7 +469,7 @@ function renderMarkdown(components: ComponentMeta[]): string {
     lines.push("");
     lines.push(`源码：\`${c.sourceRelPath}\``);
     lines.push("");
-    if (c.name === "TVirtualList") {
+    if (c.name === "TVirtualList" || c.name === "TLogView") {
       lines.push("> Experimental import: `@simon_he/vue-tui/experimental`");
       lines.push("");
     }
@@ -435,17 +480,18 @@ function renderMarkdown(components: ComponentMeta[]): string {
       lines.push("—");
       lines.push("");
     } else {
-      lines.push("| 名称 | 类型 | 默认值 | 必填 | 说明 |");
-      lines.push("| --- | --- | --- | --- | --- |");
-      for (const p of c.props) {
-        lines.push(
-          `| ${formatMaybeCode(p.name)} | ${formatMaybeCode(
-            p.type,
-          )} | ${formatMaybeCode(p.defaultValue)} | ${p.required ? "是" : "否"} | ${formatTextCell(
-            p.description,
-          )} |`,
-        );
-      }
+      lines.push(
+        ...renderTable(
+          ["名称", "类型", "默认值", "必填", "说明"],
+          c.props.map((p) => [
+            formatMaybeCode(p.name),
+            formatMaybeCode(p.type),
+            formatMaybeCode(p.defaultValue),
+            p.required ? "是" : "否",
+            formatTextCell(p.description),
+          ]),
+        ),
+      );
       lines.push("");
     }
 
@@ -455,19 +501,21 @@ function renderMarkdown(components: ComponentMeta[]): string {
       lines.push("—");
       lines.push("");
     } else {
-      lines.push("| 名称 | Payload | 说明 |");
-      lines.push("| --- | --- | --- |");
-      for (const e of c.events) {
-        lines.push(
-          `| ${formatMaybeCode(e.name)} | ${formatMaybeCode(
-            e.payload,
-          )} | ${formatTextCell(e.description)} |`,
-        );
-      }
+      lines.push(
+        ...renderTable(
+          ["名称", "Payload", "说明"],
+          c.events.map((e) => [
+            formatMaybeCode(e.name),
+            formatMaybeCode(e.payload),
+            formatTextCell(e.description),
+          ]),
+        ),
+      );
       lines.push("");
     }
   }
 
+  while (lines.at(-1) === "") lines.pop();
   return `${lines.join("\n")}\n`;
 }
 

--- a/src/experimental.ts
+++ b/src/experimental.ts
@@ -1,2 +1,5 @@
 export { TVirtualList } from "./vue/components/TVirtualList.js";
+export { TLogView } from "./vue/components/TLogView.js";
+export { createAppendOnlyLogStore } from "./vue/log/append-only-log-store.js";
 export type { RowScrollMode } from "./vue/components/TVirtualList.js";
+export type { AppendOnlyLogStore, TLogDataSource, TLogViewScrollPayload } from "./vue/log/types.js";

--- a/src/vue/components/TLogView.ts
+++ b/src/vue/components/TLogView.ts
@@ -31,6 +31,8 @@ import {
 type ScrollStrategy = "auto" | "viewport-repaint";
 type RowScrollMode = "off" | "unsafe-full-row";
 
+let nextTLogViewTaskId = 0;
+
 function clamp(n: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, n));
 }
@@ -96,6 +98,7 @@ export const TLogView = defineComponent({
     const focused = ref(false);
     const scrollTop = ref(0);
     const stickToBottom = ref(true);
+    const frameTaskId = `TLogView:${nextTLogViewTaskId++}`;
     let dirtyRowsHint: readonly number[] | undefined;
     let renderNodeId: string | null = null;
     let alive = true;
@@ -367,7 +370,7 @@ export const TLogView = defineComponent({
 
     function requestStreamFrame(): void {
       scheduler.queueFrameTask({
-        id: `TLogView:${renderNodeId ?? "pending"}:stream`,
+        id: `${frameTaskId}:stream`,
         reason: "stream",
         priority: stickToBottom.value ? "high" : "normal",
         sync: stickToBottom.value,
@@ -387,7 +390,7 @@ export const TLogView = defineComponent({
     function requestWheelScroll(nextTop: number): void {
       pendingWheelTop = nextTop;
       scheduler.queueFrameTask({
-        id: `TLogView:${renderNodeId ?? "pending"}:wheel`,
+        id: `${frameTaskId}:wheel`,
         reason: "scroll",
         priority: "high",
         sync: true,

--- a/src/vue/components/TLogView.ts
+++ b/src/vue/components/TLogView.ts
@@ -1,0 +1,578 @@
+import type { PropType } from "vue";
+import type { TerminalRenderPlane } from "../../core/render-plane.js";
+import type { Style } from "../../core/types.js";
+import type { Rect, TerminalKeyboardEvent } from "../../events/index.js";
+import type { FramePerfReason } from "../../observability/frame-perf.js";
+import type { TLogDataSource, TLogViewScrollPayload } from "../log/types.js";
+import {
+  computed,
+  defineComponent,
+  h,
+  inject,
+  onBeforeUnmount,
+  ref,
+  watch,
+  watchEffect,
+} from "vue";
+import { useLayout } from "../composables/use-layout.js";
+import { useRenderNode } from "../composables/use-render-node.js";
+import { useTerminalNode } from "../composables/use-terminal-node.js";
+import { useTerminal } from "../composables/use-terminal.js";
+import { useVisibility } from "../composables/use-visibility.js";
+import { EventZIndexContextKey, RenderPlaneContextKey } from "../context.js";
+import { intersectRect, translateRect } from "../utils/rect.js";
+import { formatInlineCellLine, padEndByCells, sliceByCellsRange } from "../utils/text.js";
+import {
+  applyWheelScroll,
+  createWheelScrollState,
+  resetWheelScrollState,
+} from "../utils/wheel-scroll.js";
+
+type ScrollStrategy = "auto" | "viewport-repaint";
+type RowScrollMode = "off" | "unsafe-full-row";
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function getWheelScrollInput(e: { deltaY?: number; deltaMode?: number }): {
+  deltaY: number;
+  mode: "auto" | "line" | "pixel";
+} {
+  const deltaY = Number(e.deltaY ?? 0);
+  const deltaMode = typeof e.deltaMode === "number" ? e.deltaMode : undefined;
+  if (
+    Number.isInteger(deltaY) &&
+    deltaY !== 0 &&
+    Math.abs(deltaY) >= 100 &&
+    Math.abs(deltaY) % 100 === 0 &&
+    deltaMode == null
+  ) {
+    return { deltaY: deltaY / 100, mode: "line" };
+  }
+  if (deltaMode === 1) return { deltaY, mode: "line" };
+  if (deltaMode === 0) return { deltaY, mode: "pixel" };
+  return { deltaY, mode: "auto" };
+}
+
+export const TLogView = defineComponent({
+  name: "TLogView",
+  props: {
+    x: { type: Number, required: true },
+    y: { type: Number, required: true },
+    w: { type: Number, required: true },
+    h: { type: Number, required: true },
+    zIndex: { type: Number, default: 0 },
+    source: {
+      type: Object as PropType<TLogDataSource>,
+      required: true,
+    },
+    version: {
+      type: Number,
+      required: true,
+    },
+    style: {
+      type: Object as PropType<Style>,
+      default: undefined,
+    },
+    autoFocus: { type: Boolean, default: false },
+    autoStickToBottom: { type: Boolean, default: true },
+    overscan: { type: Number, default: 2 },
+    rowScrollMode: {
+      type: String as PropType<RowScrollMode>,
+      default: "off",
+    },
+  },
+  emits: ["scroll", "focus", "blur", "keydown"],
+  setup(props, { emit }) {
+    const { terminal, scheduler, render, rendererCapabilities, defaultStyle, events } =
+      useTerminal();
+    const layout = useLayout();
+    const { visible, rootProps } = useVisibility();
+    const plane = inject(RenderPlaneContextKey, ref<TerminalRenderPlane>("default"));
+    const parentEventZ = inject(EventZIndexContextKey, computed(() => 0) as any);
+    const eventZ = computed(() => (parentEventZ.value ?? 0) + (props.zIndex ?? 0));
+
+    const focused = ref(false);
+    const scrollTop = ref(0);
+    const stickToBottom = ref(true);
+    let dirtyRowsHint: readonly number[] | undefined;
+    let renderNodeId: string | null = null;
+    let alive = true;
+    let pendingWheelTop: number | null = null;
+    let lastLineCount = 0;
+    let lastPaintedBottom: Readonly<{
+      index: number;
+      text: string;
+    }> | null = null;
+    const wheelState = createWheelScrollState();
+
+    const fullRect = computed<Rect>(() => {
+      const raw = { x: props.x, y: props.y, w: props.w, h: props.h };
+      return translateRect(raw, layout.originX, layout.originY);
+    });
+
+    const absRect = computed<Rect>(() => {
+      const translated = fullRect.value;
+      if (!layout.clipRect) return translated;
+      return intersectRect(translated, layout.clipRect) ?? { x: 0, y: 0, w: 0, h: 0 };
+    });
+
+    function normalizeRect(r: Rect): Rect {
+      return {
+        x: Math.floor(r.x),
+        y: Math.floor(r.y),
+        w: Math.max(0, Math.floor(r.w)),
+        h: Math.max(0, Math.floor(r.h)),
+      };
+    }
+
+    function normalizedRect(): Rect {
+      return normalizeRect(absRect.value);
+    }
+
+    function normalizedFullRect(): Rect {
+      return normalizeRect(fullRect.value);
+    }
+
+    function clipOffsets(): { x: number; y: number } {
+      const full = normalizedFullRect();
+      const clip = normalizedRect();
+      return {
+        x: Math.max(0, clip.x - full.x),
+        y: Math.max(0, clip.y - full.y),
+      };
+    }
+
+    function isClipped(): boolean {
+      const full = normalizedFullRect();
+      const clip = normalizedRect();
+      return full.x !== clip.x || full.y !== clip.y || full.w !== clip.w || full.h !== clip.h;
+    }
+
+    function lineCount(): number {
+      const n = Math.floor(Number(props.source.lineCount()));
+      return Number.isFinite(n) ? Math.max(0, n) : 0;
+    }
+
+    function maxScrollTop(): number {
+      const clip = normalizedRect();
+      const { y: clipY } = clipOffsets();
+      return Math.max(0, lineCount() - (clipY + clip.h));
+    }
+
+    function viewportHeight(): number {
+      return normalizedRect().h;
+    }
+
+    function isAtBottom(): boolean {
+      return scrollTop.value >= maxScrollTop();
+    }
+
+    function scrollPayload(): TLogViewScrollPayload {
+      return {
+        scrollTop: scrollTop.value,
+        atBottom: isAtBottom(),
+        lineCount: lineCount(),
+      };
+    }
+
+    function emitScroll(): void {
+      emit("scroll", scrollPayload());
+    }
+
+    function invalidateSelf(
+      priority: "low" | "normal" | "high" = "normal",
+      reason?: FramePerfReason,
+    ): void {
+      scheduler.invalidate({ priority, plane: plane.value, reason });
+    }
+
+    function cancelWheelScrollFrame(): void {
+      pendingWheelTop = null;
+      resetWheelScrollState(wheelState);
+    }
+
+    function exposedRowsForDelta(y0: number, h: number, delta: number): number[] {
+      const rows: number[] = [];
+      if (delta > 0) {
+        for (let i = h - delta; i < h; i++) rows.push(y0 + i);
+      } else {
+        for (let i = 0; i < -delta; i++) rows.push(y0 + i);
+      }
+      return rows;
+    }
+
+    function viewportRows(): number[] {
+      const r = normalizedRect();
+      const rows: number[] = [];
+      for (let y = r.y; y < r.y + r.h; y++) rows.push(y);
+      return rows;
+    }
+
+    function unionDirtyRows(nextRows: readonly number[]): readonly number[] {
+      if (!dirtyRowsHint?.length) return nextRows.slice().sort((a, b) => a - b);
+      const rows = new Set(dirtyRowsHint);
+      for (const y of nextRows) rows.add(y);
+      return Array.from(rows).sort((a, b) => a - b);
+    }
+
+    function markRowsDirty(nextRows: readonly number[]): void {
+      dirtyRowsHint = unionDirtyRows(nextRows);
+      if (renderNodeId) render.update(renderNodeId, { dirtyRowsHint });
+    }
+
+    function markViewportDirty(): void {
+      markRowsDirty(viewportRows());
+    }
+
+    function tailMutationDirtyRow(
+      prevCount: number,
+      nextCount: number,
+      delta: number,
+      r: Rect,
+    ): number | null {
+      if (delta <= 0 || delta >= r.h) return null;
+      if (prevCount <= 0 || nextCount <= prevCount) return null;
+      if (lastPaintedBottom?.index !== prevCount - 1) return null;
+      const nextText = props.source.getLine(prevCount - 1);
+      if (nextText === lastPaintedBottom.text) return null;
+      return r.y + r.h - delta - 1;
+    }
+
+    function applyScrollTop(
+      nextTop: number,
+      strategy: ScrollStrategy = "auto",
+      options?: Readonly<{
+        emitScroll?: boolean;
+        stickToBottom?: boolean;
+        extraDirtyRows?: readonly number[];
+      }>,
+    ): boolean {
+      const r = normalizedRect();
+      const full = normalizedFullRect();
+      const h = r.h;
+      if (h <= 0 || full.h <= 0) return false;
+      const clampedTop = clamp(nextTop, 0, maxScrollTop());
+      const delta = clampedTop - scrollTop.value;
+      if (!delta) {
+        if (options?.stickToBottom != null) stickToBottom.value = options.stickToBottom;
+        return false;
+      }
+      scrollTop.value = clampedTop;
+      stickToBottom.value = options?.stickToBottom ?? isAtBottom();
+
+      const size = terminal.size();
+      const ownsFullRows = Math.floor(r.x) === 0 && Math.floor(r.w) >= size.cols;
+      const withinTerminalRows = r.y >= 0 && r.y + h <= size.rows;
+      const canUseScrollPlane =
+        strategy === "auto" &&
+        props.rowScrollMode === "unsafe-full-row" &&
+        rendererCapabilities.value.scrollOperations &&
+        ownsFullRows &&
+        withinTerminalRows &&
+        !isClipped() &&
+        Math.abs(delta) < h &&
+        !dirtyRowsHint?.length;
+
+      if (canUseScrollPlane) {
+        render.unsafeScrollPlaneRows(plane.value, r.y, r.y + h, delta);
+        markRowsDirty(
+          options?.extraDirtyRows?.length
+            ? [...exposedRowsForDelta(r.y, h, delta), ...options.extraDirtyRows]
+            : exposedRowsForDelta(r.y, h, delta),
+        );
+        if (options?.emitScroll) emitScroll();
+        return true;
+      }
+
+      markViewportDirty();
+      if (options?.emitScroll) emitScroll();
+      return true;
+    }
+
+    function viewportIncludesLine(index: number): boolean {
+      const r = normalizedRect();
+      const { y: clipY } = clipOffsets();
+      const top = clamp(scrollTop.value, 0, maxScrollTop());
+      const start = top + clipY;
+      return index >= start && index < start + r.h;
+    }
+
+    function handleSourceVersionChanged(): boolean {
+      const prevCount = lastLineCount;
+      const nextCount = lineCount();
+      lastLineCount = nextCount;
+
+      if (nextCount < prevCount) {
+        const nextTop = stickToBottom.value
+          ? maxScrollTop()
+          : clamp(scrollTop.value, 0, maxScrollTop());
+        const changed = applyScrollTop(nextTop, "viewport-repaint", {
+          emitScroll: true,
+          stickToBottom: stickToBottom.value && nextTop >= maxScrollTop(),
+        });
+        if (!changed) markViewportDirty();
+        return true;
+      }
+
+      if (props.autoStickToBottom && stickToBottom.value) {
+        const r = normalizedRect();
+        const prevTop = scrollTop.value;
+        const nextTop = maxScrollTop();
+        const delta = nextTop - prevTop;
+        const extraDirtyRow = tailMutationDirtyRow(prevCount, nextCount, delta, r);
+        const changed = applyScrollTop(nextTop, "auto", {
+          emitScroll: true,
+          stickToBottom: true,
+          extraDirtyRows: extraDirtyRow == null ? undefined : [extraDirtyRow],
+        });
+        if (!changed) markViewportDirty();
+        return true;
+      }
+
+      if (scrollTop.value > maxScrollTop()) {
+        const changed = applyScrollTop(maxScrollTop(), "viewport-repaint", {
+          emitScroll: true,
+          stickToBottom: isAtBottom(),
+        });
+        if (!changed) markViewportDirty();
+        return true;
+      }
+
+      if (nextCount === prevCount && nextCount > 0 && viewportIncludesLine(nextCount - 1)) {
+        markViewportDirty();
+        return true;
+      }
+
+      return false;
+    }
+
+    function requestStreamFrame(): void {
+      scheduler.queueFrameTask({
+        id: `TLogView:${renderNodeId ?? "pending"}:stream`,
+        reason: "stream",
+        priority: stickToBottom.value ? "high" : "normal",
+        sync: stickToBottom.value,
+        run(ctx) {
+          if (!alive) return;
+          const invalidated = handleSourceVersionChanged();
+          if (!invalidated) return;
+          ctx.invalidate({
+            priority: stickToBottom.value ? "high" : "normal",
+            plane: plane.value,
+            reason: "stream",
+          });
+        },
+      });
+    }
+
+    function requestWheelScroll(nextTop: number): void {
+      pendingWheelTop = nextTop;
+      scheduler.queueFrameTask({
+        id: `TLogView:${renderNodeId ?? "pending"}:wheel`,
+        reason: "scroll",
+        priority: "high",
+        sync: true,
+        run(ctx) {
+          if (!alive) return;
+          const top = pendingWheelTop;
+          pendingWheelTop = null;
+          if (top == null) return;
+          const changed = applyScrollTop(top, "viewport-repaint", { emitScroll: true });
+          if (!changed) return;
+          ctx.invalidate({ priority: "high", plane: plane.value, reason: "scroll" });
+        },
+      });
+    }
+
+    function keyboardScroll(nextTop: number, nextStick?: boolean): void {
+      cancelWheelScrollFrame();
+      const changed = applyScrollTop(nextTop, "viewport-repaint", {
+        emitScroll: true,
+        stickToBottom: nextStick,
+      });
+      if (!changed && nextStick != null) stickToBottom.value = nextStick;
+      if (changed) invalidateSelf("high", "input");
+    }
+
+    function onKeydown(e: TerminalKeyboardEvent): void {
+      emit("keydown", e);
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        keyboardScroll(scrollTop.value - 1, false);
+        return;
+      }
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        keyboardScroll(scrollTop.value + 1);
+        return;
+      }
+      if (e.key === "PageUp") {
+        e.preventDefault();
+        keyboardScroll(scrollTop.value - viewportHeight(), false);
+        return;
+      }
+      if (e.key === "PageDown") {
+        e.preventDefault();
+        keyboardScroll(scrollTop.value + viewportHeight());
+        return;
+      }
+      if (e.key === "Home") {
+        e.preventDefault();
+        keyboardScroll(0, false);
+        return;
+      }
+      if (e.key === "End") {
+        e.preventDefault();
+        keyboardScroll(maxScrollTop(), true);
+      }
+    }
+
+    const eventNode = useTerminalNode(() => ({
+      rect: normalizedRect(),
+      zIndex: eventZ.value,
+      visible: visible.value,
+      focusable: true,
+      handlers: {
+        wheel: (e: any) => {
+          const { deltaY, mode } = getWheelScrollInput(e);
+          if (!deltaY) return;
+          const maxTop = maxScrollTop();
+          const baseTop = pendingWheelTop ?? scrollTop.value;
+          const now =
+            typeof e.time === "number"
+              ? e.time
+              : typeof e.timeStamp === "number"
+                ? e.timeStamp
+                : Date.now();
+          const { nextTop, dir } = applyWheelScroll(
+            wheelState,
+            deltaY,
+            baseTop,
+            maxTop,
+            now,
+            mode,
+            {
+              disableAcceleration: mode === "pixel",
+            },
+          );
+          if (!dir || nextTop === baseTop) return;
+
+          e.preventDefault?.();
+          requestWheelScroll(nextTop);
+        },
+        focus: () => {
+          focused.value = true;
+          emit("focus");
+          invalidateSelf();
+        },
+        blur: () => {
+          focused.value = false;
+          emit("blur");
+          invalidateSelf();
+        },
+        keydown: onKeydown,
+      },
+    }));
+
+    watchEffect(() => {
+      if (!props.autoFocus) return;
+      if (!visible.value) return;
+      const manager = events.value;
+      const nodeId = eventNode.id.value;
+      if (!manager || !nodeId) return;
+      if (manager.getFocused() === nodeId) return;
+      manager.focus(nodeId);
+    });
+
+    watch(
+      () => props.version,
+      () => {
+        resetWheelScrollState(wheelState);
+        requestStreamFrame();
+      },
+    );
+
+    watch(
+      [
+        () => props.source,
+        () => fullRect.value.y,
+        () => fullRect.value.h,
+        () => absRect.value.y,
+        () => absRect.value.h,
+      ],
+      () => {
+        resetWheelScrollState(wheelState);
+        lastLineCount = lineCount();
+        const nextTop = stickToBottom.value
+          ? maxScrollTop()
+          : clamp(scrollTop.value, 0, maxScrollTop());
+        const changed = applyScrollTop(nextTop, "viewport-repaint", {
+          stickToBottom: stickToBottom.value && nextTop >= maxScrollTop(),
+        });
+        if (!changed) markViewportDirty();
+        invalidateSelf("normal", "data");
+      },
+      { immediate: true },
+    );
+
+    onBeforeUnmount(() => {
+      alive = false;
+      cancelWheelScrollFrame();
+    });
+
+    const renderNode = useRenderNode(() => ({
+      zIndex: props.zIndex,
+      rect: visible.value ? normalizedRect() : { x: 0, y: 0, w: 0, h: 0 },
+      deps: [
+        visible.value,
+        absRect.value,
+        fullRect.value,
+        props.source,
+        focused.value,
+        props.style,
+        defaultStyle.value,
+      ],
+      paint: (dirtyRows) => {
+        dirtyRowsHint = undefined;
+        lastPaintedBottom = null;
+        if (!visible.value) return;
+        const r = normalizedRect();
+        const full = normalizedFullRect();
+        if (r.w <= 0 || r.h <= 0) return;
+        const base = props.style ?? defaultStyle.value;
+        const count = lineCount();
+        const top = clamp(scrollTop.value, 0, maxScrollTop());
+        const { x: clipX, y: clipY } = clipOffsets();
+
+        const paintRow = (y: number): void => {
+          if (y < r.y || y >= r.y + r.h) return;
+          const idx = top + clipY + (y - r.y);
+          const text = idx >= 0 && idx < count ? props.source.getLine(idx) : "";
+          if (idx === count - 1 && y === r.y + r.h - 1) {
+            lastPaintedBottom = { index: idx, text };
+          }
+          const fullLine = formatInlineCellLine(text, full.w);
+          const line = padEndByCells(sliceByCellsRange(fullLine, clipX, clipX + r.w), r.w);
+          terminal.write(line, { x: r.x, y, style: base });
+        };
+
+        const rows = dirtyRows;
+        if (rows?.length) {
+          for (const y of rows) paintRow(y);
+          return;
+        }
+        for (let y = r.y; y < r.y + r.h; y++) paintRow(y);
+      },
+    }));
+
+    watchEffect(() => {
+      renderNodeId = renderNode.id.value;
+    });
+
+    lastLineCount = lineCount();
+
+    return () => h("span", rootProps);
+  },
+});

--- a/src/vue/components/TLogView.ts
+++ b/src/vue/components/TLogView.ts
@@ -291,12 +291,17 @@ export const TLogView = defineComponent({
       return true;
     }
 
-    function viewportIncludesLine(index: number): boolean {
+    function visibleLineRange(): { start: number; end: number } {
       const r = normalizedRect();
       const { y: clipY } = clipOffsets();
       const top = clamp(scrollTop.value, 0, maxScrollTop());
       const start = top + clipY;
-      return index >= start && index < start + r.h;
+      return { start, end: start + r.h };
+    }
+
+    function viewportIntersectsLines(startIndex: number, endIndex: number): boolean {
+      const visible = visibleLineRange();
+      return startIndex < visible.end && endIndex > visible.start;
     }
 
     function handleSourceVersionChanged(): boolean {
@@ -331,6 +336,14 @@ export const TLogView = defineComponent({
         return true;
       }
 
+      if (nextCount > prevCount) {
+        const changedStart = Math.max(0, prevCount - 1);
+        if (viewportIntersectsLines(changedStart, nextCount)) {
+          markViewportDirty();
+          return true;
+        }
+      }
+
       if (scrollTop.value > maxScrollTop()) {
         const changed = applyScrollTop(maxScrollTop(), "viewport-repaint", {
           emitScroll: true,
@@ -340,7 +353,11 @@ export const TLogView = defineComponent({
         return true;
       }
 
-      if (nextCount === prevCount && nextCount > 0 && viewportIncludesLine(nextCount - 1)) {
+      if (
+        nextCount === prevCount &&
+        nextCount > 0 &&
+        viewportIntersectsLines(nextCount - 1, nextCount)
+      ) {
         markViewportDirty();
         return true;
       }

--- a/src/vue/log/append-only-log-store.ts
+++ b/src/vue/log/append-only-log-store.ts
@@ -31,7 +31,13 @@ export function createAppendOnlyLogStore(): AppendOnlyLogStore {
     },
     appendLines(nextLines) {
       if (nextLines.length === 0) return;
-      for (const line of nextLines) lines.push(line);
+      let start = 0;
+      if (tail) {
+        lines.push(tail + (nextLines[0] ?? ""));
+        tail = "";
+        start = 1;
+      }
+      for (let i = start; i < nextLines.length; i++) lines.push(nextLines[i] ?? "");
       bump();
     },
     appendChunk(chunk) {
@@ -45,7 +51,7 @@ export function createAppendOnlyLogStore(): AppendOnlyLogStore {
       bump();
     },
     replaceTail(text) {
-      tail = text.replace(/\r/g, "");
+      tail = text.replace(/[\r\n]/g, "");
       bump();
     },
     clear() {

--- a/src/vue/log/append-only-log-store.ts
+++ b/src/vue/log/append-only-log-store.ts
@@ -1,0 +1,57 @@
+import type { AppendOnlyLogStore } from "./types.js";
+import { ref } from "vue";
+
+export function createAppendOnlyLogStore(): AppendOnlyLogStore {
+  const lines: string[] = [];
+  const version = ref(0);
+  let tail = "";
+
+  function bump(): void {
+    version.value++;
+  }
+
+  return {
+    source: {
+      lineCount: () => lines.length + (tail ? 1 : 0),
+      getLine(index) {
+        if (index < lines.length) return lines[index] ?? "";
+        if (index === lines.length) return tail;
+        return "";
+      },
+    },
+    version,
+    appendLine(line) {
+      if (tail) {
+        lines.push(tail + line);
+        tail = "";
+      } else {
+        lines.push(line);
+      }
+      bump();
+    },
+    appendLines(nextLines) {
+      if (nextLines.length === 0) return;
+      for (const line of nextLines) lines.push(line);
+      bump();
+    },
+    appendChunk(chunk) {
+      if (!chunk) return;
+      const parts = chunk.replace(/\r/g, "").split("\n");
+      tail += parts[0] ?? "";
+      for (let i = 1; i < parts.length; i++) {
+        lines.push(tail);
+        tail = parts[i] ?? "";
+      }
+      bump();
+    },
+    replaceTail(text) {
+      tail = text.replace(/\r/g, "");
+      bump();
+    },
+    clear() {
+      lines.length = 0;
+      tail = "";
+      bump();
+    },
+  };
+}

--- a/src/vue/log/types.ts
+++ b/src/vue/log/types.ts
@@ -1,0 +1,22 @@
+import type { Ref } from "vue";
+
+export interface TLogDataSource {
+  lineCount(): number;
+  getLine(index: number): string;
+}
+
+export type AppendOnlyLogStore = Readonly<{
+  source: TLogDataSource;
+  version: Ref<number>;
+  appendLine: (line: string) => void;
+  appendLines: (lines: readonly string[]) => void;
+  appendChunk: (chunk: string) => void;
+  replaceTail: (text: string) => void;
+  clear: () => void;
+}>;
+
+export type TLogViewScrollPayload = Readonly<{
+  scrollTop: number;
+  atBottom: boolean;
+  lineCount: number;
+}>;

--- a/test/log-store.test.ts
+++ b/test/log-store.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { createAppendOnlyLogStore } from "../src/experimental.js";
+
+describe("createAppendOnlyLogStore", () => {
+  it("appends lines and bumps version", () => {
+    const store = createAppendOnlyLogStore();
+
+    store.appendLine("a");
+    store.appendLine("b");
+
+    expect(store.version.value).toBe(2);
+    expect(store.source.lineCount()).toBe(2);
+    expect(store.source.getLine(0)).toBe("a");
+    expect(store.source.getLine(1)).toBe("b");
+    expect(store.source.getLine(2)).toBe("");
+  });
+
+  it("appends multiple lines with one version bump", () => {
+    const store = createAppendOnlyLogStore();
+
+    store.appendLines(["a", "b", "c"]);
+
+    expect(store.version.value).toBe(1);
+    expect(store.source.lineCount()).toBe(3);
+    expect(store.source.getLine(2)).toBe("c");
+  });
+
+  it("does not bump version for empty appendLines", () => {
+    const store = createAppendOnlyLogStore();
+
+    store.appendLines([]);
+
+    expect(store.version.value).toBe(0);
+    expect(store.source.lineCount()).toBe(0);
+  });
+
+  it("streams chunks without rebuilding a full string", () => {
+    const store = createAppendOnlyLogStore();
+
+    store.appendChunk("a");
+    store.appendChunk("b\nc");
+
+    expect(store.version.value).toBe(2);
+    expect(store.source.lineCount()).toBe(2);
+    expect(store.source.getLine(0)).toBe("ab");
+    expect(store.source.getLine(1)).toBe("c");
+  });
+
+  it("handles multiple newlines in one chunk", () => {
+    const store = createAppendOnlyLogStore();
+
+    store.appendChunk("a\nb\nc");
+
+    expect(store.source.lineCount()).toBe(3);
+    expect(store.source.getLine(0)).toBe("a");
+    expect(store.source.getLine(1)).toBe("b");
+    expect(store.source.getLine(2)).toBe("c");
+  });
+
+  it("merges appendLine into an existing tail", () => {
+    const store = createAppendOnlyLogStore();
+
+    store.appendChunk("ab");
+    store.appendLine("c");
+
+    expect(store.source.lineCount()).toBe(1);
+    expect(store.source.getLine(0)).toBe("abc");
+  });
+
+  it("replaces tail and clears", () => {
+    const store = createAppendOnlyLogStore();
+
+    store.appendLine("a");
+    store.replaceTail("b\rc");
+
+    expect(store.version.value).toBe(2);
+    expect(store.source.lineCount()).toBe(2);
+    expect(store.source.getLine(1)).toBe("bc");
+
+    store.clear();
+
+    expect(store.version.value).toBe(3);
+    expect(store.source.lineCount()).toBe(0);
+    expect(store.source.getLine(0)).toBe("");
+  });
+});

--- a/test/log-store.test.ts
+++ b/test/log-store.test.ts
@@ -34,6 +34,17 @@ describe("createAppendOnlyLogStore", () => {
     expect(store.source.lineCount()).toBe(0);
   });
 
+  it("does not flush tail for empty appendLines", () => {
+    const store = createAppendOnlyLogStore();
+
+    store.appendChunk("partial");
+    store.appendLines([]);
+
+    expect(store.version.value).toBe(1);
+    expect(store.source.lineCount()).toBe(1);
+    expect(store.source.getLine(0)).toBe("partial");
+  });
+
   it("streams chunks without rebuilding a full string", () => {
     const store = createAppendOnlyLogStore();
 
@@ -62,6 +73,26 @@ describe("createAppendOnlyLogStore", () => {
 
     store.appendChunk("ab");
     store.appendLine("c");
+
+    expect(store.source.lineCount()).toBe(1);
+    expect(store.source.getLine(0)).toBe("abc");
+  });
+
+  it("merges appendLines first line into an existing tail", () => {
+    const store = createAppendOnlyLogStore();
+
+    store.appendChunk("partial");
+    store.appendLines(["-done", "next"]);
+
+    expect(store.source.lineCount()).toBe(2);
+    expect(store.source.getLine(0)).toBe("partial-done");
+    expect(store.source.getLine(1)).toBe("next");
+  });
+
+  it("keeps replaceTail single-line", () => {
+    const store = createAppendOnlyLogStore();
+
+    store.replaceTail("a\nb\rc");
 
     expect(store.source.lineCount()).toBe(1);
     expect(store.source.getLine(0)).toBe("abc");

--- a/test/package-exports.test.ts
+++ b/test/package-exports.test.ts
@@ -11,39 +11,44 @@ const distExperimentalTypes = resolve("dist/experimental.d.ts");
 const requireDistExports = process.env.VUE_TUI_REQUIRE_DIST_EXPORTS === "1";
 
 describe("package exports", () => {
-  it("keeps TVirtualList behind the experimental entrypoint", async () => {
+  it("keeps high-throughput components behind the experimental entrypoint", async () => {
     const root = await import("../src/index.js");
     const experimental = await import("../src/experimental.js");
 
     expect("TVirtualList" in root).toBe(false);
+    expect("TLogView" in root).toBe(false);
+    expect("createAppendOnlyLogStore" in root).toBe(false);
     expect(root.createFramePerfStore).toBeTruthy();
     expect(root.framePerfNow).toBeTruthy();
     expect(experimental.TVirtualList).toBeTruthy();
+    expect(experimental.TLogView).toBeTruthy();
+    expect(experimental.createAppendOnlyLogStore).toBeTruthy();
   });
 
-  it.skipIf(!requireDistExports && !existsSync(distIndex))(
-    "keeps built ESM/CJS experimental exports usable",
-    async () => {
-      expect(existsSync(distIndex)).toBe(true);
-      expect(existsSync(distExperimental)).toBe(true);
-      expect(existsSync(distTypes)).toBe(true);
-      expect(existsSync(distExperimentalTypes)).toBe(true);
+  it.skipIf(!requireDistExports)("keeps built ESM/CJS experimental exports usable", async () => {
+    expect(existsSync(distIndex)).toBe(true);
+    expect(existsSync(distExperimental)).toBe(true);
+    expect(existsSync(distTypes)).toBe(true);
+    expect(existsSync(distExperimentalTypes)).toBe(true);
 
-      const root = await import(/* @vite-ignore */ pathToFileURL(distIndex).href);
-      const experimental = await import(/* @vite-ignore */ pathToFileURL(distExperimental).href);
-      const require = createRequire(import.meta.url);
-      const rootCjs = require("../dist/index.cjs");
-      const experimentalCjs = require("../dist/experimental.cjs");
+    const root = await import(/* @vite-ignore */ pathToFileURL(distIndex).href);
+    const experimental = await import(/* @vite-ignore */ pathToFileURL(distExperimental).href);
+    const require = createRequire(import.meta.url);
+    const rootCjs = require("../dist/index.cjs");
+    const experimentalCjs = require("../dist/experimental.cjs");
 
-      expect("TVirtualList" in root).toBe(false);
-      expect(root.TerminalProvider).toBeTruthy();
-      expect(root.createFramePerfStore).toBeTruthy();
-      expect(root.framePerfNow).toBeTruthy();
-      expect(rootCjs.TerminalProvider).toBeTruthy();
-      expect(rootCjs.createFramePerfStore).toBeTruthy();
-      expect(rootCjs.framePerfNow).toBeTruthy();
-      expect(experimental.TVirtualList).toBeTruthy();
-      expect(experimentalCjs.TVirtualList).toBeTruthy();
-    },
-  );
+    expect("TVirtualList" in root).toBe(false);
+    expect(root.TerminalProvider).toBeTruthy();
+    expect(root.createFramePerfStore).toBeTruthy();
+    expect(root.framePerfNow).toBeTruthy();
+    expect(rootCjs.TerminalProvider).toBeTruthy();
+    expect(rootCjs.createFramePerfStore).toBeTruthy();
+    expect(rootCjs.framePerfNow).toBeTruthy();
+    expect(experimental.TVirtualList).toBeTruthy();
+    expect(experimental.TLogView).toBeTruthy();
+    expect(experimental.createAppendOnlyLogStore).toBeTruthy();
+    expect(experimentalCjs.TVirtualList).toBeTruthy();
+    expect(experimentalCjs.TLogView).toBeTruthy();
+    expect(experimentalCjs.createAppendOnlyLogStore).toBeTruthy();
+  });
 });

--- a/test/tlog-view.test.ts
+++ b/test/tlog-view.test.ts
@@ -201,6 +201,118 @@ describe("TLogView", () => {
     }
   });
 
+  it("repaints visible appended lines when autoStickToBottom is false and viewport is not full", async () => {
+    const log = createAppendOnlyLogStore();
+
+    const App = defineComponent({
+      name: "TLogViewNoStickShortAppendApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 4,
+            source: log.source,
+            version: log.version.value,
+            autoStickToBottom: false,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 8, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      log.appendLine("line-0");
+      await nextTick();
+      await nextTick();
+
+      expect(rowText(app, 0)).toBe("line-0");
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("repaints newly visible appended row when autoStickToBottom is false", async () => {
+    const log = createAppendOnlyLogStore();
+    log.appendLines(["a", "b", "c"]);
+
+    const App = defineComponent({
+      name: "TLogViewNoStickVisibleAppendApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 4,
+            source: log.source,
+            version: log.version.value,
+            autoStickToBottom: false,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 8, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      log.appendLine("d");
+      await nextTick();
+      await nextTick();
+
+      expect([0, 1, 2, 3].map((y) => rowText(app, y))).toEqual(["a", "b", "c", "d"]);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("does not scroll when autoStickToBottom is false and append grows past the viewport", async () => {
+    const log = createAppendOnlyLogStore();
+    log.appendLines(Array.from({ length: 20 }, (_, index) => `line-${index}`));
+
+    const App = defineComponent({
+      name: "TLogViewNoStickOverflowAppendApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 4,
+            source: log.source,
+            version: log.version.value,
+            autoStickToBottom: false,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 8, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      log.appendLine("line-20");
+      await nextTick();
+      await nextTick();
+
+      expect([0, 1, 2, 3].map((y) => rowText(app, y))).toEqual([
+        "line-16",
+        "line-17",
+        "line-18",
+        "line-19",
+      ]);
+    } finally {
+      app.dispose();
+    }
+  });
+
   it("restores bottom stickiness with End", async () => {
     const log = createAppendOnlyLogStore();
     log.appendLines(Array.from({ length: 20 }, (_, index) => `line-${index}`));

--- a/test/tlog-view.test.ts
+++ b/test/tlog-view.test.ts
@@ -313,6 +313,178 @@ describe("TLogView", () => {
     }
   });
 
+  it("repaints visible tail when appendChunk mutates the current tail", async () => {
+    const log = createAppendOnlyLogStore();
+
+    const App = defineComponent({
+      name: "TLogViewAppendChunkTailApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 4,
+            source: log.source,
+            version: log.version.value,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 8, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      log.appendChunk("hello");
+      await nextTick();
+      await nextTick();
+      expect(rowText(app, 0)).toBe("hello");
+
+      log.appendChunk(" world");
+      await nextTick();
+      await nextTick();
+      expect(rowText(app, 0)).toBe("hello world");
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("repaints visible tail when replaceTail changes the current tail", async () => {
+    const log = createAppendOnlyLogStore();
+    log.appendChunk("draft");
+
+    const App = defineComponent({
+      name: "TLogViewReplaceTailApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 4,
+            source: log.source,
+            version: log.version.value,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 8, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      expect(rowText(app, 0)).toBe("draft");
+
+      log.replaceTail("final");
+      await nextTick();
+      await nextTick();
+
+      expect(rowText(app, 0)).toBe("final");
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("paints completed line and new tail when appendChunk contains newline", async () => {
+    const log = createAppendOnlyLogStore();
+
+    const App = defineComponent({
+      name: "TLogViewAppendChunkNewlineApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 4,
+            source: log.source,
+            version: log.version.value,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 8, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      log.appendChunk("a");
+      await nextTick();
+      await nextTick();
+
+      log.appendChunk("b\nc");
+      await nextTick();
+      await nextTick();
+
+      expect([0, 1].map((y) => rowText(app, y))).toEqual(["ab", "c"]);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("does not coalesce stream tasks across multiple TLogView instances", async () => {
+    const raf = installManualRaf();
+    const logA = createAppendOnlyLogStore();
+    const logB = createAppendOnlyLogStore();
+    let framePerf: ReturnType<typeof useTerminal>["observability"]["framePerf"] | null = null;
+
+    const App = defineComponent({
+      name: "TLogViewMultipleStreamTasksApp",
+      setup() {
+        framePerf = useTerminal().observability.framePerf;
+        framePerf.enabled.value = true;
+        return () => [
+          h(TLogView, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 2,
+            source: logA.source,
+            version: logA.version.value,
+          }),
+          h(TLogView, {
+            x: 0,
+            y: 2,
+            w: 20,
+            h: 2,
+            source: logB.source,
+            version: logB.version.value,
+          }),
+        ];
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 8, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      framePerf!.clear();
+
+      logA.appendLine("a");
+      logB.appendLine("b");
+      await nextTick();
+
+      expect(raf.pending()).toBe(1);
+      raf.flush();
+      await nextTick();
+
+      expect(rowText(app, 0)).toBe("a");
+      expect(rowText(app, 2)).toBe("b");
+      expect(framePerf!.latest()).toMatchObject({
+        reason: "stream",
+        frameTaskCount: 2,
+        remainingFrameTasks: 0,
+      });
+    } finally {
+      app.dispose();
+      raf.restore();
+    }
+  });
+
   it("restores bottom stickiness with End", async () => {
     const log = createAppendOnlyLogStore();
     log.appendLines(Array.from({ length: 20 }, (_, index) => `line-${index}`));

--- a/test/tlog-view.test.ts
+++ b/test/tlog-view.test.ts
@@ -1,0 +1,415 @@
+import type { TLogDataSource } from "../src/experimental.js";
+import { describe, expect, it, vi } from "vitest";
+import { createTerminalApp } from "../src/index.js";
+import { createAppendOnlyLogStore, TLogView } from "../src/experimental.js";
+import {
+  defineComponent,
+  h,
+  mountTerminal,
+  nextTick,
+  ref,
+  TText,
+  useTerminal,
+} from "./ui-regressions-support.js";
+
+function rowText(
+  mounted: { terminal: ReturnType<typeof createTerminalApp>["terminal"] },
+  y: number,
+): string {
+  return mounted.terminal
+    .getRow(y)
+    .map((cell) => cell.ch)
+    .join("")
+    .trimEnd();
+}
+
+function installManualRaf(): Readonly<{
+  pending: () => number;
+  flush: () => void;
+  restore: () => void;
+}> {
+  const previousRaf = globalThis.requestAnimationFrame;
+  const previousCancel = globalThis.cancelAnimationFrame;
+  const callbacks = new Map<number, FrameRequestCallback>();
+  let id = 0;
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    const nextId = ++id;
+    callbacks.set(nextId, cb);
+    return nextId;
+  }) as typeof requestAnimationFrame;
+  globalThis.cancelAnimationFrame = ((rafId: number) => {
+    callbacks.delete(rafId);
+  }) as typeof cancelAnimationFrame;
+
+  return {
+    pending: () => callbacks.size,
+    flush: () => {
+      const pending = Array.from(callbacks.values());
+      callbacks.clear();
+      for (const cb of pending) cb(0);
+    },
+    restore: () => {
+      globalThis.requestAnimationFrame = previousRaf;
+      globalThis.cancelAnimationFrame = previousCancel;
+    },
+  };
+}
+
+describe("TLogView", () => {
+  it("reads only visible rows while painting", async () => {
+    const getLine = vi.fn((index: number) => `line-${index}`);
+    const source: TLogDataSource = {
+      lineCount: () => 100_000,
+      getLine,
+    };
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TLogView, {
+          x: 0,
+          y: 0,
+          w: 20,
+          h: 4,
+          source,
+          version: 1,
+        }),
+      20,
+      8,
+    );
+
+    expect(getLine.mock.calls.length).toBeLessThan(20);
+    expect([0, 1, 2, 3].map((y) => rowText(mounted, y))).toEqual([
+      "line-99996",
+      "line-99997",
+      "line-99998",
+      "line-99999",
+    ]);
+    mounted.unmount();
+  });
+
+  it("uses exposed dirty row when appending at bottom in full-row unsafe mode", async () => {
+    const log = createAppendOnlyLogStore();
+    log.appendLines(Array.from({ length: 20 }, (_, index) => `line-${index}`));
+    let framePerf: ReturnType<typeof useTerminal>["observability"]["framePerf"] | null = null;
+
+    const App = defineComponent({
+      name: "TLogViewAppendBottomApp",
+      setup() {
+        framePerf = useTerminal().observability.framePerf;
+        framePerf.enabled.value = true;
+        return () =>
+          h(TLogView, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 4,
+            source: log.source,
+            version: log.version.value,
+            rowScrollMode: "unsafe-full-row",
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 8, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      framePerf!.clear();
+
+      const commits: Array<{
+        dirtyRows: readonly number[] | null;
+        scrollOperations: unknown;
+      }> = [];
+      const off = app.terminal.on("commit", ({ dirtyRows, scrollOperations }) => {
+        commits.push({ dirtyRows, scrollOperations: scrollOperations ?? null });
+      });
+
+      log.appendLine("line-20");
+      await nextTick();
+      await nextTick();
+
+      off();
+      expect(commits).toContainEqual({
+        dirtyRows: [3],
+        scrollOperations: [{ startY: 0, endY: 4, delta: 1 }],
+      });
+      expect([0, 1, 2, 3].map((y) => rowText(app, y))).toEqual([
+        "line-17",
+        "line-18",
+        "line-19",
+        "line-20",
+      ]);
+      expect(framePerf!.latest()).toMatchObject({
+        reason: "stream",
+        dirtyRows: 1,
+        frameTaskCount: 1,
+      });
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("does not repaint or scroll to bottom when appending while detached from bottom", async () => {
+    const log = createAppendOnlyLogStore();
+    log.appendLines(Array.from({ length: 100 }, (_, index) => `line-${index}`));
+    const onScroll = vi.fn();
+
+    const App = defineComponent({
+      name: "TLogViewDetachedAppendApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 4,
+            source: log.source,
+            version: log.version.value,
+            autoFocus: true,
+            onScroll,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 8, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "keydown", key: "PageUp", code: "PageUp", time: Date.now() });
+      await nextTick();
+      app.scheduler.flushNow();
+      const before = [0, 1, 2, 3].map((y) => rowText(app, y));
+      const scrollCallsBeforeAppend = onScroll.mock.calls.length;
+      const commits: Array<readonly number[] | null> = [];
+      const off = app.terminal.on("commit", ({ dirtyRows }) => {
+        commits.push(dirtyRows);
+      });
+
+      log.appendLine("line-100");
+      await nextTick();
+      await nextTick();
+
+      off();
+      expect([0, 1, 2, 3].map((y) => rowText(app, y))).toEqual(before);
+      expect(onScroll.mock.calls.length).toBe(scrollCallsBeforeAppend);
+      expect(commits).toEqual([]);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("restores bottom stickiness with End", async () => {
+    const log = createAppendOnlyLogStore();
+    log.appendLines(Array.from({ length: 20 }, (_, index) => `line-${index}`));
+
+    const App = defineComponent({
+      name: "TLogViewEndStickinessApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 4,
+            source: log.source,
+            version: log.version.value,
+            autoFocus: true,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 8, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "keydown", key: "PageUp", code: "PageUp", time: Date.now() });
+      await nextTick();
+      app.scheduler.flushNow();
+      log.appendLine("line-20");
+      await nextTick();
+      await nextTick();
+      expect(rowText(app, 3)).not.toBe("line-20");
+
+      app.events.dispatch({ type: "keydown", key: "End", code: "End", time: Date.now() });
+      await nextTick();
+      app.scheduler.flushNow();
+      log.appendLine("line-21");
+      await nextTick();
+      await nextTick();
+
+      expect([0, 1, 2, 3].map((y) => rowText(app, y))).toEqual([
+        "line-18",
+        "line-19",
+        "line-20",
+        "line-21",
+      ]);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("clamps and repaints when the source shrinks", async () => {
+    const sourceLines = ref(Array.from({ length: 100 }, (_, index) => `line-${index}`));
+    const version = ref(1);
+    const source: TLogDataSource = {
+      lineCount: () => sourceLines.value.length,
+      getLine: (index) => sourceLines.value[index] ?? "",
+    };
+
+    const App = defineComponent({
+      name: "TLogViewShrinkApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 4,
+            source,
+            version: version.value,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 8, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      sourceLines.value = ["short-0", "short-1"];
+      version.value++;
+      await nextTick();
+      await nextTick();
+
+      expect([0, 1, 2, 3].map((y) => rowText(app, y))).toEqual(["short-0", "short-1", "", ""]);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("uses DOM exposed row flush for full-row append", async () => {
+    const log = createAppendOnlyLogStore();
+    log.appendLines(Array.from({ length: 20 }, (_, index) => `line-${index}`));
+    let rendererRef: any = null;
+
+    const Probe = defineComponent({
+      name: "TLogViewDomFlushProbe",
+      setup() {
+        rendererRef = useTerminal().renderer;
+        return () =>
+          h(TLogView, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 4,
+            source: log.source,
+            version: log.version.value,
+            rowScrollMode: "unsafe-full-row",
+          });
+      },
+    });
+
+    const mounted = await mountTerminal(() => h(Probe), 20, 8);
+
+    log.appendLine("line-20");
+    await nextTick();
+    await nextTick();
+
+    expect(rendererRef!.value!.debugStats.flush.last!.planeRows).toBeLessThan(4);
+    expect(rowText(mounted, 3)).toBe("line-20");
+    mounted.unmount();
+  });
+
+  it("falls back to viewport repaint when unsafe row scroll does not own full rows", async () => {
+    const log = createAppendOnlyLogStore();
+    log.appendLines(Array.from({ length: 20 }, (_, index) => `line-${index}`));
+
+    const mounted = await mountTerminal(
+      () => [
+        h(TLogView, {
+          x: 1,
+          y: 0,
+          w: 19,
+          h: 4,
+          source: log.source,
+          version: log.version.value,
+          rowScrollMode: "unsafe-full-row",
+        }),
+        h(TText, { x: 0, y: 1, w: 1, value: "x" }),
+      ],
+      20,
+      8,
+    );
+
+    const commits: Array<{
+      dirtyRows: readonly number[] | null;
+      scrollOperations: unknown;
+    }> = [];
+    const off = mounted.terminal.on("commit", ({ dirtyRows, scrollOperations }) => {
+      commits.push({ dirtyRows, scrollOperations: scrollOperations ?? null });
+    });
+
+    log.appendLine("line-20");
+    await nextTick();
+    await nextTick();
+
+    off();
+    expect(commits).toContainEqual({ dirtyRows: [0, 1, 2, 3], scrollOperations: null });
+    mounted.unmount();
+  });
+
+  it("coalesces burst append through one stream frame task", async () => {
+    const raf = installManualRaf();
+    const log = createAppendOnlyLogStore();
+    log.appendLines(Array.from({ length: 20 }, (_, index) => `line-${index}`));
+    let framePerf: ReturnType<typeof useTerminal>["observability"]["framePerf"] | null = null;
+
+    const App = defineComponent({
+      name: "TLogViewBurstAppendApp",
+      setup() {
+        framePerf = useTerminal().observability.framePerf;
+        framePerf.enabled.value = true;
+        return () =>
+          h(TLogView, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 4,
+            source: log.source,
+            version: log.version.value,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 8, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      framePerf!.clear();
+
+      for (let i = 20; i < 120; i++) log.appendLine(`line-${i}`);
+      await nextTick();
+
+      expect(raf.pending()).toBe(1);
+      raf.flush();
+      await nextTick();
+
+      expect(rowText(app, 3)).toBe("line-119");
+      expect(framePerf!.latest()).toMatchObject({
+        reason: "stream",
+        frameTaskCount: 1,
+        remainingFrameTasks: 0,
+      });
+    } finally {
+      app.dispose();
+      raf.restore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add `TLogView` component for terminal log rendering
- Add append-only log store under `src/vue/log/`
- Update docs, benchmarks, and export tests
- Register `TLogView` in experimental exports
- Fix visible appended-line repaint behavior when `autoStickToBottom` is disabled
- Use stable per-instance TLogView frame task ids
- Cover streaming tail repaint for `appendChunk()` / `replaceTail()`

## Changed files (13)

- `src/vue/components/TLogView.ts`
- `src/vue/log/types.ts`
- `src/vue/log/append-only-log-store.ts`
- `src/experimental.ts`
- `test/log-store.test.ts`
- `test/tlog-view.test.ts`
- `test/package-exports.test.ts`
- `scripts/bench-phase2.ts`
- `docs/components.md`
- `docs/high-throughput-rendering.md`
- `docs/performance.md`
- `docs/generated/components.md`
- `docs/generated/components.json`

## Validation

- `pnpm vitest run test/log-store.test.ts test/tlog-view.test.ts test/package-exports.test.ts`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run test:package-exports`
- `pnpm run bench:phase2`
- `pnpm docs:build`
