### PR TITLE
feat(TLogScrollbar): add search marker rendering and click handling

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -437,6 +437,8 @@ type TLogDataSource = {
 
 `searchQuery` 只搜索 visible text。`ansi=true` 时，ANSI escape sequences 不参与搜索，也不会污染 match offset；match highlight 会叠加在 ANSI style 上。match 坐标使用 terminal cell offset，因此宽字符会按 cell width 定位。`wrap=true` 时，`findNext()` / `findPrevious()` 会滚动到 match 所在 visual row。搜索范围始终是当前 retained source window；retention trim、append、tail mutation、source 或 version 变化后会基于当前窗口重新扫描。
 
+`getSearchMarkers()` 会把当前 search matches 投影成 scrollbar-friendly marker 数据：`visualRow` 仍然是 retained window 内的 visual-row index，`absoluteLineIndex` 保留原始 logical line 编号，`estimated` 用来区分 lazy visual index 和 exact visual index，`current` 表示当前 match。这个方法只基于当前 search/visual index 状态计算 markers，不会为了 marker 数据强制做一次全量 exact measurement。
+
 `searchOptions.wholeWord` 使用 ASCII word boundary：`[A-Za-z0-9_]`。例如 `error-1` 中的 `error` 会被视为 whole-word match，而 `_error` 不会。
 
 `clearSearch()` 会 emit `update:searchQuery`，并等待父组件把 `searchQuery` 回写为空后清除 matches；如果父组件不回写，当前 search state 和 highlight 不会提前改变。
@@ -508,10 +510,12 @@ function measureRows() {
 
 ### TLogScrollbar
 
-`TLogScrollbar` 是一个 terminal-rendered 的 experimental companion 组件，消费 `TLogViewScrollMetrics` 渲染 1-cell 宽滚动条。它不持有滚动状态，也不会直接调用 `TLogView` 内部逻辑；父组件负责把 `scrollTo` / `scrollBy` 接到 `TLogViewHandle` 上。
+`TLogScrollbar` 是一个 terminal-rendered 的 experimental companion 组件，消费 `TLogViewScrollMetrics` 渲染 1-cell 宽滚动条。它不持有滚动状态，也不会直接调用 `TLogView` 内部逻辑；父组件负责把 `scrollTo` / `scrollBy` / `markerClick` 接到 `TLogViewHandle` 或应用层状态上。
 
 - `metrics` 可以直接来自 `logView.value?.getScrollMetrics()`，也可以由 `@scroll` / `@visualIndex` 事件在外部维护
 - `visualIndexStatus="estimated" | "measuring" | "exact"` 会分别用不同 thumb 状态渲染，方便区分估算值、后台测量中和精确 visual-row index
+- `markers` 可以直接来自 `logView.value?.getSearchMarkers()`；scrollbar 只根据 marker 的 `visualRow` / `current` / `estimated` 渲染，不依赖 `TLogView` 私有状态
+- `markerClick` 只把命中的 marker 回传给父组件；是否调用 `findNext()`、`scrollToVisualRow()` 或其它跳转逻辑由父组件决定
 - 点击 track 会 emit 目标 visual-row `scrollTo`
 - wheel 会 emit 简单的 `scrollBy(+/-1)` delegation
 - `showArrows=true` 时首尾两行会渲染 `▲` / `▼`，点击后按一个 viewport 高度翻动
@@ -522,15 +526,27 @@ import { onMounted, ref } from "vue";
 import {
   TLogScrollbar,
   TLogView,
+  type TLogScrollbarMarker,
   type TLogViewHandle,
+  type TLogViewSearchMarker,
   type TLogViewScrollMetrics,
 } from "@simon_he/vue-tui/experimental";
 
 const logView = ref<TLogViewHandle | null>(null);
 const metrics = ref<TLogViewScrollMetrics | null>(null);
+const markers = ref<readonly TLogScrollbarMarker[]>([]);
+const query = ref("ERROR");
 
 function refreshMetrics() {
   metrics.value = logView.value?.getScrollMetrics() ?? null;
+  markers.value =
+    logView.value?.getSearchMarkers().map((marker) => ({
+      id: marker.matchIndex,
+      visualRow: marker.visualRow,
+      current: marker.current,
+      estimated: marker.estimated,
+      payload: marker,
+    })) ?? [];
 }
 
 function scrollTo(top: number) {
@@ -540,6 +556,15 @@ function scrollTo(top: number) {
 
 function scrollBy(delta: number) {
   logView.value?.scrollBy(delta);
+  refreshMetrics();
+}
+
+function onMarkerClick(payload: {
+  marker: TLogScrollbarMarker & { payload?: TLogViewSearchMarker };
+}) {
+  const marker = payload.marker.payload;
+  if (!marker) return;
+  logView.value?.scrollToVisualRow(marker.visualRow);
   refreshMetrics();
 }
 
@@ -556,8 +581,10 @@ onMounted(refreshMetrics);
   :version="log.version"
   wrap
   visual-index-mode="exact"
+  :search-query="query"
   @scroll="refreshMetrics"
   @visualIndex="refreshMetrics"
+  @searchMarkers="refreshMetrics"
 />
 
 <TLogScrollbar
@@ -565,8 +592,10 @@ onMounted(refreshMetrics);
   :y="0"
   :h="20"
   :metrics="metrics"
+  :markers="markers"
   @scrollTo="scrollTo"
   @scrollBy="scrollBy"
+  @markerClick="onMarkerClick"
 />
 ```
 
@@ -577,6 +606,7 @@ onMounted(refreshMetrics);
 - `update:searchQuery`: `searchQuery`
 - `search`: `{ query, status, matchCount }`
 - `searchMatch`: `{ match, currentMatchIndex, matchCount }`
+- `searchMarkers`: `{ markers, visualIndexStatus, matchCount, currentMatchIndex }`
 - `linkClick`: `{ href, text, absoluteLineIndex, index, startCell, endCell, cellX, cellY }`
 - `focus` / `blur` / `keydown`
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -515,7 +515,7 @@ function measureRows() {
 - `metrics` 可以直接来自 `logView.value?.getScrollMetrics()`，也可以由 `@scroll` / `@visualIndex` 事件在外部维护
 - `visualIndexStatus="estimated" | "measuring" | "exact"` 会分别用不同 thumb 状态渲染，方便区分估算值、后台测量中和精确 visual-row index
 - `markers` 可以直接来自 `logView.value?.getSearchMarkers()`；scrollbar 只根据 marker 的 `visualRow` / `current` / `estimated` 渲染，不依赖 `TLogView` 私有状态
-- `markerClick` 只把命中的 marker 回传给父组件；是否调用 `findNext()`、`scrollToVisualRow()` 或其它跳转逻辑由父组件决定
+- `markerClick` 只把当前可见的 marker row 回传给父组件；如果 marker 与 thumb 落在同一 row，thumb 仍然保持视觉和交互优先级
 - 点击 track 会 emit 目标 visual-row `scrollTo`
 - wheel 会 emit 简单的 `scrollBy(+/-1)` delegation
 - `showArrows=true` 时首尾两行会渲染 `▲` / `▼`，点击后按一个 viewport 高度翻动

--- a/docs/generated/components-api.md
+++ b/docs/generated/components-api.md
@@ -389,25 +389,30 @@
 
 ### Props
 
-| 名称                        | 类型                                          | 默认值                 | 必填 | 说明 |
-| --------------------------- | --------------------------------------------- | ---------------------- | ---- | ---- |
-| <code>x</code>              | <code>number</code>                           | —                      | 是   | —    |
-| <code>y</code>              | <code>number</code>                           | —                      | 是   | —    |
-| <code>h</code>              | <code>number</code>                           | —                      | 是   | —    |
-| <code>zIndex</code>         | <code>number</code>                           | <code>0</code>         | 否   | —    |
-| <code>metrics</code>        | <code>TLogScrollbarMetrics &#124; null</code> | <code>null</code>      | 否   | —    |
-| <code>style</code>          | <code>Style</code>                            | <code>undefined</code> | 否   | —    |
-| <code>thumbStyle</code>     | <code>Style</code>                            | <code>undefined</code> | 否   | —    |
-| <code>trackStyle</code>     | <code>Style</code>                            | <code>undefined</code> | 否   | —    |
-| <code>measuringStyle</code> | <code>Style</code>                            | <code>undefined</code> | 否   | —    |
-| <code>showArrows</code>     | <code>boolean</code>                          | <code>false</code>     | 否   | —    |
+| 名称                            | 类型                                          | 默认值                                                            | 必填 | 说明 |
+| ------------------------------- | --------------------------------------------- | ----------------------------------------------------------------- | ---- | ---- |
+| <code>x</code>                  | <code>number</code>                           | —                                                                 | 是   | —    |
+| <code>y</code>                  | <code>number</code>                           | —                                                                 | 是   | —    |
+| <code>h</code>                  | <code>number</code>                           | —                                                                 | 是   | —    |
+| <code>zIndex</code>             | <code>number</code>                           | <code>0</code>                                                    | 否   | —    |
+| <code>metrics</code>            | <code>TLogScrollbarMetrics &#124; null</code> | <code>null</code>                                                 | 否   | —    |
+| <code>style</code>              | <code>Style</code>                            | <code>undefined</code>                                            | 否   | —    |
+| <code>thumbStyle</code>         | <code>Style</code>                            | <code>undefined</code>                                            | 否   | —    |
+| <code>trackStyle</code>         | <code>Style</code>                            | <code>undefined</code>                                            | 否   | —    |
+| <code>measuringStyle</code>     | <code>Style</code>                            | <code>undefined</code>                                            | 否   | —    |
+| <code>markers</code>            | <code>readonly TLogScrollbarMarker[]</code>   | <code>() =&gt; []</code>                                          | 否   | —    |
+| <code>markerStyle</code>        | <code>Style</code>                            | <code>() =&gt; ({ fg: &quot;yellowBright&quot; })</code>          | 否   | —    |
+| <code>currentMarkerStyle</code> | <code>Style</code>                            | <code>() =&gt; ({ fg: &quot;redBright&quot;, bold: true })</code> | 否   | —    |
+| <code>showMarkers</code>        | <code>boolean</code>                          | <code>true</code>                                                 | 否   | —    |
+| <code>showArrows</code>         | <code>boolean</code>                          | <code>false</code>                                                | 否   | —    |
 
 ### Events
 
-| 名称                  | Payload | 说明 |
-| --------------------- | ------- | ---- |
-| <code>scrollTo</code> | —       | —    |
-| <code>scrollBy</code> | —       | —    |
+| 名称                     | Payload | 说明 |
+| ------------------------ | ------- | ---- |
+| <code>scrollTo</code>    | —       | —    |
+| <code>scrollBy</code>    | —       | —    |
+| <code>markerClick</code> | —       | —    |
 
 ## TLogView
 
@@ -454,6 +459,7 @@
 | <code>update:searchQuery</code> | —       | —    |
 | <code>search</code>             | —       | —    |
 | <code>searchMatch</code>        | —       | —    |
+| <code>searchMarkers</code>      | —       | —    |
 | <code>linkClick</code>          | —       | —    |
 | <code>visualIndex</code>        | —       | —    |
 | <code>focus</code>              | —       | —    |

--- a/src/experimental.ts
+++ b/src/experimental.ts
@@ -5,6 +5,8 @@ export { createAppendOnlyLogStore } from "./vue/log/append-only-log-store.js";
 export type { RowScrollMode } from "./vue/components/TVirtualList.js";
 export type {
   TLogScrollbarMetrics,
+  TLogScrollbarMarker,
+  TLogScrollbarMarkerClickPayload,
   TLogScrollbarScrollByPayload,
   TLogScrollbarScrollToPayload,
 } from "./vue/components/TLogScrollbar.js";
@@ -13,6 +15,8 @@ export type {
   TLogViewLinkClickPayload,
   TLogViewScrollMetrics,
   TLogViewSearchMatch,
+  TLogViewSearchMarker,
+  TLogViewSearchMarkersPayload,
   TLogViewSearchMatchPayload,
   TLogViewSearchOptions,
   TLogViewSearchPayload,

--- a/src/vue/components/TLogScrollbar.ts
+++ b/src/vue/components/TLogScrollbar.ts
@@ -234,10 +234,13 @@ export const TLogScrollbar = defineComponent({
       }
       if (trackHeight <= 0) return;
 
-      const markerHit = props.showMarkers
-        ? collectMarkersByRow(props.markers, metrics, full.h, props.showArrows).get(localY)
-        : undefined;
-      if (markerHit) {
+      const thumb = computeThumb(metrics, full.h, props.showArrows);
+      const isThumbRow = thumb != null && localY >= thumb.top && localY < thumb.top + thumb.size;
+      const markerHit =
+        !isThumbRow && props.showMarkers
+          ? collectMarkersByRow(props.markers, metrics, full.h, props.showArrows).get(localY)
+          : undefined;
+      if (markerHit != null) {
         emit("markerClick", {
           marker: markerHit.marker,
           markerIndex: markerHit.index,

--- a/src/vue/components/TLogScrollbar.ts
+++ b/src/vue/components/TLogScrollbar.ts
@@ -17,6 +17,9 @@ const TRACK_CHAR = "│";
 const EXACT_THUMB_CHAR = "█";
 const MEASURING_THUMB_CHAR = "▒";
 const ESTIMATED_THUMB_CHAR = "░";
+const MARKER_CHAR = "•";
+const ESTIMATED_MARKER_CHAR = "·";
+const CURRENT_MARKER_CHAR = "◆";
 const UP_ARROW_CHAR = "▲";
 const DOWN_ARROW_CHAR = "▼";
 
@@ -28,6 +31,20 @@ type TLogScrollbarThumb = Readonly<{
 export type TLogScrollbarMetrics = TLogViewScrollMetrics;
 export type TLogScrollbarScrollToPayload = number;
 export type TLogScrollbarScrollByPayload = number;
+export type TLogScrollbarMarker = Readonly<{
+  id?: string | number;
+  visualRow: number;
+  current?: boolean;
+  estimated?: boolean;
+  payload?: unknown;
+}>;
+export type TLogScrollbarMarkerClickPayload = Readonly<{
+  marker: TLogScrollbarMarker;
+  markerIndex: number;
+  visualRow: number;
+  cellX: number;
+  cellY: number;
+}>;
 
 function clamp(n: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, n));
@@ -81,6 +98,59 @@ function computeThumb(
   };
 }
 
+function markerRow(
+  marker: TLogScrollbarMarker,
+  metrics: TLogScrollbarMetrics,
+  height: number,
+  showArrows: boolean,
+): number | null {
+  const { trackTop, trackHeight } = trackGeometry(height, showArrows);
+  if (trackHeight <= 0) return null;
+
+  const total = Math.max(
+    normalizeInt(metrics.visualRowCount),
+    normalizeInt(metrics.viewportRows),
+    1,
+  );
+  const maxVisual = Math.max(1, total - 1);
+  const visualRow = clamp(normalizeInt(marker.visualRow), 0, maxVisual);
+  return trackTop + Math.round((visualRow / maxVisual) * (trackHeight - 1));
+}
+
+type TLogScrollbarMarkerHit = Readonly<{
+  marker: TLogScrollbarMarker;
+  index: number;
+}>;
+
+function markerPriority(marker: TLogScrollbarMarker): number {
+  if (marker.current) return 2;
+  if (!marker.estimated) return 1;
+  return 0;
+}
+
+function collectMarkersByRow(
+  markers: readonly TLogScrollbarMarker[],
+  metrics: TLogScrollbarMetrics | null | undefined,
+  height: number,
+  showArrows: boolean,
+): ReadonlyMap<number, TLogScrollbarMarkerHit> {
+  if (!metrics || !markers.length) return new Map();
+
+  const rows = new Map<number, TLogScrollbarMarkerHit>();
+  for (let i = 0; i < markers.length; i++) {
+    const marker = markers[i]!;
+    const row = markerRow(marker, metrics, height, showArrows);
+    if (row == null) continue;
+
+    const previous = rows.get(row);
+    if (!previous || markerPriority(marker) >= markerPriority(previous.marker)) {
+      rows.set(row, { marker, index: i });
+    }
+  }
+
+  return rows;
+}
+
 function mergeStyle(base: Style, overlay?: Style): Style {
   return overlay ? { ...base, ...overlay } : base;
 }
@@ -100,9 +170,22 @@ export const TLogScrollbar = defineComponent({
     thumbStyle: { type: Object as PropType<Style>, default: undefined },
     trackStyle: { type: Object as PropType<Style>, default: undefined },
     measuringStyle: { type: Object as PropType<Style>, default: undefined },
+    markers: {
+      type: Array as PropType<readonly TLogScrollbarMarker[]>,
+      default: () => [],
+    },
+    markerStyle: {
+      type: Object as PropType<Style>,
+      default: () => ({ fg: "yellowBright" }),
+    },
+    currentMarkerStyle: {
+      type: Object as PropType<Style>,
+      default: () => ({ fg: "redBright", bold: true }),
+    },
+    showMarkers: { type: Boolean, default: true },
     showArrows: { type: Boolean, default: false },
   },
-  emits: ["scrollTo", "scrollBy"],
+  emits: ["scrollTo", "scrollBy", "markerClick"],
   setup(props, { emit }) {
     const { terminal, defaultStyle } = useTerminal();
     const parent = useLayout();
@@ -151,6 +234,21 @@ export const TLogScrollbar = defineComponent({
       }
       if (trackHeight <= 0) return;
 
+      const markerHit = props.showMarkers
+        ? collectMarkersByRow(props.markers, metrics, full.h, props.showArrows).get(localY)
+        : undefined;
+      if (markerHit) {
+        emit("markerClick", {
+          marker: markerHit.marker,
+          markerIndex: markerHit.index,
+          visualRow: markerHit.marker.visualRow,
+          cellX: e.cellX,
+          cellY: e.cellY,
+        } satisfies TLogScrollbarMarkerClickPayload);
+        e.preventDefault?.();
+        return;
+      }
+
       const pos = clamp(localY - trackTop, 0, trackHeight - 1);
       const ratio = trackHeight <= 1 ? 0 : pos / (trackHeight - 1);
       const target = Math.round(ratio * Math.max(0, normalizeInt(metrics.maxScrollTop)));
@@ -186,6 +284,10 @@ export const TLogScrollbar = defineComponent({
         props.trackStyle,
         props.thumbStyle,
         props.measuringStyle,
+        props.markers,
+        props.markerStyle,
+        props.currentMarkerStyle,
+        props.showMarkers,
         props.showArrows,
         defaultStyle.value,
       ],
@@ -198,11 +300,16 @@ export const TLogScrollbar = defineComponent({
         const trackStyle = mergeStyle(baseStyle, props.trackStyle ?? { dim: true });
         const thumbStyle = mergeStyle(baseStyle, props.thumbStyle ?? { inverse: true });
         const estimatedThumbStyle = mergeStyle(thumbStyle, { dim: true });
+        const markerStyle = mergeStyle(baseStyle, props.markerStyle);
+        const currentMarkerStyle = mergeStyle(baseStyle, props.currentMarkerStyle);
         const measuringThumbStyle = mergeStyle(
           baseStyle,
           props.measuringStyle ?? { ...thumbStyle, dim: true },
         );
         const thumb = computeThumb(props.metrics, full.h, props.showArrows);
+        const markersByRow = props.showMarkers
+          ? collectMarkersByRow(props.markers, props.metrics, full.h, props.showArrows)
+          : new Map<number, TLogScrollbarMarkerHit>();
         const { arrowRows } = trackGeometry(full.h, props.showArrows);
 
         const paintRow = (y: number): void => {
@@ -216,7 +323,18 @@ export const TLogScrollbar = defineComponent({
             char = UP_ARROW_CHAR;
           } else if (arrowRows && localY === full.h - 1) {
             char = DOWN_ARROW_CHAR;
-          } else if (thumb && localY >= thumb.top && localY < thumb.top + thumb.size) {
+          } else {
+            const markerHit = markersByRow.get(localY);
+            if (markerHit) {
+              char = markerHit.marker.current
+                ? CURRENT_MARKER_CHAR
+                : markerHit.marker.estimated
+                  ? ESTIMATED_MARKER_CHAR
+                  : MARKER_CHAR;
+              style = markerHit.marker.current ? currentMarkerStyle : markerStyle;
+            }
+          }
+          if (thumb && localY >= thumb.top && localY < thumb.top + thumb.size) {
             if (props.metrics?.visualIndexStatus === "measuring") {
               char = MEASURING_THUMB_CHAR;
               style = measuringThumbStyle;

--- a/src/vue/components/TLogView.ts
+++ b/src/vue/components/TLogView.ts
@@ -1164,6 +1164,11 @@ export const TLogView = defineComponent({
       return visualIndexStatus === "exact" || index < measuredLineCount;
     }
 
+    function isMeasuredVisualMarkerLine(index: number): boolean {
+      if (!props.wrap) return true;
+      return visualKeys[index] === lineKey(index);
+    }
+
     function getSearchMarkers(): readonly TLogViewSearchMarker[] {
       if (searchMarkersCacheGeneration === searchMarkersGeneration) return searchMarkersCache;
       if (!searchMatches.length) {
@@ -1188,29 +1193,32 @@ export const TLogView = defineComponent({
         let exact = true;
 
         if (props.wrap) {
-          measureVisualLine(match.index);
           let lineStart = lineStartCache.get(match.index);
           if (lineStart == null) {
             lineStart = visualStartForLine(match.index);
             lineStartCache.set(match.index, lineStart);
           }
 
-          exact = exactCache.get(match.index) ?? isExactVisualMarkerLine(match.index);
+          const lineMeasured = isMeasuredVisualMarkerLine(match.index);
+          exact =
+            exactCache.get(match.index) ?? (lineMeasured && isExactVisualMarkerLine(match.index));
           exactCache.set(match.index, exact);
-          if (props.ansi) {
+          if (lineMeasured && props.ansi) {
             let rows = ansiRowsCache.get(match.index);
             if (!rows) {
               rows = ansiWrappedRowsForLine(match.index, count, width, base, baseStyleKey);
               ansiRowsCache.set(match.index, rows);
             }
             visualRow = lineStart + partIndexForCellInAnsiWrappedRow(rows, match.startCell);
-          } else {
+          } else if (lineMeasured) {
             let rows = plainRowsCache.get(match.index);
             if (!rows) {
               rows = wrappedRowsForLine(match.index, count, width);
               plainRowsCache.set(match.index, rows);
             }
             visualRow = lineStart + partIndexForCellInPlainWrappedRow(rows, match.startCell);
+          } else {
+            visualRow = lineStart + Math.max(0, Math.floor(match.startCell / width));
           }
         }
 

--- a/src/vue/components/TLogView.ts
+++ b/src/vue/components/TLogView.ts
@@ -136,6 +136,20 @@ export type TLogViewSearchMatchPayload = Readonly<{
   currentMatchIndex: number;
   matchCount: number;
 }>;
+export type TLogViewSearchMarker = Readonly<{
+  matchIndex: number;
+  absoluteLineIndex: number;
+  index: number;
+  visualRow: number;
+  estimated: boolean;
+  current: boolean;
+}>;
+export type TLogViewSearchMarkersPayload = Readonly<{
+  markers: readonly TLogViewSearchMarker[];
+  visualIndexStatus: TLogViewVisualIndexStatus;
+  matchCount: number;
+  currentMatchIndex: number;
+}>;
 export type TLogViewLinkClickPayload = Readonly<{
   href: string;
   text: string;
@@ -184,6 +198,7 @@ export type TLogViewHandle = Readonly<{
   getSearchState: () => TLogViewSearchState;
   measureVisualIndex: () => void;
   getScrollMetrics: () => TLogViewScrollMetrics;
+  getSearchMarkers: () => readonly TLogViewSearchMarker[];
 }>;
 
 let nextTLogViewTaskId = 0;
@@ -613,6 +628,7 @@ export const TLogView = defineComponent({
     "update:searchQuery",
     "search",
     "searchMatch",
+    "searchMarkers",
     "linkClick",
     "visualIndex",
     "focus",
@@ -656,6 +672,10 @@ export const TLogView = defineComponent({
     let searchStatus: TLogSearchStatus = "idle";
     let currentMatchIndex = -1;
     let searchMatches: TLogViewSearchMatch[] = [];
+    let searchMarkersGeneration = 0;
+    let searchMarkersCacheGeneration = -1;
+    let searchMarkersCache: readonly TLogViewSearchMarker[] = [];
+    let lastSearchMarkersPayloadKey = "";
     const matchesByLine = new Map<number, number[]>();
     const wheelState = createWheelScrollState();
     // Unknown wrapped lines count as one row until measured, so large bottom mounts avoid full-source wrapping.
@@ -1135,10 +1155,107 @@ export const TLogView = defineComponent({
       emit("searchMatch", searchMatchPayload());
     }
 
+    function invalidateSearchMarkers(): void {
+      searchMarkersGeneration++;
+    }
+
+    function isExactVisualMarkerLine(index: number): boolean {
+      if (!props.wrap) return true;
+      return visualIndexStatus === "exact" || index < measuredLineCount;
+    }
+
+    function getSearchMarkers(): readonly TLogViewSearchMarker[] {
+      if (searchMarkersCacheGeneration === searchMarkersGeneration) return searchMarkersCache;
+      if (!searchMatches.length) {
+        searchMarkersCache = [];
+        searchMarkersCacheGeneration = searchMarkersGeneration;
+        return searchMarkersCache;
+      }
+
+      const count = lineCount();
+      const width = currentWrapWidth();
+      const base = props.style ?? defaultStyle.value;
+      const baseStyleKey = styleCacheKey(base);
+      const lineStartCache = new Map<number, number>();
+      const exactCache = new Map<number, boolean>();
+      const plainRowsCache = new Map<number, readonly string[]>();
+      const ansiRowsCache = new Map<number, ReturnType<typeof ansiWrappedRowsForLine>>();
+      const markers: TLogViewSearchMarker[] = [];
+
+      for (let matchIndex = 0; matchIndex < searchMatches.length; matchIndex++) {
+        const match = searchMatches[matchIndex]!;
+        let visualRow = match.index;
+        let exact = true;
+
+        if (props.wrap) {
+          measureVisualLine(match.index);
+          let lineStart = lineStartCache.get(match.index);
+          if (lineStart == null) {
+            lineStart = visualStartForLine(match.index);
+            lineStartCache.set(match.index, lineStart);
+          }
+
+          exact = exactCache.get(match.index) ?? isExactVisualMarkerLine(match.index);
+          exactCache.set(match.index, exact);
+          if (props.ansi) {
+            let rows = ansiRowsCache.get(match.index);
+            if (!rows) {
+              rows = ansiWrappedRowsForLine(match.index, count, width, base, baseStyleKey);
+              ansiRowsCache.set(match.index, rows);
+            }
+            visualRow = lineStart + partIndexForCellInAnsiWrappedRow(rows, match.startCell);
+          } else {
+            let rows = plainRowsCache.get(match.index);
+            if (!rows) {
+              rows = wrappedRowsForLine(match.index, count, width);
+              plainRowsCache.set(match.index, rows);
+            }
+            visualRow = lineStart + partIndexForCellInPlainWrappedRow(rows, match.startCell);
+          }
+        }
+
+        markers.push({
+          matchIndex,
+          absoluteLineIndex: match.absoluteLineIndex,
+          index: match.index,
+          visualRow,
+          estimated: !exact,
+          current: matchIndex === currentMatchIndex,
+        });
+      }
+
+      searchMarkersCache = markers;
+      searchMarkersCacheGeneration = searchMarkersGeneration;
+      return searchMarkersCache;
+    }
+
+    function searchMarkersPayload(): TLogViewSearchMarkersPayload {
+      return {
+        markers: getSearchMarkers(),
+        visualIndexStatus,
+        matchCount: searchMatches.length,
+        currentMatchIndex,
+      };
+    }
+
+    function emitSearchMarkers(force = false): void {
+      const payload = searchMarkersPayload();
+      const key = JSON.stringify([
+        searchMarkersGeneration,
+        visualIndexStatus,
+        payload.matchCount,
+        payload.currentMatchIndex,
+      ]);
+      if (!force && key === lastSearchMarkersPayloadKey) return;
+      lastSearchMarkersPayloadKey = key;
+      emit("searchMarkers", payload);
+    }
+
     function clearSearchMatches(): void {
       searchMatches = [];
       matchesByLine.clear();
       currentMatchIndex = -1;
+      invalidateSearchMarkers();
     }
 
     function addSearchMatch(match: TLogViewSearchMatch): void {
@@ -1150,6 +1267,7 @@ export const TLogView = defineComponent({
         matchesByLine.set(match.index, lineMatches);
       }
       lineMatches.push(matchIndex);
+      invalidateSearchMarkers();
     }
 
     function searchableTextForLine(
@@ -1255,6 +1373,7 @@ export const TLogView = defineComponent({
         clearSearchMatches();
         emitSearch("");
         emitSearchMatch();
+        emitSearchMarkers(true);
         return;
       }
 
@@ -1291,6 +1410,7 @@ export const TLogView = defineComponent({
 
       searchStatus = "done";
       emitSearch(query);
+      emitSearchMarkers(true);
       markViewportDirty();
       ctx.invalidate({ priority: "low", plane: plane.value, reason: "data" });
       trimSearchLineCache();
@@ -1309,6 +1429,7 @@ export const TLogView = defineComponent({
           clearSearchMatches();
           emitSearch("");
           emitSearchMatch();
+          emitSearchMarkers(true);
           markViewportDirty();
           invalidateSelf("normal", "data");
         }
@@ -1319,6 +1440,7 @@ export const TLogView = defineComponent({
       searchStatus = "scanning";
       emitSearch(query);
       emitSearchMatch();
+      emitSearchMarkers(true);
       markViewportDirty();
       invalidateSelf("normal", "data");
       scheduler.queueFrameTask({
@@ -1497,7 +1619,9 @@ export const TLogView = defineComponent({
       const key = JSON.stringify(payload);
       if (!force && key === lastVisualIndexPayloadKey) return;
       lastVisualIndexPayloadKey = key;
+      if (props.wrap) invalidateSearchMarkers();
       emit("visualIndex", payload);
+      if (!props.wrap || visualIndexStatus !== "measuring") emitSearchMarkers(true);
     }
 
     function fenwickAdd(index: number, delta: number): void {
@@ -2479,6 +2603,8 @@ export const TLogView = defineComponent({
       if (index < 0 || index >= searchMatches.length) return;
       currentMatchIndex = index;
       emitSearchMatch();
+      invalidateSearchMarkers();
+      emitSearchMarkers(true);
       scrollToMatch(searchMatches[index]!);
       markViewportDirty();
       invalidateSelf("high", "data");
@@ -2512,6 +2638,7 @@ export const TLogView = defineComponent({
       clearSearchMatches();
       emitSearch("");
       emitSearchMatch();
+      emitSearchMarkers(true);
       markViewportDirty();
       invalidateSelf("normal", "data");
     }
@@ -2541,6 +2668,7 @@ export const TLogView = defineComponent({
       getSearchState,
       measureVisualIndex,
       getScrollMetrics,
+      getSearchMarkers,
     };
     expose(handle);
 

--- a/test/tlog-scrollbar.test.ts
+++ b/test/tlog-scrollbar.test.ts
@@ -298,6 +298,53 @@ describe("TLogScrollbar", () => {
     }
   });
 
+  it("does not emit markerClick for marker rows covered by the thumb", async () => {
+    const onScrollTo = vi.fn();
+    const onMarkerClick = vi.fn();
+    const markers = [{ id: "top", visualRow: 0, current: true }] as const;
+    const App = defineComponent({
+      name: "TLogScrollbarThumbDominatesMarkerClickApp",
+      setup() {
+        return () =>
+          h(TLogScrollbar, {
+            x: 0,
+            y: 0,
+            h: 10,
+            metrics: createMetrics({
+              scrollTop: 0,
+              maxScrollTop: 90,
+              viewportRows: 10,
+              visualRowCount: 100,
+              estimatedVisualRowCount: 100,
+              measuredVisualRowCount: 100,
+            }),
+            markers,
+            onScrollTo,
+            onMarkerClick,
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 1, rows: 10, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({
+        type: "click",
+        cellX: 0,
+        cellY: 0,
+      } as any);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(onMarkerClick).not.toHaveBeenCalled();
+      expect(onScrollTo).toHaveBeenCalledWith(0);
+    } finally {
+      app.dispose();
+    }
+  });
+
   it("emits scrollBy when receiving wheel input", async () => {
     const onScrollBy = vi.fn();
     const App = defineComponent({

--- a/test/tlog-scrollbar.test.ts
+++ b/test/tlog-scrollbar.test.ts
@@ -1,5 +1,6 @@
 import type {
   TLogDataSource,
+  TLogScrollbarMarker,
   TLogScrollbarMetrics,
   TLogViewHandle,
   TLogViewScrollMetrics,
@@ -62,6 +63,18 @@ function createMetrics(overrides: Partial<TLogScrollbarMetrics> = {}): TLogViewS
     atTop: overrides.atTop ?? scrollTop <= 0,
     atBottom: overrides.atBottom ?? scrollTop >= maxScrollTop,
   };
+}
+
+async function flushSearch(
+  app: ReturnType<typeof createTerminalApp>,
+  handle: TLogViewHandle,
+  maxFrames = 20,
+): Promise<void> {
+  for (let i = 0; i < maxFrames; i++) {
+    await nextTick();
+    app.scheduler.flushNow();
+    if (handle.getSearchState().status !== "scanning") return;
+  }
 }
 
 describe("TLogScrollbar", () => {
@@ -199,6 +212,92 @@ describe("TLogScrollbar", () => {
     }
   });
 
+  it("renders markers on the track and keeps the thumb visible", async () => {
+    const mounted = await mountTerminal(
+      () =>
+        h(TLogScrollbar, {
+          x: 0,
+          y: 0,
+          h: 10,
+          metrics: createMetrics({
+            scrollTop: 0,
+            maxScrollTop: 90,
+            viewportRows: 10,
+            visualRowCount: 100,
+            estimatedVisualRowCount: 100,
+            measuredVisualRowCount: 100,
+          }),
+          markers: [
+            { visualRow: 50 },
+            { visualRow: 0, current: true },
+            { visualRow: 99, estimated: true },
+          ] satisfies readonly TLogScrollbarMarker[],
+        }),
+      1,
+      10,
+    );
+
+    try {
+      expect(columnChars(mounted, 0, 10)).toBe("█││││•│││·");
+      expect(cell(mounted, 0, 5).style).toMatchObject({ fg: "yellowBright" });
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("emits markerClick instead of scrollTo when clicking a marker row", async () => {
+    const onScrollTo = vi.fn();
+    const onMarkerClick = vi.fn();
+    const markers = [{ id: "m1", visualRow: 50, payload: { kind: "match" } }] as const;
+    const App = defineComponent({
+      name: "TLogScrollbarMarkerClickApp",
+      setup() {
+        return () =>
+          h(TLogScrollbar, {
+            x: 0,
+            y: 0,
+            h: 10,
+            metrics: createMetrics({
+              scrollTop: 0,
+              maxScrollTop: 90,
+              viewportRows: 10,
+              visualRowCount: 100,
+              estimatedVisualRowCount: 100,
+              measuredVisualRowCount: 100,
+            }),
+            markers,
+            onScrollTo,
+            onMarkerClick,
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 1, rows: 10, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({
+        type: "click",
+        cellX: 0,
+        cellY: 5,
+      } as any);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(onMarkerClick).toHaveBeenCalledWith({
+        marker: markers[0],
+        markerIndex: 0,
+        visualRow: 50,
+        cellX: 0,
+        cellY: 5,
+      });
+      expect(onScrollTo).not.toHaveBeenCalled();
+    } finally {
+      app.dispose();
+    }
+  });
+
   it("emits scrollBy when receiving wheel input", async () => {
     const onScrollBy = vi.fn();
     const App = defineComponent({
@@ -330,6 +429,102 @@ describe("TLogScrollbar", () => {
       app.scheduler.flushNow();
 
       expect(rowText(app, 0, 19)).toBe("line-16");
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("integrates TLogView search markers and lets the parent handle marker clicks", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const metrics = ref<TLogViewScrollMetrics | null>(null);
+    const markers = ref<readonly TLogScrollbarMarker[]>([]);
+    const source: TLogDataSource = {
+      lineCount: () => 8,
+      getLine: (index) =>
+        [
+          "ok line-0",
+          "ok line-1",
+          "error line-2",
+          "ok line-3",
+          "ok line-4",
+          "ok line-5",
+          "error line-6",
+          "ok line-7",
+        ][index] ?? "",
+      getLineKey: (index) => index,
+    };
+
+    const App = defineComponent({
+      name: "TLogScrollbarSearchMarkersIntegrationApp",
+      setup() {
+        const refresh = () => {
+          metrics.value = logView.value?.getScrollMetrics() ?? null;
+          markers.value =
+            logView.value?.getSearchMarkers().map((marker) => ({
+              id: marker.matchIndex,
+              visualRow: marker.visualRow,
+              current: marker.current,
+              estimated: marker.estimated,
+              payload: marker,
+            })) ?? [];
+        };
+
+        onMounted(refresh);
+
+        return () => [
+          h(TLogView, {
+            ref: logView,
+            x: 0,
+            y: 0,
+            w: 19,
+            h: 4,
+            source,
+            version: 1,
+            defaultScrollTop: 0,
+            searchQuery: "error",
+            searchOptions: { scanBudgetMs: 1000 },
+            onScroll: refresh,
+            onVisualIndex: refresh,
+            onSearchMarkers: refresh,
+          }),
+          h(TLogScrollbar, {
+            x: 19,
+            y: 0,
+            h: 4,
+            metrics: metrics.value,
+            markers: markers.value,
+            onMarkerClick: (payload: {
+              marker: TLogScrollbarMarker & { payload?: { visualRow: number } };
+            }) => {
+              const marker = payload.marker.payload;
+              if (!marker) return;
+              logView.value?.scrollToVisualRow(marker.visualRow);
+              refresh();
+            },
+          }),
+        ];
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 6, component: App });
+    try {
+      app.mount();
+      await flushSearch(app, logView.value!);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(rowText(app, 0, 19)).toBe("ok line-0");
+      expect(columnChars(app, 19, 4)).toContain("•");
+
+      app.events.dispatch({
+        type: "click",
+        cellX: 19,
+        cellY: 3,
+      } as any);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(rowText(app, 2, 19)).toBe("error line-6");
     } finally {
       app.dispose();
     }

--- a/test/tlog-view.test.ts
+++ b/test/tlog-view.test.ts
@@ -2072,6 +2072,58 @@ describe("TLogView", () => {
     }
   });
 
+  it("does not synchronously wrap all search matches when projecting estimated markers", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const getLine = vi.fn((index: number) => `ERROR ${index} ${"x".repeat(200)}`);
+    const source: TLogDataSource = {
+      lineCount: () => 100_000,
+      getLine,
+      getLineKey: (index) => index,
+    };
+
+    const App = defineComponent({
+      name: "TLogViewEstimatedSearchMarkersApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            ref: logView,
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 4,
+            source,
+            version: 1,
+            wrap: true,
+            searchQuery: "ERROR",
+            searchOptions: {
+              scanBudgetMs: 1000,
+              maxMatches: 10_000,
+            },
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 6, component: App });
+    try {
+      app.mount();
+      await flushSearch(app, logView.value!);
+      getLine.mockClear();
+
+      const before = logView.value!.getScrollMetrics();
+      const markers = logView.value!.getSearchMarkers();
+      const after = logView.value!.getScrollMetrics();
+
+      expect(markers.length).toBe(10_000);
+      expect(markers.some((marker) => marker.estimated)).toBe(true);
+      expect(getLine.mock.calls.length).toBeLessThan(50);
+      expect(after.estimatedVisualRowCount).toBe(before.estimatedVisualRowCount);
+      expect(after.measuredLineCount).toBe(before.measuredLineCount);
+      expect(after.visualIndexStatus).toBe(before.visualIndexStatus);
+    } finally {
+      app.dispose();
+    }
+  });
+
   it("rescans search matches after retention drops head lines", async () => {
     const log = createAppendOnlyLogStore({ maxLines: 3 });
     log.appendLines(["line-0", "line-1", "line-2"]);

--- a/test/tlog-view.test.ts
+++ b/test/tlog-view.test.ts
@@ -1963,6 +1963,115 @@ describe("TLogView", () => {
     }
   });
 
+  it("getSearchMarkers maps wrapped matches to visual rows and updates the current marker", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const source: TLogDataSource = {
+      lineCount: () => 2,
+      getLine: (index) => (index === 0 ? "aaaa" : "bbbbcccc"),
+      getLineKey: (index) => index,
+    };
+
+    const App = defineComponent({
+      name: "TLogViewSearchMarkersApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            ref: logView,
+            x: 0,
+            y: 0,
+            w: 4,
+            h: 2,
+            source,
+            version: 1,
+            wrap: true,
+            searchQuery: "cccc",
+            searchOptions: { scanBudgetMs: 1000 },
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 4, rows: 3, component: App });
+    try {
+      app.mount();
+      await flushSearch(app, logView.value!);
+
+      expect(logView.value!.getSearchMarkers()).toEqual([
+        {
+          matchIndex: 0,
+          absoluteLineIndex: 1,
+          index: 1,
+          visualRow: 2,
+          estimated: true,
+          current: false,
+        },
+      ]);
+
+      logView.value!.findNext();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(logView.value!.getSearchMarkers()[0]).toMatchObject({
+        visualRow: 2,
+        estimated: true,
+        current: true,
+      });
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("marks wrapped search markers as exact after visual index measurement completes", async () => {
+    const raf = installManualRaf();
+    const logView = ref<TLogViewHandle | null>(null);
+    const source: TLogDataSource = {
+      lineCount: () => 2,
+      getLine: (index) => (index === 0 ? "aaaa" : "bbbbcccc"),
+      getLineKey: (index) => index,
+    };
+
+    const App = defineComponent({
+      name: "TLogViewExactSearchMarkersApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            ref: logView,
+            x: 0,
+            y: 0,
+            w: 4,
+            h: 2,
+            source,
+            version: 1,
+            wrap: true,
+            visualIndexMode: "exact",
+            visualIndexOptions: { measureBudgetMs: 0 },
+            searchQuery: "cccc",
+            searchOptions: { scanBudgetMs: 1000 },
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 4, rows: 3, component: App });
+    try {
+      app.mount();
+      await flushSearch(app, logView.value!);
+      await flushVisualIndex(logView.value!, raf);
+
+      expect(logView.value!.getSearchMarkers()).toEqual([
+        {
+          matchIndex: 0,
+          absoluteLineIndex: 1,
+          index: 1,
+          visualRow: 2,
+          estimated: false,
+          current: false,
+        },
+      ]);
+    } finally {
+      app.dispose();
+      raf.restore();
+    }
+  });
+
   it("rescans search matches after retention drops head lines", async () => {
     const log = createAppendOnlyLogStore({ maxLines: 3 });
     log.appendLines(["line-0", "line-1", "line-2"]);


### PR DESCRIPTION
## Summary

Add search marker support to `TLogScrollbar`, enabling visual indication of search match positions on the scrollbar track and click-to-navigate functionality.

### TLogScrollbar changes
- **New props**: `markers`, `markerStyle`, `currentMarkerStyle`, `showMarkers`
- **New event**: `markerClick` — fires instead of `scrollTo` when clicking a marker row, delegating navigation to the parent
- **Marker rendering**: distinct characters for current (`◆`), exact (`•`), and estimated (`·`) markers
- Markers are rendered on the track alongside the existing thumb; marker rows take priority over track chars but the thumb is always painted on top

### TLogView changes
- **New handle method**: `getSearchMarkers()` — projects search matches into scrollbar-friendly marker data (`visualRow`, `estimated`, `current`, `absoluteLineIndex`)
- **New event**: `searchMarkers` — emitted reactively when search state or visual index changes, with deduplication
- Cached marker computation with generation-based invalidation

### Exports
- `TLogScrollbarMarker`, `TLogScrollbarMarkerClickPayload` from `experimental`
- `TLogViewSearchMarker`, `TLogViewSearchMarkersPayload` from `experimental`

### Tests
- Marker rendering with thumb coexistence
- `markerClick` event dispatch vs `scrollTo`
- Integration test: TLogView search + TLogScrollbar marker click navigation
- Exact visual index marker behavior after measurement

## Files changed
- `src/vue/components/TLogScrollbar.ts` — marker types, props, rendering, click handling
- `src/vue/components/TLogView.ts` — `getSearchMarkers()`, `searchMarkers` event, cache/invalidation
- `src/experimental.ts` — new type exports
- `docs/components.md` — updated docs and usage example
- `docs/generated/components-api.md` — regenerated API tables
- `test/tlog-scrollbar.test.ts` — 4 new test cases
- `test/tlog-view.test.ts` — 2 new test cases