### PR TITLE
feat(TLogScrollbar): add terminal-rendered scrollbar companion for TLogView

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -8,15 +8,15 @@
 
 ## 组件速读
 
-| 类别          | 组件                                                           | 典型用途                                        | 适配性判断                                         |
-| ------------- | -------------------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------- |
-| Root          | `TerminalProvider`                                             | 创建 terminal / renderer / event manager 上下文 | 通用，适合所有宿主                                 |
-| Layout        | `TBox` `TView` `TAnchor` `TFlow` `TRenderLayer` `TRenderPlane` | 布局、裁剪、层级、分层组合                      | 通用，和 CLI 业务无关                              |
-| Text / Motion | `TText` `TTransition`                                          | 文本渲染、状态切换、动画插值                    | 通用                                               |
-| Input         | `TInput` `TInputBox` `TJsonEditor`                             | prompt、表单、结构化文本编辑                    | 通用，但推荐把补全/校验放到插件层                  |
-| Pickers       | `TList` `TVirtualList` `TLogView` `TSelect` `TPathPicker`      | palette、列表、日志、路径选择                   | `TPathPicker` 本体可复用，路径语义由 provider 注入 |
-| Overlay       | `TDialog` `TMultilineModal` `TDebugOverlay`                    | 对话框、详情查看、调试覆盖层                    | 通用，适合多种宿主                                 |
-| Navigation    | `TRouterView` + `createTerminalRouter()`                       | 多页面 TUI / shell                              | 通用                                               |
+| 类别          | 组件                                                                      | 典型用途                                        | 适配性判断                                         |
+| ------------- | ------------------------------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------- |
+| Root          | `TerminalProvider`                                                        | 创建 terminal / renderer / event manager 上下文 | 通用，适合所有宿主                                 |
+| Layout        | `TBox` `TView` `TAnchor` `TFlow` `TRenderLayer` `TRenderPlane`            | 布局、裁剪、层级、分层组合                      | 通用，和 CLI 业务无关                              |
+| Text / Motion | `TText` `TTransition`                                                     | 文本渲染、状态切换、动画插值                    | 通用                                               |
+| Input         | `TInput` `TInputBox` `TJsonEditor`                                        | prompt、表单、结构化文本编辑                    | 通用，但推荐把补全/校验放到插件层                  |
+| Pickers       | `TList` `TVirtualList` `TLogView` `TLogScrollbar` `TSelect` `TPathPicker` | palette、列表、日志、路径选择                   | `TPathPicker` 本体可复用，路径语义由 provider 注入 |
+| Overlay       | `TDialog` `TMultilineModal` `TDebugOverlay`                               | 对话框、详情查看、调试覆盖层                    | 通用，适合多种宿主                                 |
+| Navigation    | `TRouterView` + `createTerminalRouter()`                                  | 多页面 TUI / shell                              | 通用                                               |
 
 如果你更关心“哪些地方还应该继续做插件化”，建议配合阅读：[扩展性与插件化](./extensibility.md)。
 
@@ -503,6 +503,70 @@ function measureRows() {
   :y="0"
   :w="80"
   :h="20"
+/>
+```
+
+### TLogScrollbar
+
+`TLogScrollbar` 是一个 terminal-rendered 的 experimental companion 组件，消费 `TLogViewScrollMetrics` 渲染 1-cell 宽滚动条。它不持有滚动状态，也不会直接调用 `TLogView` 内部逻辑；父组件负责把 `scrollTo` / `scrollBy` 接到 `TLogViewHandle` 上。
+
+- `metrics` 可以直接来自 `logView.value?.getScrollMetrics()`，也可以由 `@scroll` / `@visualIndex` 事件在外部维护
+- `visualIndexStatus="estimated" | "measuring" | "exact"` 会分别用不同 thumb 状态渲染，方便区分估算值、后台测量中和精确 visual-row index
+- 点击 track 会 emit 目标 visual-row `scrollTo`
+- wheel 会 emit 简单的 `scrollBy(+/-1)` delegation
+- `showArrows=true` 时首尾两行会渲染 `▲` / `▼`，点击后按一个 viewport 高度翻动
+
+```vue
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import {
+  TLogScrollbar,
+  TLogView,
+  type TLogViewHandle,
+  type TLogViewScrollMetrics,
+} from "@simon_he/vue-tui/experimental";
+
+const logView = ref<TLogViewHandle | null>(null);
+const metrics = ref<TLogViewScrollMetrics | null>(null);
+
+function refreshMetrics() {
+  metrics.value = logView.value?.getScrollMetrics() ?? null;
+}
+
+function scrollTo(top: number) {
+  logView.value?.scrollToVisualRow(top);
+  refreshMetrics();
+}
+
+function scrollBy(delta: number) {
+  logView.value?.scrollBy(delta);
+  refreshMetrics();
+}
+
+onMounted(refreshMetrics);
+</script>
+
+<TLogView
+  ref="logView"
+  :x="0"
+  :y="0"
+  :w="79"
+  :h="20"
+  :source="log.source"
+  :version="log.version"
+  wrap
+  visual-index-mode="exact"
+  @scroll="refreshMetrics"
+  @visualIndex="refreshMetrics"
+/>
+
+<TLogScrollbar
+  :x="79"
+  :y="0"
+  :h="20"
+  :metrics="metrics"
+  @scrollTo="scrollTo"
+  @scrollBy="scrollBy"
 />
 ```
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -572,7 +572,7 @@ onMounted(refreshMetrics);
 
 ### Events
 
-- `scroll`: `{ scrollTop, atBottom, lineCount, estimatedVisualRowCount, firstLineIndex }`
+- `scroll`: `{ scrollTop, atBottom, lineCount, estimatedVisualRowCount, visualRowCount, measuredVisualRowCount, measuredLineCount, visualIndexStatus, firstLineIndex }`
 - `update:scrollTop`: `scrollTop`（visual row）
 - `update:searchQuery`: `searchQuery`
 - `search`: `{ query, status, matchCount }`

--- a/docs/generated/components-api.md
+++ b/docs/generated/components-api.md
@@ -14,6 +14,7 @@
 - [TInputBox](#tinputbox)
 - [TJsonEditor](#tjsoneditor)
 - [TList](#tlist)
+- [TLogScrollbar](#tlogscrollbar)
 - [TLogView](#tlogview)
 - [TMultilineModal](#tmultilinemodal)
 - [TPathPicker](#tpathpicker)
@@ -381,6 +382,32 @@
 | <code>focus</code>             | —       | —    |
 | <code>blur</code>              | —       | —    |
 | <code>keydown</code>           | —       | —    |
+
+## TLogScrollbar
+
+源码：`src/vue/components/TLogScrollbar.ts`
+
+### Props
+
+| 名称                        | 类型                                          | 默认值                 | 必填 | 说明 |
+| --------------------------- | --------------------------------------------- | ---------------------- | ---- | ---- |
+| <code>x</code>              | <code>number</code>                           | —                      | 是   | —    |
+| <code>y</code>              | <code>number</code>                           | —                      | 是   | —    |
+| <code>h</code>              | <code>number</code>                           | —                      | 是   | —    |
+| <code>zIndex</code>         | <code>number</code>                           | <code>0</code>         | 否   | —    |
+| <code>metrics</code>        | <code>TLogScrollbarMetrics &#124; null</code> | <code>null</code>      | 否   | —    |
+| <code>style</code>          | <code>Style</code>                            | <code>undefined</code> | 否   | —    |
+| <code>thumbStyle</code>     | <code>Style</code>                            | <code>undefined</code> | 否   | —    |
+| <code>trackStyle</code>     | <code>Style</code>                            | <code>undefined</code> | 否   | —    |
+| <code>measuringStyle</code> | <code>Style</code>                            | <code>undefined</code> | 否   | —    |
+| <code>showArrows</code>     | <code>boolean</code>                          | <code>false</code>     | 否   | —    |
+
+### Events
+
+| 名称                  | Payload | 说明 |
+| --------------------- | ------- | ---- |
+| <code>scrollTo</code> | —       | —    |
+| <code>scrollBy</code> | —       | —    |
 
 ## TLogView
 

--- a/src/experimental.ts
+++ b/src/experimental.ts
@@ -1,7 +1,13 @@
 export { TVirtualList } from "./vue/components/TVirtualList.js";
 export { TLogView } from "./vue/components/TLogView.js";
+export { TLogScrollbar } from "./vue/components/TLogScrollbar.js";
 export { createAppendOnlyLogStore } from "./vue/log/append-only-log-store.js";
 export type { RowScrollMode } from "./vue/components/TVirtualList.js";
+export type {
+  TLogScrollbarMetrics,
+  TLogScrollbarScrollByPayload,
+  TLogScrollbarScrollToPayload,
+} from "./vue/components/TLogScrollbar.js";
 export type {
   TLogViewHandle,
   TLogViewLinkClickPayload,

--- a/src/vue/components/TLogScrollbar.ts
+++ b/src/vue/components/TLogScrollbar.ts
@@ -1,0 +1,245 @@
+import type { PropType } from "vue";
+import type { Style } from "../../core/types.js";
+import type { Rect, TerminalPointerEvent } from "../../events/index.js";
+import type { TLogViewScrollMetrics } from "./TLogView.js";
+import { computed, defineComponent, h, inject } from "vue";
+import { useLayout } from "../composables/use-layout.js";
+import { useRenderNode } from "../composables/use-render-node.js";
+import { useTerminalNode } from "../composables/use-terminal-node.js";
+import { useTerminal } from "../composables/use-terminal.js";
+import { useVisibility } from "../composables/use-visibility.js";
+import { EventZIndexContextKey } from "../context.js";
+import { intersectRect, translateRect } from "../utils/rect.js";
+
+const EMPTY_RECT: Rect = Object.freeze({ x: 0, y: 0, w: 0, h: 0 });
+const SCROLLBAR_WIDTH = 1;
+const TRACK_CHAR = "│";
+const EXACT_THUMB_CHAR = "█";
+const MEASURING_THUMB_CHAR = "▒";
+const ESTIMATED_THUMB_CHAR = "░";
+const UP_ARROW_CHAR = "▲";
+const DOWN_ARROW_CHAR = "▼";
+
+type TLogScrollbarThumb = Readonly<{
+  top: number;
+  size: number;
+}>;
+
+export type TLogScrollbarMetrics = TLogViewScrollMetrics;
+export type TLogScrollbarScrollToPayload = number;
+export type TLogScrollbarScrollByPayload = number;
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function normalizeInt(value: number): number {
+  const n = Math.floor(Number(value));
+  return Number.isFinite(n) ? n : 0;
+}
+
+function arrowInset(height: number, showArrows: boolean): number {
+  return showArrows && height >= 2 ? 1 : 0;
+}
+
+function trackGeometry(
+  height: number,
+  showArrows: boolean,
+): Readonly<{
+  arrowRows: number;
+  trackTop: number;
+  trackHeight: number;
+}> {
+  const arrowRows = arrowInset(height, showArrows);
+  return {
+    arrowRows,
+    trackTop: arrowRows,
+    trackHeight: Math.max(0, height - arrowRows * 2),
+  };
+}
+
+function computeThumb(
+  metrics: TLogScrollbarMetrics | null | undefined,
+  height: number,
+  showArrows: boolean,
+): TLogScrollbarThumb | null {
+  if (!metrics) return null;
+  const { trackTop, trackHeight } = trackGeometry(height, showArrows);
+  if (trackHeight <= 0) return null;
+
+  const viewport = Math.max(0, normalizeInt(metrics.viewportRows));
+  const total = Math.max(normalizeInt(metrics.visualRowCount), viewport, 1);
+  const maxTop = Math.max(0, normalizeInt(metrics.maxScrollTop));
+  const top = clamp(normalizeInt(metrics.scrollTop), 0, maxTop);
+  const size = clamp(Math.round((viewport / total) * trackHeight), 1, trackHeight);
+  const maxThumbTop = Math.max(0, trackHeight - size);
+  const thumbTop = maxTop <= 0 ? 0 : Math.round((top / maxTop) * maxThumbTop);
+
+  return {
+    top: trackTop + thumbTop,
+    size,
+  };
+}
+
+function mergeStyle(base: Style, overlay?: Style): Style {
+  return overlay ? { ...base, ...overlay } : base;
+}
+
+export const TLogScrollbar = defineComponent({
+  name: "TLogScrollbar",
+  props: {
+    x: { type: Number, required: true },
+    y: { type: Number, required: true },
+    h: { type: Number, required: true },
+    zIndex: { type: Number, default: 0 },
+    metrics: {
+      type: Object as PropType<TLogScrollbarMetrics | null>,
+      default: null,
+    },
+    style: { type: Object as PropType<Style>, default: undefined },
+    thumbStyle: { type: Object as PropType<Style>, default: undefined },
+    trackStyle: { type: Object as PropType<Style>, default: undefined },
+    measuringStyle: { type: Object as PropType<Style>, default: undefined },
+    showArrows: { type: Boolean, default: false },
+  },
+  emits: ["scrollTo", "scrollBy"],
+  setup(props, { emit }) {
+    const { terminal, defaultStyle } = useTerminal();
+    const parent = useLayout();
+    const { visible, rootProps } = useVisibility();
+    const parentEventZ = inject(EventZIndexContextKey, computed(() => 0) as any);
+    const eventZ = computed(() => (parentEventZ.value ?? 0) + (props.zIndex ?? 0));
+
+    const fullRect = computed<Rect>(() =>
+      translateRect(
+        {
+          x: normalizeInt(props.x),
+          y: normalizeInt(props.y),
+          w: SCROLLBAR_WIDTH,
+          h: Math.max(0, normalizeInt(props.h)),
+        },
+        parent.originX,
+        parent.originY,
+      ),
+    );
+
+    const rect = computed<Rect>(() => {
+      const translated = fullRect.value;
+      if (!parent.clipRect) return translated;
+      return intersectRect(translated, parent.clipRect) ?? EMPTY_RECT;
+    });
+
+    function emitTrackScroll(e: TerminalPointerEvent): void {
+      const metrics = props.metrics;
+      if (!metrics) return;
+      const full = fullRect.value;
+      const localY = e.cellY - full.y;
+      if (localY < 0 || localY >= full.h) return;
+
+      const { arrowRows, trackTop, trackHeight } = trackGeometry(full.h, props.showArrows);
+      if (arrowRows) {
+        if (localY === 0) {
+          emit("scrollBy", -Math.max(1, normalizeInt(metrics.viewportRows)));
+          e.preventDefault?.();
+          return;
+        }
+        if (localY === full.h - 1) {
+          emit("scrollBy", Math.max(1, normalizeInt(metrics.viewportRows)));
+          e.preventDefault?.();
+          return;
+        }
+      }
+      if (trackHeight <= 0) return;
+
+      const pos = clamp(localY - trackTop, 0, trackHeight - 1);
+      const ratio = trackHeight <= 1 ? 0 : pos / (trackHeight - 1);
+      const target = Math.round(ratio * Math.max(0, normalizeInt(metrics.maxScrollTop)));
+      emit("scrollTo", target);
+      e.preventDefault?.();
+    }
+
+    useTerminalNode(() => ({
+      rect: rect.value,
+      zIndex: eventZ.value,
+      visible: visible.value,
+      focusable: false,
+      handlers: {
+        click: emitTrackScroll,
+        wheel: (e) => {
+          const dir = Math.sign(Number(e.deltaY ?? 0));
+          if (!dir) return;
+          emit("scrollBy", dir);
+          e.preventDefault?.();
+        },
+      },
+    }));
+
+    useRenderNode(() => ({
+      zIndex: props.zIndex,
+      rect: visible.value ? rect.value : EMPTY_RECT,
+      deps: [
+        visible.value,
+        rect.value,
+        fullRect.value,
+        props.metrics,
+        props.style,
+        props.trackStyle,
+        props.thumbStyle,
+        props.measuringStyle,
+        props.showArrows,
+        defaultStyle.value,
+      ],
+      paint: (dirtyRows) => {
+        if (!visible.value) return;
+        const r = rect.value;
+        if (r.w <= 0 || r.h <= 0) return;
+        const full = fullRect.value;
+        const baseStyle = props.style ?? defaultStyle.value;
+        const trackStyle = mergeStyle(baseStyle, props.trackStyle ?? { dim: true });
+        const thumbStyle = mergeStyle(baseStyle, props.thumbStyle ?? { inverse: true });
+        const estimatedThumbStyle = mergeStyle(thumbStyle, { dim: true });
+        const measuringThumbStyle = mergeStyle(
+          baseStyle,
+          props.measuringStyle ?? { ...thumbStyle, dim: true },
+        );
+        const thumb = computeThumb(props.metrics, full.h, props.showArrows);
+        const { arrowRows } = trackGeometry(full.h, props.showArrows);
+
+        const paintRow = (y: number): void => {
+          if (y < r.y || y >= r.y + r.h) return;
+          const localY = y - full.y;
+          if (localY < 0 || localY >= full.h) return;
+
+          let char = TRACK_CHAR;
+          let style = trackStyle;
+          if (arrowRows && localY === 0) {
+            char = UP_ARROW_CHAR;
+          } else if (arrowRows && localY === full.h - 1) {
+            char = DOWN_ARROW_CHAR;
+          } else if (thumb && localY >= thumb.top && localY < thumb.top + thumb.size) {
+            if (props.metrics?.visualIndexStatus === "measuring") {
+              char = MEASURING_THUMB_CHAR;
+              style = measuringThumbStyle;
+            } else if (props.metrics?.visualIndexStatus === "estimated") {
+              char = ESTIMATED_THUMB_CHAR;
+              style = estimatedThumbStyle;
+            } else {
+              char = EXACT_THUMB_CHAR;
+              style = thumbStyle;
+            }
+          }
+
+          terminal.put(r.x, y, char, style);
+        };
+
+        if (!dirtyRows) {
+          for (let y = r.y; y < r.y + r.h; y++) paintRow(y);
+          return;
+        }
+        for (const y of dirtyRows) paintRow(y);
+      },
+    }));
+
+    return () => h("span", rootProps);
+  },
+});

--- a/test/package-exports.test.ts
+++ b/test/package-exports.test.ts
@@ -17,11 +17,13 @@ describe("package exports", () => {
 
     expect("TVirtualList" in root).toBe(false);
     expect("TLogView" in root).toBe(false);
+    expect("TLogScrollbar" in root).toBe(false);
     expect("createAppendOnlyLogStore" in root).toBe(false);
     expect(root.createFramePerfStore).toBeTruthy();
     expect(root.framePerfNow).toBeTruthy();
     expect(experimental.TVirtualList).toBeTruthy();
     expect(experimental.TLogView).toBeTruthy();
+    expect(experimental.TLogScrollbar).toBeTruthy();
     expect(experimental.createAppendOnlyLogStore).toBeTruthy();
   });
 
@@ -46,9 +48,11 @@ describe("package exports", () => {
     expect(rootCjs.framePerfNow).toBeTruthy();
     expect(experimental.TVirtualList).toBeTruthy();
     expect(experimental.TLogView).toBeTruthy();
+    expect(experimental.TLogScrollbar).toBeTruthy();
     expect(experimental.createAppendOnlyLogStore).toBeTruthy();
     expect(experimentalCjs.TVirtualList).toBeTruthy();
     expect(experimentalCjs.TLogView).toBeTruthy();
+    expect(experimentalCjs.TLogScrollbar).toBeTruthy();
     expect(experimentalCjs.createAppendOnlyLogStore).toBeTruthy();
   });
 });

--- a/test/tlog-scrollbar.test.ts
+++ b/test/tlog-scrollbar.test.ts
@@ -1,0 +1,337 @@
+import type {
+  TLogDataSource,
+  TLogScrollbarMetrics,
+  TLogViewHandle,
+  TLogViewScrollMetrics,
+} from "../src/experimental.js";
+import { describe, expect, it, vi } from "vitest";
+import { createTerminalApp } from "../src/index.js";
+import { TLogScrollbar, TLogView } from "../src/experimental.js";
+import {
+  defineComponent,
+  h,
+  mountTerminal,
+  nextTick,
+  onMounted,
+  ref,
+} from "./ui-regressions-support.js";
+
+function cell(
+  mounted: { terminal: ReturnType<typeof createTerminalApp>["terminal"] },
+  x: number,
+  y: number,
+) {
+  return mounted.terminal.getRow(y)[x]!;
+}
+
+function columnChars(
+  mounted: { terminal: ReturnType<typeof createTerminalApp>["terminal"] },
+  x: number,
+  height: number,
+): string {
+  return Array.from({ length: height }, (_, y) => cell(mounted, x, y).ch).join("");
+}
+
+function rowText(
+  mounted: { terminal: ReturnType<typeof createTerminalApp>["terminal"] },
+  y: number,
+  width?: number,
+): string {
+  const row = mounted.terminal.getRow(y);
+  return row
+    .slice(0, width ?? row.length)
+    .map((entry) => entry.ch)
+    .join("")
+    .trimEnd();
+}
+
+function createMetrics(overrides: Partial<TLogScrollbarMetrics> = {}): TLogViewScrollMetrics {
+  const scrollTop = overrides.scrollTop ?? 0;
+  const maxScrollTop = overrides.maxScrollTop ?? 10;
+  return {
+    scrollTop,
+    maxScrollTop,
+    viewportRows: overrides.viewportRows ?? 10,
+    lineCount: overrides.lineCount ?? 20,
+    firstLineIndex: overrides.firstLineIndex ?? 0,
+    estimatedVisualRowCount: overrides.estimatedVisualRowCount ?? 20,
+    visualRowCount: overrides.visualRowCount ?? 20,
+    measuredVisualRowCount: overrides.measuredVisualRowCount ?? 20,
+    measuredLineCount: overrides.measuredLineCount ?? 20,
+    visualIndexStatus: overrides.visualIndexStatus ?? "exact",
+    atTop: overrides.atTop ?? scrollTop <= 0,
+    atBottom: overrides.atBottom ?? scrollTop >= maxScrollTop,
+  };
+}
+
+describe("TLogScrollbar", () => {
+  it("renders an exact thumb proportional to wrapped visual rows", async () => {
+    const mounted = await mountTerminal(
+      () =>
+        h(TLogScrollbar, {
+          x: 0,
+          y: 0,
+          h: 10,
+          metrics: createMetrics({
+            viewportRows: 10,
+            visualRowCount: 20,
+            estimatedVisualRowCount: 20,
+            measuredVisualRowCount: 20,
+            maxScrollTop: 10,
+          }),
+        }),
+      1,
+      10,
+    );
+
+    try {
+      expect(columnChars(mounted, 0, 10)).toBe("█████│││││");
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("moves the thumb as scrollTop approaches the bottom", async () => {
+    const mounted = await mountTerminal(
+      () =>
+        h(TLogScrollbar, {
+          x: 0,
+          y: 0,
+          h: 10,
+          metrics: createMetrics({
+            scrollTop: 10,
+            maxScrollTop: 10,
+            viewportRows: 10,
+            visualRowCount: 20,
+            estimatedVisualRowCount: 20,
+            measuredVisualRowCount: 20,
+          }),
+        }),
+      1,
+      10,
+    );
+
+    try {
+      expect(columnChars(mounted, 0, 10)).toBe("│││││█████");
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("renders measuring and estimated thumb states distinctly", async () => {
+    const status = ref<TLogScrollbarMetrics["visualIndexStatus"]>("measuring");
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TLogScrollbar, {
+          x: 0,
+          y: 0,
+          h: 4,
+          metrics: createMetrics({
+            scrollTop: 0,
+            maxScrollTop: 0,
+            viewportRows: 4,
+            visualRowCount: 4,
+            estimatedVisualRowCount: 4,
+            measuredVisualRowCount: 4,
+            visualIndexStatus: status.value,
+          }),
+          measuringStyle: { fg: "yellow", underline: true },
+        }),
+      1,
+      4,
+    );
+
+    try {
+      expect(columnChars(mounted, 0, 4)).toBe("▒▒▒▒");
+      expect(cell(mounted, 0, 0).style).toMatchObject({ fg: "yellow", underline: true });
+
+      status.value = "estimated";
+      await nextTick();
+
+      expect(columnChars(mounted, 0, 4)).toBe("░░░░");
+      expect(cell(mounted, 0, 0).style).toMatchObject({ inverse: true, dim: true });
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("emits scrollTo when clicking the track", async () => {
+    const onScrollTo = vi.fn();
+    const App = defineComponent({
+      name: "TLogScrollbarClickApp",
+      setup() {
+        return () =>
+          h(TLogScrollbar, {
+            x: 0,
+            y: 0,
+            h: 10,
+            metrics: createMetrics({
+              scrollTop: 0,
+              maxScrollTop: 100,
+              viewportRows: 10,
+              lineCount: 110,
+              visualRowCount: 110,
+              estimatedVisualRowCount: 110,
+              measuredVisualRowCount: 110,
+            }),
+            onScrollTo,
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 1, rows: 10, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({
+        type: "click",
+        cellX: 0,
+        cellY: 5,
+      } as any);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(onScrollTo).toHaveBeenCalledWith(56);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("emits scrollBy when receiving wheel input", async () => {
+    const onScrollBy = vi.fn();
+    const App = defineComponent({
+      name: "TLogScrollbarWheelApp",
+      setup() {
+        return () =>
+          h(TLogScrollbar, {
+            x: 0,
+            y: 0,
+            h: 4,
+            metrics: createMetrics(),
+            onScrollBy,
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 1, rows: 4, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({
+        type: "wheel",
+        cellX: 0,
+        cellY: 1,
+        deltaY: 1,
+      } as any);
+      app.events.dispatch({
+        type: "wheel",
+        cellX: 0,
+        cellY: 1,
+        deltaY: -1,
+      } as any);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(onScrollBy).toHaveBeenNthCalledWith(1, 1);
+      expect(onScrollBy).toHaveBeenNthCalledWith(2, -1);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("renders track safely when metrics are null", async () => {
+    const mounted = await mountTerminal(
+      () =>
+        h(TLogScrollbar, {
+          x: 0,
+          y: 0,
+          h: 4,
+          metrics: null,
+        }),
+      1,
+      4,
+    );
+
+    try {
+      expect(columnChars(mounted, 0, 4)).toBe("││││");
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("integrates with TLogView through external metrics and scroll callbacks", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const metrics = ref<TLogViewScrollMetrics | null>(null);
+    const source: TLogDataSource = {
+      lineCount: () => 20,
+      getLine: (index) => `line-${index}`,
+      getLineKey: (index) => index,
+    };
+
+    const App = defineComponent({
+      name: "TLogScrollbarIntegrationApp",
+      setup() {
+        const refreshMetrics = () => {
+          metrics.value = logView.value?.getScrollMetrics() ?? null;
+        };
+
+        onMounted(refreshMetrics);
+
+        return () => [
+          h(TLogView, {
+            ref: logView,
+            x: 0,
+            y: 0,
+            w: 19,
+            h: 4,
+            source,
+            version: 1,
+            defaultScrollTop: 0,
+            onScroll: refreshMetrics,
+            onVisualIndex: refreshMetrics,
+          }),
+          h(TLogScrollbar, {
+            x: 19,
+            y: 0,
+            h: 4,
+            metrics: metrics.value,
+            onScrollTo: (top: number) => {
+              logView.value?.scrollToVisualRow(top);
+              refreshMetrics();
+            },
+            onScrollBy: (delta: number) => {
+              logView.value?.scrollBy(delta);
+              refreshMetrics();
+            },
+          }),
+        ];
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 6, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(rowText(app, 0, 19)).toBe("line-0");
+
+      app.events.dispatch({
+        type: "click",
+        cellX: 19,
+        cellY: 3,
+      } as any);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(rowText(app, 0, 19)).toBe("line-16");
+    } finally {
+      app.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Add `TLogScrollbar` — a terminal-rendered, 1-cell wide scrollbar component designed as a companion to `TLogView`.

### Features
- Renders a proportional thumb based on `TLogViewScrollMetrics` (from `TLogView.getScrollMetrics()`)
- Three distinct thumb states reflecting `visualIndexStatus`: exact (`█`), measuring (`▒`), estimated (`░`)
- Emits `scrollTo` on track click, `scrollBy` on wheel — parent wires these to `TLogViewHandle`
- Optional `showArrows` prop renders `▲`/`▼` for page-up/down
- Customizable `trackStyle`, `thumbStyle`, `measuringStyle`

### Changes
- **New**: `src/vue/components/TLogScrollbar.ts` — component implementation
- **New**: `test/tlog-scrollbar.test.ts` — unit tests (thumb rendering, click/wheel events, TLogView integration)
- **Updated**: `src/experimental.ts` — exports `TLogScrollbar` and related types
- **Updated**: `test/package-exports.test.ts` — verifies new exports in both ESM and CJS
- **Updated**: `docs/components.md` — component guide with usage example
- **Updated**: `docs/generated/components-api.md` — generated API docs

### Usage

\`\`\`vue
<TLogScrollbar
  :x="79"
  :y="0"
  :h="20"
  :metrics="metrics"
  @scrollTo="scrollTo"
  @scrollBy="scrollBy"
/>
\`\`\`