### PR TITLE
feat(TLogView): add selectSearchMatch, getSearchMatch, and getSearchResults APIs

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -435,9 +435,11 @@ type TLogDataSource = {
 
 `links=true` 只在 `ansi=true` 时生效。TLogView 会解析 OSC8 opener/closer，忽略 params，把 visible link text 渲染为带 `Style.href` 的 cells，并叠加 `linkStyle`。BEL 和 ST terminator 都支持。组件不会自动打开链接、不会做 URL auto-detect、不会解析 Markdown link，也不会提供 hover tooltip；点击 visible link cell 时只 emit `linkClick`，由应用层决定如何处理。
 
-`searchQuery` 只搜索 visible text。`ansi=true` 时，ANSI escape sequences 不参与搜索，也不会污染 match offset；match highlight 会叠加在 ANSI style 上。match 坐标使用 terminal cell offset，因此宽字符会按 cell width 定位。`wrap=true` 时，`findNext()` / `findPrevious()` 会滚动到 match 所在 visual row。搜索范围始终是当前 retained source window；retention trim、append、tail mutation、source 或 version 变化后会基于当前窗口重新扫描。
+`searchQuery` 只搜索 visible text。`ansi=true` 时，ANSI escape sequences 不参与搜索，也不会污染 match offset；match highlight 会叠加在 ANSI style 上。match 坐标使用 terminal cell offset，因此宽字符会按 cell width 定位。`wrap=true` 时，`findNext()` / `findPrevious()` / `selectSearchMatch()` 都会滚动到 match 所在 visual row。搜索范围始终是当前 retained source window；retention trim、append、tail mutation、source 或 version 变化后会基于当前窗口重新扫描。
 
 `getSearchMarkers()` 会把当前 search matches 投影成 scrollbar-friendly marker 数据：`visualRow` 仍然是 retained window 内的 visual-row index，`absoluteLineIndex` 保留原始 logical line 编号，`estimated` 用来区分 lazy visual index 和 exact visual index，`current` 表示当前 match。这个方法只基于当前 search/visual index 状态计算 markers，不会为了 marker 数据强制做一次全量 exact measurement。
+
+当外部 UI（例如 scrollbar marker、后续的 search result panel）需要把某个 match 设为 current match 时，应该调用 `selectSearchMatch(matchIndex)`。`scrollToVisualRow(marker.visualRow)` 只会移动 viewport，不会更新 `currentMatchIndex`，也不会切换 current marker / `currentMatchStyle` 或按新的 current match 继续 `findNext()` / `findPrevious()`。`getSearchMatch()` 和 `getSearchResults()` 只返回 lightweight match 引用，不会触发滚动、事件或 preview 生成；`getSearchResults()` 当前也不会生成 line preview/snippet。
 
 `searchOptions.wholeWord` 使用 ASCII word boundary：`[A-Za-z0-9_]`。例如 `error-1` 中的 `error` 会被视为 whole-word match，而 `_error` 不会。
 
@@ -564,7 +566,9 @@ function onMarkerClick(payload: {
 }) {
   const marker = payload.marker.payload;
   if (!marker) return;
-  logView.value?.scrollToVisualRow(marker.visualRow);
+  logView.value?.selectSearchMatch(marker.matchIndex, {
+    align: "center",
+  });
   refreshMetrics();
 }
 

--- a/src/experimental.ts
+++ b/src/experimental.ts
@@ -15,11 +15,13 @@ export type {
   TLogViewLinkClickPayload,
   TLogViewScrollMetrics,
   TLogViewSearchMatch,
+  TLogViewSearchResult,
   TLogViewSearchMarker,
   TLogViewSearchMarkersPayload,
   TLogViewSearchMatchPayload,
   TLogViewSearchOptions,
   TLogViewSearchPayload,
+  TLogViewSelectSearchMatchOptions,
   TLogViewSearchState,
   TLogViewVisualIndexPayload,
 } from "./vue/components/TLogView.js";

--- a/src/vue/components/TLogView.ts
+++ b/src/vue/components/TLogView.ts
@@ -120,6 +120,14 @@ export type TLogViewSearchMatch = Readonly<{
   endCell: number;
   text: string;
 }>;
+export type TLogViewSelectSearchMatchOptions = Readonly<{
+  scroll?: boolean;
+  align?: "start" | "center" | "end";
+}>;
+export type TLogViewSearchResult = Readonly<{
+  matchIndex: number;
+  match: TLogViewSearchMatch;
+}>;
 export type TLogViewSearchState = Readonly<{
   query: string;
   status: TLogSearchStatus;
@@ -196,6 +204,14 @@ export type TLogViewHandle = Readonly<{
   findPrevious: () => void;
   clearSearch: () => void;
   getSearchState: () => TLogViewSearchState;
+  selectSearchMatch: (matchIndex: number, options?: TLogViewSelectSearchMatchOptions) => boolean;
+  getSearchMatch: (matchIndex: number) => TLogViewSearchMatch | null;
+  getSearchResults: (
+    options?: Readonly<{
+      offset?: number;
+      limit?: number;
+    }>,
+  ) => readonly TLogViewSearchResult[];
   measureVisualIndex: () => void;
   getScrollMetrics: () => TLogViewScrollMetrics;
   getSearchMarkers: () => readonly TLogViewSearchMarker[];
@@ -2597,25 +2613,74 @@ export const TLogView = defineComponent({
       return searchMatches.length - 1;
     }
 
-    function scrollToMatch(match: TLogViewSearchMatch): void {
+    function scrollToMatch(
+      match: TLogViewSearchMatch,
+      align: "start" | "center" | "end" = "center",
+    ): void {
       if (!props.wrap) {
-        scrollToLine(match.index, { align: "center" });
+        scrollToLine(match.index, { align });
         return;
       }
 
       const row = visualRowForMatch(match);
-      scrollToVisualRow(row - Math.floor(viewportHeight() / 2));
+      const height = viewportHeight();
+      let target = row;
+      if (align === "center") target = row - Math.floor(height / 2);
+      else if (align === "end") target = row - height + 1;
+      scrollToVisualRow(target);
     }
 
-    function setCurrentMatch(index: number): void {
-      if (index < 0 || index >= searchMatches.length) return;
+    function setCurrentMatch(index: number, options?: TLogViewSelectSearchMatchOptions): boolean {
+      if (index < 0 || index >= searchMatches.length) return false;
       currentMatchIndex = index;
       emitSearchMatch();
       invalidateSearchMarkers();
       emitSearchMarkers(true);
-      scrollToMatch(searchMatches[index]!);
+      if (options?.scroll !== false) {
+        scrollToMatch(searchMatches[index]!, options?.align ?? "center");
+      }
       markViewportDirty();
       invalidateSelf("high", "data");
+      return true;
+    }
+
+    function normalizeSearchMatchIndex(matchIndex: number): number | null {
+      const index = Math.floor(Number(matchIndex));
+      return Number.isFinite(index) ? index : null;
+    }
+
+    function selectSearchMatch(
+      matchIndex: number,
+      options?: TLogViewSelectSearchMatchOptions,
+    ): boolean {
+      const index = normalizeSearchMatchIndex(matchIndex);
+      if (index == null) return false;
+      return setCurrentMatch(index, options);
+    }
+
+    function getSearchMatch(matchIndex: number): TLogViewSearchMatch | null {
+      const index = normalizeSearchMatchIndex(matchIndex);
+      if (index == null) return null;
+      return searchMatches[index] ?? null;
+    }
+
+    function getSearchResults(
+      options?: Readonly<{
+        offset?: number;
+        limit?: number;
+      }>,
+    ): readonly TLogViewSearchResult[] {
+      const rawOffset = Number(options?.offset ?? 0);
+      const rawLimit = Number(options?.limit ?? searchMatches.length);
+      const offset = Number.isFinite(rawOffset) ? Math.max(0, Math.floor(rawOffset)) : 0;
+      const limit = Number.isFinite(rawLimit)
+        ? Math.max(0, Math.floor(rawLimit))
+        : searchMatches.length;
+
+      return searchMatches.slice(offset, offset + limit).map((match, index) => ({
+        matchIndex: offset + index,
+        match,
+      }));
     }
 
     function findNext(): void {
@@ -2624,7 +2689,7 @@ export const TLogView = defineComponent({
         currentMatchIndex < 0
           ? firstMatchAtOrAfterViewport()
           : (currentMatchIndex + 1) % searchMatches.length;
-      setCurrentMatch(next);
+      selectSearchMatch(next);
     }
 
     function findPrevious(): void {
@@ -2633,7 +2698,7 @@ export const TLogView = defineComponent({
         currentMatchIndex < 0
           ? lastMatchAtOrBeforeViewport()
           : (currentMatchIndex - 1 + searchMatches.length) % searchMatches.length;
-      setCurrentMatch(previous);
+      selectSearchMatch(previous);
     }
 
     function clearSearch(): void {
@@ -2674,6 +2739,9 @@ export const TLogView = defineComponent({
       findPrevious,
       clearSearch,
       getSearchState,
+      selectSearchMatch,
+      getSearchMatch,
+      getSearchResults,
       measureVisualIndex,
       getScrollMetrics,
       getSearchMarkers,

--- a/test/tlog-view.test.ts
+++ b/test/tlog-view.test.ts
@@ -1,16 +1,20 @@
 import type {
   TLogDataSource,
+  TLogScrollbarMarker,
   TLogViewHandle,
   TLogViewLinkClickPayload,
+  TLogViewScrollMetrics,
+  TLogViewSearchMarker,
 } from "../src/experimental.js";
 import { describe, expect, it, vi } from "vitest";
 import { createTerminalApp } from "../src/index.js";
-import { createAppendOnlyLogStore, TLogView } from "../src/experimental.js";
+import { createAppendOnlyLogStore, TLogScrollbar, TLogView } from "../src/experimental.js";
 import {
   defineComponent,
   h,
   mountTerminal,
   nextTick,
+  onMounted,
   ref,
   TText,
   useTerminal,
@@ -1768,7 +1772,152 @@ describe("TLogView", () => {
       await nextTick();
       app.scheduler.flushNow();
       expect(logView.value!.getSearchState().currentMatchIndex).toBe(1);
-      expect(rowText(app, 1)).toBe("error line-4");
+      expect(rowText(app, 1).startsWith("error line-4")).toBe(true);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("selectSearchMatch updates the current match and emits the selected payload", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const onSearchMatch = vi.fn();
+    const source: TLogDataSource = {
+      lineCount: () => 6,
+      getLine: (index) => (index === 1 || index === 4 ? `error line-${index}` : `ok line-${index}`),
+      getLineKey: (index) => index,
+    };
+
+    const App = defineComponent({
+      name: "TLogViewSelectSearchMatchApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            ref: logView,
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 3,
+            source,
+            version: 1,
+            defaultScrollTop: 0,
+            searchQuery: "error",
+            searchOptions: { scanBudgetMs: 1000 },
+            onSearchMatch,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 4, component: App });
+    try {
+      app.mount();
+      await flushSearch(app, logView.value!);
+      onSearchMatch.mockClear();
+
+      expect(logView.value!.selectSearchMatch(1)).toBe(true);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(logView.value!.getSearchState().currentMatchIndex).toBe(1);
+      expect(onSearchMatch).toHaveBeenLastCalledWith({
+        match: {
+          absoluteLineIndex: 4,
+          index: 4,
+          startCell: 0,
+          endCell: 5,
+          text: "error",
+        },
+        currentMatchIndex: 1,
+        matchCount: 2,
+      });
+      expect(rowText(app, 1).startsWith("error line-4")).toBe(true);
+      expect(rowStyles(app, 1)[0]).toMatchObject({
+        inverse: true,
+        bold: true,
+      });
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("selectSearchMatch supports align and scroll=false without mutating getters", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const onScroll = vi.fn();
+    const onSearchMatch = vi.fn();
+    const getLine = vi.fn((index: number) => `line-${index}${index === 20 ? " error" : ""}`);
+    const source: TLogDataSource = {
+      lineCount: () => 30,
+      getLine,
+      getLineKey: (index) => index,
+    };
+
+    const App = defineComponent({
+      name: "TLogViewSelectSearchMatchScrollOptionsApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            ref: logView,
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 3,
+            source,
+            version: 1,
+            defaultScrollTop: 0,
+            searchQuery: "error",
+            searchOptions: { scanBudgetMs: 1000 },
+            onScroll,
+            onSearchMatch,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 4, component: App });
+    try {
+      app.mount();
+      await flushSearch(app, logView.value!);
+
+      expect(logView.value!.selectSearchMatch(0, { align: "start" })).toBe(true);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(rowText(app, 0)).toBe("line-20 error");
+      expect(logView.value!.getScrollMetrics().scrollTop).toBe(20);
+
+      onScroll.mockClear();
+      onSearchMatch.mockClear();
+      getLine.mockClear();
+      expect(logView.value!.selectSearchMatch(0, { scroll: false })).toBe(true);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(logView.value!.getSearchState().currentMatchIndex).toBe(0);
+      expect(rowText(app, 0)).toBe("line-20 error");
+      expect(onScroll).not.toHaveBeenCalled();
+      expect(onSearchMatch).toHaveBeenCalledTimes(1);
+
+      const beforeState = logView.value!.getSearchState();
+      const beforeMetrics = logView.value!.getScrollMetrics();
+      onSearchMatch.mockClear();
+      getLine.mockClear();
+
+      expect(logView.value!.getSearchMatch(0)).toMatchObject({
+        index: 20,
+        text: "error",
+      });
+      expect(logView.value!.getSearchResults()).toEqual([
+        {
+          matchIndex: 0,
+          match: expect.objectContaining({
+            index: 20,
+            text: "error",
+          }),
+        },
+      ]);
+      expect(logView.value!.getSearchResults({ offset: 1, limit: 1 })).toEqual([]);
+      expect(logView.value!.getSearchState()).toEqual(beforeState);
+      expect(logView.value!.getScrollMetrics()).toEqual(beforeMetrics);
+      expect(onSearchMatch).not.toHaveBeenCalled();
+      expect(getLine).not.toHaveBeenCalled();
     } finally {
       app.dispose();
     }
@@ -1915,6 +2064,52 @@ describe("TLogView", () => {
     }
   });
 
+  it("selectSearchMatch navigates to the actual wrapped visual row for wide-character matches", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const source: TLogDataSource = {
+      lineCount: () => 1,
+      getLine: () => "ab中cd",
+      getLineKey: () => "wide-select",
+    };
+
+    const App = defineComponent({
+      name: "TLogViewWideWrapSelectSearchMatchApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            ref: logView,
+            x: 0,
+            y: 0,
+            w: 3,
+            h: 1,
+            source,
+            version: 1,
+            wrap: true,
+            searchQuery: "中",
+            searchOptions: { scanBudgetMs: 1000 },
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 3, rows: 2, component: App });
+    try {
+      app.mount();
+      await flushSearch(app, logView.value!);
+
+      expect(logView.value!.selectSearchMatch(0)).toBe(true);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(rowText(app, 0)).toBe("中c");
+      expect(rowStyles(app, 0)[0]!).toMatchObject({
+        inverse: true,
+        bold: true,
+      });
+    } finally {
+      app.dispose();
+    }
+  });
+
   it("findNext navigates to the actual ANSI wrapped visual row for wide-character matches", async () => {
     const logView = ref<TLogViewHandle | null>(null);
     const source: TLogDataSource = {
@@ -1960,6 +2155,115 @@ describe("TLogView", () => {
       expect(styles[2]!.fg).toBe("red");
     } finally {
       app.dispose();
+    }
+  });
+
+  it("selectSearchMatch navigates to the actual ANSI wrapped visual row and preserves ANSI style", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const source: TLogDataSource = {
+      lineCount: () => 1,
+      getLine: () => "\x1b[31mab中cd\x1b[0m",
+      getLineKey: () => "wide-ansi-select",
+    };
+
+    const App = defineComponent({
+      name: "TLogViewWideAnsiWrapSelectSearchMatchApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            ref: logView,
+            x: 0,
+            y: 0,
+            w: 3,
+            h: 1,
+            source,
+            version: 1,
+            wrap: true,
+            ansi: true,
+            searchQuery: "中",
+            searchOptions: { scanBudgetMs: 1000 },
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 3, rows: 2, component: App });
+    try {
+      app.mount();
+      await flushSearch(app, logView.value!);
+
+      expect(logView.value!.selectSearchMatch(0)).toBe(true);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(rowText(app, 0)).toBe("中c");
+      const styles = rowStyles(app, 0);
+      expect(styles[0]!).toMatchObject({
+        fg: "red",
+        inverse: true,
+        bold: true,
+      });
+      expect(styles[2]!.fg).toBe("red");
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("selectSearchMatch works after exact visual index measurement completes", async () => {
+    const raf = installManualRaf();
+    const logView = ref<TLogViewHandle | null>(null);
+    const source: TLogDataSource = {
+      lineCount: () => 2,
+      getLine: (index) => (index === 0 ? "aaaa" : "bbbbcccc"),
+      getLineKey: (index) => index,
+    };
+
+    const App = defineComponent({
+      name: "TLogViewExactSelectSearchMatchApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            ref: logView,
+            x: 0,
+            y: 0,
+            w: 4,
+            h: 2,
+            source,
+            version: 1,
+            wrap: true,
+            visualIndexMode: "exact",
+            visualIndexOptions: { measureBudgetMs: 0 },
+            searchQuery: "cccc",
+            searchOptions: { scanBudgetMs: 1000 },
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 4, rows: 3, component: App });
+    try {
+      app.mount();
+      await flushSearch(app, logView.value!);
+      await flushVisualIndex(logView.value!, raf);
+
+      expect(logView.value!.getSearchMarkers()[0]).toMatchObject({
+        visualRow: 2,
+        estimated: false,
+        current: false,
+      });
+
+      expect(logView.value!.selectSearchMatch(0)).toBe(true);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(logView.value!.getSearchState().currentMatchIndex).toBe(0);
+      expect(logView.value!.getSearchMarkers()[0]).toMatchObject({
+        visualRow: 2,
+        estimated: false,
+        current: true,
+      });
+      expect(rowText(app, 1)).toBe("cccc");
+    } finally {
+      app.dispose();
+      raf.restore();
     }
   });
 
@@ -2015,6 +2319,182 @@ describe("TLogView", () => {
         estimated: true,
         current: true,
       });
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("selectSearchMatch returns false for invalid match indexes", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const onSearchMatch = vi.fn();
+    const onSearchMarkers = vi.fn();
+    const source: TLogDataSource = {
+      lineCount: () => 1,
+      getLine: () => "error",
+      getLineKey: () => "invalid-index",
+    };
+
+    const App = defineComponent({
+      name: "TLogViewInvalidSelectSearchMatchApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            ref: logView,
+            x: 0,
+            y: 0,
+            w: 8,
+            h: 1,
+            source,
+            version: 1,
+            searchQuery: "error",
+            searchOptions: { scanBudgetMs: 1000 },
+            onSearchMatch,
+            onSearchMarkers,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 8, rows: 2, component: App });
+    try {
+      app.mount();
+      await flushSearch(app, logView.value!);
+      onSearchMatch.mockClear();
+      onSearchMarkers.mockClear();
+
+      expect(logView.value!.selectSearchMatch(-1)).toBe(false);
+      expect(logView.value!.selectSearchMatch(999)).toBe(false);
+      expect(logView.value!.selectSearchMatch(Number.NaN)).toBe(false);
+      expect(logView.value!.getSearchMatch(Number.NaN)).toBeNull();
+      expect(logView.value!.getSearchMatch(999)).toBeNull();
+      expect(onSearchMatch).not.toHaveBeenCalled();
+      expect(onSearchMarkers).not.toHaveBeenCalled();
+      expect(logView.value!.getSearchState().currentMatchIndex).toBe(-1);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("updates current marker and current match style when a scrollbar marker selects a match", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const metrics = ref<TLogViewScrollMetrics | null>(null);
+    const markers = ref<readonly TLogScrollbarMarker[]>([]);
+    const onSearchMatch = vi.fn();
+    const source: TLogDataSource = {
+      lineCount: () => 6,
+      getLine: (index) => (index === 1 || index === 4 ? `error line-${index}` : `ok line-${index}`),
+      getLineKey: (index) => index,
+    };
+
+    function toScrollbarMarkers(
+      searchMarkers: readonly TLogViewSearchMarker[],
+    ): readonly TLogScrollbarMarker[] {
+      return searchMarkers.map((marker) => ({
+        id: marker.matchIndex,
+        visualRow: marker.visualRow,
+        current: marker.current,
+        estimated: marker.estimated,
+        payload: marker,
+      }));
+    }
+
+    const App = defineComponent({
+      name: "TLogViewScrollbarMarkerSelectionApp",
+      setup() {
+        function refreshMetrics() {
+          metrics.value = logView.value?.getScrollMetrics() ?? null;
+          markers.value = toScrollbarMarkers(logView.value?.getSearchMarkers() ?? []);
+        }
+
+        function onMarkerClick(payload: {
+          marker: TLogScrollbarMarker & { payload?: TLogViewSearchMarker };
+        }) {
+          const marker = payload.marker.payload;
+          if (!marker) return;
+          logView.value?.selectSearchMatch(marker.matchIndex, { align: "center" });
+          refreshMetrics();
+        }
+
+        onMounted(refreshMetrics);
+
+        return () =>
+          h("div", [
+            h(TLogView, {
+              ref: logView,
+              x: 0,
+              y: 0,
+              w: 11,
+              h: 3,
+              source,
+              version: 1,
+              defaultScrollTop: 0,
+              searchQuery: "error",
+              searchOptions: { scanBudgetMs: 1000 },
+              onSearchMatch,
+              onScroll: refreshMetrics,
+              onVisualIndex: refreshMetrics,
+              onSearchMarkers: refreshMetrics,
+            }),
+            h(TLogScrollbar, {
+              x: 11,
+              y: 0,
+              h: 6,
+              metrics: metrics.value,
+              markers: markers.value,
+              onMarkerClick,
+            }),
+          ]);
+      },
+    });
+
+    const app = createTerminalApp({ cols: 12, rows: 6, component: App });
+    try {
+      app.mount();
+      await flushSearch(app, logView.value!);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(markers.value).toHaveLength(2);
+      expect(markers.value[1]).toMatchObject({
+        visualRow: 4,
+        current: false,
+      });
+
+      onSearchMatch.mockClear();
+      app.events.dispatch({
+        type: "click",
+        cellX: 11,
+        cellY: 4,
+      } as any);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(logView.value!.getSearchState().currentMatchIndex).toBe(1);
+      expect(onSearchMatch).toHaveBeenLastCalledWith({
+        match: expect.objectContaining({
+          absoluteLineIndex: 4,
+          index: 4,
+          text: "error",
+        }),
+        currentMatchIndex: 1,
+        matchCount: 2,
+      });
+      expect(markers.value[1]).toMatchObject({
+        visualRow: 4,
+        current: true,
+      });
+      const visibleRows = [0, 1, 2].map((row) => rowText(app, row));
+      const matchRow = visibleRows.findIndex((text) => text.startsWith("error line-"));
+      expect(matchRow >= 0).toBe(true);
+      expect(rowStyles(app, matchRow)[0]).toMatchObject({
+        inverse: true,
+        bold: true,
+      });
+
+      logView.value!.findNext();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(logView.value!.getSearchState().currentMatchIndex).toBe(0);
     } finally {
       app.dispose();
     }


### PR DESCRIPTION
## Summary

Add programmatic search match selection and read-only query APIs to TLogView:

- **`selectSearchMatch(matchIndex, options?)`** — Select a search match by index, with optional `align` (start/center/end) and `scroll` (boolean) control. Returns `false` for invalid indexes without side effects.
- **`getSearchMatch(matchIndex)`** — Read-only getter for a single match; returns `null` for invalid indexes.
- **`getSearchResults(options?)`** — Read-only getter for paginated match results with `offset`/`limit`. Returns lightweight references without triggering scroll, events, or preview generation.

### Other changes

- `scrollToMatch` now supports `align` parameter (start/center/end)
- `setCurrentMatch` supports `scroll: false` option
- Scrollbar marker click handler uses `selectSearchMatch` instead of `scrollToVisualRow`, so clicking a marker properly updates `currentMatchIndex`, current marker highlight, and `currentMatchStyle`
- Export new types: `TLogViewSelectSearchMatchOptions`, `TLogViewSearchResult`
- Updated `docs/components.md` with new API descriptions and usage notes

## Test plan

- [x] `selectSearchMatch` updates current match and emits correct payload
- [x] `selectSearchMatch` supports `align` and `scroll: false` options
- [x] `getSearchMatch` and `getSearchResults` are read-only (no side effects)
- [x] `selectSearchMatch` navigates wrapped visual rows for wide-character and ANSI matches
- [x] `selectSearchMatch` works after exact visual index measurement
- [x] `selectSearchMatch` returns `false` for invalid indexes (NaN, negative, out of range)
- [x] Scrollbar marker click integration test verifies current marker/style update and `findNext` continuation
- [ ] CI passes