### PR TITLE
feat(TLogSearchResults): add search result panel component and preview support

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -603,6 +603,85 @@ onMounted(refreshMetrics);
 />
 ```
 
+### TLogSearchResults
+
+`TLogSearchResults` 是一个 experimental search result panel，用来渲染分页后的搜索结果预览。它只消费外部准备好的 result items，不持有 search state，也不会直接读取 `TLogView` 或 log source。
+
+- 结果数据建议来自 `logView.value?.getSearchResults({ offset, limit, includePreview: true })`
+- `includePreview` 默认是 `false`，避免每次 getter 都去读取结果行内容
+- preview 基于 visible text 生成；`ansi=true` 时不会把 ANSI escape sequences 带进结果面板
+- preview 和高亮 offset 都按 cell 计算，因此宽字符场景可以保持匹配位置正确
+- 组件只负责渲染和交互：`ArrowUp` / `ArrowDown` / `Home` / `End` 更新 active row，`Enter` 和 click emit `select`
+- 不要每一帧都对全部 10k matches 调 `includePreview: true`；应当只给当前页或当前窗口取 preview
+
+```vue
+<script setup lang="ts">
+import { ref } from "vue";
+import {
+  TLogSearchResults,
+  TLogView,
+  type TLogSearchResultItem,
+  type TLogSearchResultsSelectPayload,
+  type TLogViewHandle,
+} from "@simon_he/vue-tui/experimental";
+
+const logView = ref<TLogViewHandle | null>(null);
+const results = ref<readonly TLogSearchResultItem[]>([]);
+const activeIndex = ref(-1);
+const query = ref("ERROR");
+
+function refreshResults() {
+  const raw =
+    logView.value?.getSearchResults({
+      offset: 0,
+      limit: 20,
+      includePreview: true,
+      previewWidth: 60,
+    }) ?? [];
+  const state = logView.value?.getSearchState();
+
+  results.value = raw.map((entry) => ({
+    matchIndex: entry.matchIndex,
+    absoluteLineIndex: entry.match.absoluteLineIndex,
+    lineIndex: entry.match.index,
+    text: entry.preview?.text ?? "",
+    matchStartCell: entry.preview?.matchStartCell ?? 0,
+    matchEndCell: entry.preview?.matchEndCell ?? 0,
+    current: entry.matchIndex === state?.currentMatchIndex,
+  }));
+  activeIndex.value = raw.findIndex((entry) => entry.matchIndex === state?.currentMatchIndex);
+}
+
+function onSelect(payload: TLogSearchResultsSelectPayload) {
+  logView.value?.selectSearchMatch(payload.matchIndex);
+  refreshResults();
+}
+</script>
+
+<TLogView
+  ref="logView"
+  :x="0"
+  :y="0"
+  :w="60"
+  :h="20"
+  :source="log.source"
+  :version="log.version"
+  :search-query="query"
+  @search="refreshResults"
+  @searchMatch="refreshResults"
+/>
+
+<TLogSearchResults
+  :x="61"
+  :y="0"
+  :w="19"
+  :h="20"
+  :results="results"
+  :active-index="activeIndex"
+  @select="onSelect"
+/>
+```
+
 ### Events
 
 - `scroll`: `{ scrollTop, atBottom, lineCount, estimatedVisualRowCount, visualRowCount, measuredVisualRowCount, measuredLineCount, visualIndexStatus, firstLineIndex }`

--- a/docs/generated/components-api.md
+++ b/docs/generated/components-api.md
@@ -15,6 +15,7 @@
 - [TJsonEditor](#tjsoneditor)
 - [TList](#tlist)
 - [TLogScrollbar](#tlogscrollbar)
+- [TLogSearchResults](#tlogsearchresults)
 - [TLogView](#tlogview)
 - [TMultilineModal](#tmultilinemodal)
 - [TPathPicker](#tpathpicker)
@@ -413,6 +414,38 @@
 | <code>scrollTo</code>    | —       | —    |
 | <code>scrollBy</code>    | —       | —    |
 | <code>markerClick</code> | —       | —    |
+
+## TLogSearchResults
+
+源码：`src/vue/components/TLogSearchResults.ts`
+
+### Props
+
+| 名称                         | 类型                                         | 默认值                                      | 必填 | 说明 |
+| ---------------------------- | -------------------------------------------- | ------------------------------------------- | ---- | ---- |
+| <code>x</code>               | <code>number</code>                          | —                                           | 是   | —    |
+| <code>y</code>               | <code>number</code>                          | —                                           | 是   | —    |
+| <code>w</code>               | <code>number</code>                          | —                                           | 是   | —    |
+| <code>h</code>               | <code>number</code>                          | —                                           | 是   | —    |
+| <code>zIndex</code>          | <code>number</code>                          | <code>0</code>                              | 否   | —    |
+| <code>results</code>         | <code>readonly TLogSearchResultItem[]</code> | <code>() =&gt; []</code>                    | 否   | —    |
+| <code>activeIndex</code>     | <code>number</code>                          | <code>-1</code>                             | 否   | —    |
+| <code>style</code>           | <code>Style</code>                           | <code>undefined</code>                      | 否   | —    |
+| <code>activeStyle</code>     | <code>Style</code>                           | <code>() =&gt; ({ inverse: true })</code>   | 否   | —    |
+| <code>matchStyle</code>      | <code>Style</code>                           | <code>() =&gt; ({ underline: true })</code> | 否   | —    |
+| <code>currentStyle</code>    | <code>Style</code>                           | <code>() =&gt; ({ bold: true })</code>      | 否   | —    |
+| <code>showLineNumbers</code> | <code>boolean</code>                         | <code>true</code>                           | 否   | —    |
+| <code>focusable</code>       | <code>boolean</code>                         | <code>true</code>                           | 否   | —    |
+
+### Events
+
+| 名称                      | Payload | 说明 |
+| ------------------------- | ------- | ---- |
+| <code>select</code>       | —       | —    |
+| <code>activeChange</code> | —       | —    |
+| <code>keydown</code>      | —       | —    |
+| <code>focus</code>        | —       | —    |
+| <code>blur</code>         | —       | —    |
 
 ## TLogView
 

--- a/src/experimental.ts
+++ b/src/experimental.ts
@@ -1,6 +1,7 @@
 export { TVirtualList } from "./vue/components/TVirtualList.js";
 export { TLogView } from "./vue/components/TLogView.js";
 export { TLogScrollbar } from "./vue/components/TLogScrollbar.js";
+export { TLogSearchResults } from "./vue/components/TLogSearchResults.js";
 export { createAppendOnlyLogStore } from "./vue/log/append-only-log-store.js";
 export type { RowScrollMode } from "./vue/components/TVirtualList.js";
 export type {
@@ -11,11 +12,18 @@ export type {
   TLogScrollbarScrollToPayload,
 } from "./vue/components/TLogScrollbar.js";
 export type {
+  TLogSearchResultItem,
+  TLogSearchResultsActiveChangePayload,
+  TLogSearchResultsSelectPayload,
+} from "./vue/components/TLogSearchResults.js";
+export type {
   TLogViewHandle,
   TLogViewLinkClickPayload,
   TLogViewScrollMetrics,
   TLogViewSearchMatch,
   TLogViewSearchResult,
+  TLogViewSearchResultPreview,
+  TLogViewSearchResultsOptions,
   TLogViewSearchMarker,
   TLogViewSearchMarkersPayload,
   TLogViewSearchMatchPayload,

--- a/src/vue/components/TLogSearchResults.ts
+++ b/src/vue/components/TLogSearchResults.ts
@@ -1,0 +1,326 @@
+import type { PropType } from "vue";
+import type { Style } from "../../core/types.js";
+import type { Rect, TerminalKeyboardEvent, TerminalPointerEvent } from "../../events/index.js";
+import { computed, defineComponent, h, inject, ref, watch } from "vue";
+import { useLayout } from "../composables/use-layout.js";
+import { useRenderNode } from "../composables/use-render-node.js";
+import { useTerminalNode } from "../composables/use-terminal-node.js";
+import { useTerminal } from "../composables/use-terminal.js";
+import { useVisibility } from "../composables/use-visibility.js";
+import { EventZIndexContextKey } from "../context.js";
+import { intersectRect, translateRect } from "../utils/rect.js";
+import { sliceByCellsRange, spaces, textCellWidth } from "../utils/text.js";
+
+const EMPTY_RECT: Rect = Object.freeze({ x: 0, y: 0, w: 0, h: 0 });
+
+export type TLogSearchResultItem = Readonly<{
+  matchIndex: number;
+  absoluteLineIndex: number;
+  lineIndex: number;
+  text: string;
+  matchStartCell: number;
+  matchEndCell: number;
+  current?: boolean;
+}>;
+
+export type TLogSearchResultsSelectPayload = Readonly<{
+  matchIndex: number;
+  result: TLogSearchResultItem;
+}>;
+
+export type TLogSearchResultsActiveChangePayload = Readonly<{
+  activeIndex: number;
+  result: TLogSearchResultItem | null;
+}>;
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function normalizeInt(value: number): number {
+  const n = Math.floor(Number(value));
+  return Number.isFinite(n) ? n : 0;
+}
+
+function mergeStyle(base: Style, overlay?: Style): Style {
+  return overlay ? { ...base, ...overlay } : base;
+}
+
+function normalizeActiveIndex(value: number, count: number): number {
+  if (count <= 0) return -1;
+  const n = Math.floor(Number(value));
+  if (!Number.isFinite(n)) return -1;
+  if (n < 0) return -1;
+  return clamp(n, 0, count - 1);
+}
+
+export const TLogSearchResults = defineComponent({
+  name: "TLogSearchResults",
+  props: {
+    x: { type: Number, required: true },
+    y: { type: Number, required: true },
+    w: { type: Number, required: true },
+    h: { type: Number, required: true },
+    zIndex: { type: Number, default: 0 },
+    results: {
+      type: Array as PropType<readonly TLogSearchResultItem[]>,
+      default: () => [],
+    },
+    activeIndex: { type: Number, default: -1 },
+    style: { type: Object as PropType<Style>, default: undefined },
+    activeStyle: {
+      type: Object as PropType<Style>,
+      default: () => ({ inverse: true }),
+    },
+    matchStyle: {
+      type: Object as PropType<Style>,
+      default: () => ({ underline: true }),
+    },
+    currentStyle: {
+      type: Object as PropType<Style>,
+      default: () => ({ bold: true }),
+    },
+    showLineNumbers: { type: Boolean, default: true },
+    focusable: { type: Boolean, default: true },
+  },
+  emits: ["select", "activeChange", "keydown", "focus", "blur"],
+  setup(props, { emit }) {
+    const { terminal, scheduler, defaultStyle, events } = useTerminal();
+    const parent = useLayout();
+    const { visible, rootProps } = useVisibility();
+    const parentEventZ = inject(EventZIndexContextKey, computed(() => 0) as any);
+    const eventZ = computed(() => (parentEventZ.value ?? 0) + (props.zIndex ?? 0));
+    const focused = ref(false);
+    const internalActiveIndex = ref(-1);
+
+    const fullRect = computed<Rect>(() =>
+      translateRect(
+        {
+          x: normalizeInt(props.x),
+          y: normalizeInt(props.y),
+          w: Math.max(0, normalizeInt(props.w)),
+          h: Math.max(0, normalizeInt(props.h)),
+        },
+        parent.originX,
+        parent.originY,
+      ),
+    );
+
+    const rect = computed<Rect>(() => {
+      const translated = fullRect.value;
+      if (!parent.clipRect) return translated;
+      return intersectRect(translated, parent.clipRect) ?? EMPTY_RECT;
+    });
+
+    const lineNumberDigits = computed(() =>
+      props.showLineNumbers
+        ? props.results.reduce(
+            (max, result) => Math.max(max, String(result.absoluteLineIndex).length),
+            1,
+          )
+        : 0,
+    );
+
+    watch(
+      [() => props.activeIndex, () => props.results.length],
+      () => {
+        internalActiveIndex.value = normalizeActiveIndex(props.activeIndex, props.results.length);
+      },
+      { immediate: true },
+    );
+
+    function activeResult(index = internalActiveIndex.value): TLogSearchResultItem | null {
+      return index >= 0 ? (props.results[index] ?? null) : null;
+    }
+
+    function emitActiveChange(): void {
+      emit("activeChange", {
+        activeIndex: internalActiveIndex.value,
+        result: activeResult(),
+      } satisfies TLogSearchResultsActiveChangePayload);
+    }
+
+    function setActiveIndex(index: number): void {
+      const next = normalizeActiveIndex(index, props.results.length);
+      if (next === internalActiveIndex.value) return;
+      internalActiveIndex.value = next;
+      emitActiveChange();
+      scheduler.invalidate({ reason: "input" });
+    }
+
+    function emitSelect(index: number): void {
+      const result = props.results[index];
+      if (!result) return;
+      emit("select", {
+        matchIndex: result.matchIndex,
+        result,
+      } satisfies TLogSearchResultsSelectPayload);
+    }
+
+    function onKeydown(e: TerminalKeyboardEvent): void {
+      emit("keydown", e);
+      if (!props.results.length) return;
+
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActiveIndex((internalActiveIndex.value < 0 ? -1 : internalActiveIndex.value) + 1);
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActiveIndex(internalActiveIndex.value < 0 ? 0 : internalActiveIndex.value - 1);
+        return;
+      }
+      if (e.key === "Home") {
+        e.preventDefault();
+        setActiveIndex(0);
+        return;
+      }
+      if (e.key === "End") {
+        e.preventDefault();
+        setActiveIndex(props.results.length - 1);
+        return;
+      }
+      if (e.key === "Enter") {
+        e.preventDefault();
+        if (internalActiveIndex.value >= 0) emitSelect(internalActiveIndex.value);
+      }
+    }
+
+    function onClick(e: TerminalPointerEvent): void {
+      const full = fullRect.value;
+      const localY = e.cellY - full.y;
+      if (localY < 0 || localY >= full.h) return;
+      const result = props.results[localY];
+      if (!result) return;
+      const nodeId = eventNode.id.value;
+      if (props.focusable && nodeId) events.value?.focus(nodeId);
+      setActiveIndex(localY);
+      emitSelect(localY);
+      e.preventDefault?.();
+    }
+
+    const eventNode = useTerminalNode(() => ({
+      rect: rect.value,
+      zIndex: eventZ.value,
+      visible: visible.value,
+      focusable: props.focusable,
+      handlers: {
+        click: onClick,
+        focus: () => {
+          focused.value = true;
+          emit("focus");
+          scheduler.invalidate();
+        },
+        blur: () => {
+          focused.value = false;
+          emit("blur");
+          scheduler.invalidate();
+        },
+        keydown: onKeydown,
+      },
+    }));
+
+    useRenderNode(() => ({
+      zIndex: props.zIndex,
+      rect: visible.value ? rect.value : EMPTY_RECT,
+      deps: [
+        visible.value,
+        rect.value,
+        fullRect.value,
+        props.results,
+        props.activeIndex,
+        props.style,
+        props.activeStyle,
+        props.matchStyle,
+        props.currentStyle,
+        props.showLineNumbers,
+        props.focusable,
+        internalActiveIndex.value,
+        focused.value,
+        lineNumberDigits.value,
+        defaultStyle.value,
+      ],
+      paint: () => {
+        if (!visible.value) return;
+        const r = rect.value;
+        if (r.w <= 0 || r.h <= 0) return;
+
+        const full = fullRect.value;
+        const base = props.style ?? defaultStyle.value;
+
+        const writeSegments = (
+          y: number,
+          rowStyle: Style,
+          segments: readonly Readonly<{
+            text: string;
+            style: Style;
+          }>[],
+        ): void => {
+          let x = r.x;
+          let used = 0;
+          for (const segment of segments) {
+            if (used >= r.w || !segment.text) continue;
+            const text = sliceByCellsRange(segment.text, 0, r.w - used);
+            const cells = textCellWidth(text);
+            if (!text || cells <= 0) continue;
+            terminal.write(text, { x, y, style: segment.style });
+            x += cells;
+            used += cells;
+          }
+          if (used < r.w) terminal.write(spaces(r.w - used), { x, y, style: rowStyle });
+        };
+
+        for (let y = r.y; y < r.y + r.h; y++) {
+          const localY = y - full.y;
+          const result = props.results[localY];
+          if (!result) {
+            terminal.write(spaces(r.w), { x: r.x, y, style: base });
+            continue;
+          }
+
+          let rowStyle = base;
+          if (localY === internalActiveIndex.value)
+            rowStyle = mergeStyle(rowStyle, props.activeStyle);
+          if (result.current) rowStyle = mergeStyle(rowStyle, props.currentStyle);
+          const rowMatchStyle = mergeStyle(rowStyle, props.matchStyle);
+          const lineNumberText = props.showLineNumbers
+            ? `${String(result.absoluteLineIndex).padStart(lineNumberDigits.value)} `
+            : "";
+          const previewCells = textCellWidth(result.text);
+          const matchStartCell = clamp(result.matchStartCell, 0, previewCells);
+          const matchEndCell = clamp(result.matchEndCell, matchStartCell, previewCells);
+
+          const segments: Array<{
+            text: string;
+            style: Style;
+          }> = [];
+          if (lineNumberText) segments.push({ text: lineNumberText, style: rowStyle });
+          if (matchStartCell > 0) {
+            segments.push({
+              text: sliceByCellsRange(result.text, 0, matchStartCell),
+              style: rowStyle,
+            });
+          }
+          if (matchEndCell > matchStartCell) {
+            segments.push({
+              text: sliceByCellsRange(result.text, matchStartCell, matchEndCell),
+              style: rowMatchStyle,
+            });
+          }
+          if (matchEndCell < previewCells) {
+            segments.push({
+              text: sliceByCellsRange(result.text, matchEndCell, previewCells),
+              style: rowStyle,
+            });
+          }
+          if (!result.text) segments.push({ text: "", style: rowStyle });
+
+          writeSegments(y, rowStyle, segments);
+        }
+      },
+    }));
+
+    return () => h("span", rootProps);
+  },
+});

--- a/src/vue/components/TLogView.ts
+++ b/src/vue/components/TLogView.ts
@@ -127,6 +127,19 @@ export type TLogViewSelectSearchMatchOptions = Readonly<{
 export type TLogViewSearchResult = Readonly<{
   matchIndex: number;
   match: TLogViewSearchMatch;
+  preview?: TLogViewSearchResultPreview;
+}>;
+export type TLogViewSearchResultPreview = Readonly<{
+  text: string;
+  matchStartCell: number;
+  matchEndCell: number;
+}>;
+export type TLogViewSearchResultsOptions = Readonly<{
+  offset?: number;
+  limit?: number;
+  includePreview?: boolean;
+  previewWidth?: number;
+  contextCells?: number;
 }>;
 export type TLogViewSearchState = Readonly<{
   query: string;
@@ -206,12 +219,7 @@ export type TLogViewHandle = Readonly<{
   getSearchState: () => TLogViewSearchState;
   selectSearchMatch: (matchIndex: number, options?: TLogViewSelectSearchMatchOptions) => boolean;
   getSearchMatch: (matchIndex: number) => TLogViewSearchMatch | null;
-  getSearchResults: (
-    options?: Readonly<{
-      offset?: number;
-      limit?: number;
-    }>,
-  ) => readonly TLogViewSearchResult[];
+  getSearchResults: (options?: TLogViewSearchResultsOptions) => readonly TLogViewSearchResult[];
   measureVisualIndex: () => void;
   getScrollMetrics: () => TLogViewScrollMetrics;
   getSearchMarkers: () => readonly TLogViewSearchMarker[];
@@ -224,6 +232,8 @@ const DEFAULT_VISUAL_INDEX_CAPACITY = 1_024;
 const DEFAULT_SEARCH_MAX_MATCHES = 10_000;
 const DEFAULT_SEARCH_SCAN_BUDGET_MS = 4;
 const DEFAULT_VISUAL_INDEX_MEASURE_BUDGET_MS = 4;
+const DEFAULT_SEARCH_RESULTS_PREVIEW_WIDTH = 80;
+const DEFAULT_SEARCH_RESULTS_CONTEXT_CELLS = 24;
 
 function clamp(n: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, n));
@@ -1306,6 +1316,68 @@ export const TLogView = defineComponent({
           .join("");
       }
       return sanitizeInlineText(props.source.getLine(index));
+    }
+
+    function normalizeSearchResultPreviewWidth(value: number | undefined): number {
+      const n = Math.floor(Number(value ?? DEFAULT_SEARCH_RESULTS_PREVIEW_WIDTH));
+      if (!Number.isFinite(n)) return DEFAULT_SEARCH_RESULTS_PREVIEW_WIDTH;
+      return Math.max(1, n);
+    }
+
+    function normalizeSearchResultContextCells(value: number | undefined): number {
+      const n = Math.floor(Number(value ?? DEFAULT_SEARCH_RESULTS_CONTEXT_CELLS));
+      if (!Number.isFinite(n)) return DEFAULT_SEARCH_RESULTS_CONTEXT_CELLS;
+      return Math.max(0, n);
+    }
+
+    function previewForMatch(
+      match: TLogViewSearchMatch,
+      count: number,
+      baseStyle: Style,
+      baseStyleKey: string,
+      options: Readonly<{
+        previewWidth: number;
+        contextCells: number;
+      }>,
+    ): TLogViewSearchResultPreview {
+      const text = searchableTextForLine(match.index, count, baseStyle, baseStyleKey);
+      const totalCells = textCellWidth(text);
+      const matchCells = Math.max(1, match.endCell - match.startCell);
+      const previewWidth = Math.max(options.previewWidth, matchCells);
+      const maxStart = Math.max(0, totalCells - previewWidth);
+      let startCell = Math.max(0, match.startCell - options.contextCells);
+      let endCell = Math.min(totalCells, match.endCell + options.contextCells);
+
+      if (endCell - startCell > previewWidth) {
+        const minStart = Math.max(0, match.endCell - previewWidth);
+        const maxVisibleStart = Math.min(match.startCell, maxStart);
+        startCell = clamp(startCell, minStart, maxVisibleStart);
+        endCell = Math.min(totalCells, startCell + previewWidth);
+      }
+
+      if (endCell - startCell < previewWidth && endCell < totalCells) {
+        endCell = Math.min(totalCells, startCell + previewWidth);
+      }
+      if (endCell - startCell < previewWidth && startCell > 0) {
+        startCell = Math.max(0, endCell - previewWidth);
+      }
+
+      let previewText = sliceByCellsRange(text, startCell, endCell);
+      let matchStartCell = match.startCell - startCell;
+      let matchEndCell = match.endCell - startCell;
+
+      if (startCell > 0) {
+        previewText = `…${previewText}`;
+        matchStartCell += 1;
+        matchEndCell += 1;
+      }
+      if (endCell < totalCells) previewText = `${previewText}…`;
+
+      return {
+        text: previewText,
+        matchStartCell,
+        matchEndCell,
+      };
     }
 
     function findLineSearchMatches(text: string, query: string): readonly TLogSearchLineMatch[] {
@@ -2665,10 +2737,7 @@ export const TLogView = defineComponent({
     }
 
     function getSearchResults(
-      options?: Readonly<{
-        offset?: number;
-        limit?: number;
-      }>,
+      options?: TLogViewSearchResultsOptions,
     ): readonly TLogViewSearchResult[] {
       const rawOffset = Number(options?.offset ?? 0);
       const rawLimit = Number(options?.limit ?? searchMatches.length);
@@ -2676,10 +2745,28 @@ export const TLogView = defineComponent({
       const limit = Number.isFinite(rawLimit)
         ? Math.max(0, Math.floor(rawLimit))
         : searchMatches.length;
+      const includePreview = options?.includePreview === true;
+
+      if (!includePreview) {
+        return searchMatches.slice(offset, offset + limit).map((match, index) => ({
+          matchIndex: offset + index,
+          match,
+        }));
+      }
+
+      const count = lineCount();
+      const base = props.style ?? defaultStyle.value;
+      const baseStyleKey = styleCacheKey(base);
+      const previewWidth = normalizeSearchResultPreviewWidth(options?.previewWidth);
+      const contextCells = normalizeSearchResultContextCells(options?.contextCells);
 
       return searchMatches.slice(offset, offset + limit).map((match, index) => ({
         matchIndex: offset + index,
         match,
+        preview: previewForMatch(match, count, base, baseStyleKey, {
+          previewWidth,
+          contextCells,
+        }),
       }));
     }
 

--- a/test/package-exports.test.ts
+++ b/test/package-exports.test.ts
@@ -18,12 +18,14 @@ describe("package exports", () => {
     expect("TVirtualList" in root).toBe(false);
     expect("TLogView" in root).toBe(false);
     expect("TLogScrollbar" in root).toBe(false);
+    expect("TLogSearchResults" in root).toBe(false);
     expect("createAppendOnlyLogStore" in root).toBe(false);
     expect(root.createFramePerfStore).toBeTruthy();
     expect(root.framePerfNow).toBeTruthy();
     expect(experimental.TVirtualList).toBeTruthy();
     expect(experimental.TLogView).toBeTruthy();
     expect(experimental.TLogScrollbar).toBeTruthy();
+    expect(experimental.TLogSearchResults).toBeTruthy();
     expect(experimental.createAppendOnlyLogStore).toBeTruthy();
   });
 
@@ -49,10 +51,12 @@ describe("package exports", () => {
     expect(experimental.TVirtualList).toBeTruthy();
     expect(experimental.TLogView).toBeTruthy();
     expect(experimental.TLogScrollbar).toBeTruthy();
+    expect(experimental.TLogSearchResults).toBeTruthy();
     expect(experimental.createAppendOnlyLogStore).toBeTruthy();
     expect(experimentalCjs.TVirtualList).toBeTruthy();
     expect(experimentalCjs.TLogView).toBeTruthy();
     expect(experimentalCjs.TLogScrollbar).toBeTruthy();
+    expect(experimentalCjs.TLogSearchResults).toBeTruthy();
     expect(experimentalCjs.createAppendOnlyLogStore).toBeTruthy();
   });
 });

--- a/test/tlog-search-results.test.ts
+++ b/test/tlog-search-results.test.ts
@@ -1,0 +1,360 @@
+import type { TLogDataSource, TLogSearchResultItem, TLogViewHandle } from "../src/experimental.js";
+import { describe, expect, it, vi } from "vitest";
+import { createTerminalApp } from "../src/index.js";
+import { TLogSearchResults, TLogView } from "../src/experimental.js";
+import {
+  defineComponent,
+  h,
+  mountTerminal,
+  nextTick,
+  onMounted,
+  ref,
+} from "./ui-regressions-support.js";
+
+function rowText(
+  mounted: { terminal: ReturnType<typeof createTerminalApp>["terminal"] },
+  y: number,
+): string {
+  return mounted.terminal
+    .getRow(y)
+    .map((cell) => cell.ch)
+    .join("")
+    .trimEnd();
+}
+
+function rowStyles(
+  mounted: { terminal: ReturnType<typeof createTerminalApp>["terminal"] },
+  y: number,
+) {
+  return mounted.terminal.getRow(y).map((cell) => cell.style);
+}
+
+async function flushSearch(
+  app: ReturnType<typeof createTerminalApp>,
+  handle: TLogViewHandle,
+  maxFrames = 20,
+): Promise<void> {
+  for (let i = 0; i < maxFrames; i++) {
+    await nextTick();
+    app.scheduler.flushNow();
+    if (handle.getSearchState().status !== "scanning") return;
+  }
+}
+
+describe("TLogSearchResults", () => {
+  it("renders result rows with line numbers and preview text", async () => {
+    const mounted = await mountTerminal(
+      () =>
+        h(TLogSearchResults, {
+          x: 0,
+          y: 0,
+          w: 24,
+          h: 2,
+          results: [
+            {
+              matchIndex: 0,
+              absoluteLineIndex: 1042,
+              lineIndex: 42,
+              text: "ERROR failed to connect…",
+              matchStartCell: 0,
+              matchEndCell: 5,
+            },
+            {
+              matchIndex: 1,
+              absoluteLineIndex: 1188,
+              lineIndex: 188,
+              text: "ERROR retry exhausted…",
+              matchStartCell: 0,
+              matchEndCell: 5,
+            },
+          ] satisfies readonly TLogSearchResultItem[],
+        }),
+      24,
+      2,
+    );
+
+    try {
+      expect(rowText(mounted, 0)).toBe("1042 ERROR failed to con");
+      expect(rowText(mounted, 1)).toBe("1188 ERROR retry exhaust");
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("composes active current and match styles", async () => {
+    const mounted = await mountTerminal(
+      () =>
+        h(TLogSearchResults, {
+          x: 0,
+          y: 0,
+          w: 20,
+          h: 1,
+          activeIndex: 0,
+          activeStyle: { inverse: true },
+          currentStyle: { bold: true },
+          matchStyle: { underline: true, fg: "yellow" },
+          results: [
+            {
+              matchIndex: 0,
+              absoluteLineIndex: 12,
+              lineIndex: 12,
+              text: "foo ERROR bar",
+              matchStartCell: 4,
+              matchEndCell: 9,
+              current: true,
+            },
+          ] satisfies readonly TLogSearchResultItem[],
+        }),
+      20,
+      1,
+    );
+
+    try {
+      const styles = rowStyles(mounted, 0);
+      expect(styles[0]).toMatchObject({ inverse: true, bold: true });
+      expect(styles[7]).toMatchObject({
+        inverse: true,
+        bold: true,
+        underline: true,
+        fg: "yellow",
+      });
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("emits select when clicking a row", async () => {
+    const onSelect = vi.fn();
+    const App = defineComponent({
+      name: "TLogSearchResultsClickApp",
+      setup() {
+        return () =>
+          h(TLogSearchResults, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 2,
+            results: [
+              {
+                matchIndex: 0,
+                absoluteLineIndex: 10,
+                lineIndex: 10,
+                text: "alpha",
+                matchStartCell: 0,
+                matchEndCell: 5,
+              },
+              {
+                matchIndex: 3,
+                absoluteLineIndex: 20,
+                lineIndex: 20,
+                text: "bravo",
+                matchStartCell: 0,
+                matchEndCell: 5,
+              },
+            ] satisfies readonly TLogSearchResultItem[],
+            onSelect,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 2, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "click", cellX: 0, cellY: 1, time: Date.now() } as any);
+      await nextTick();
+
+      expect(onSelect).toHaveBeenCalledWith({
+        matchIndex: 3,
+        result: expect.objectContaining({
+          absoluteLineIndex: 20,
+          text: "bravo",
+        }),
+      });
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("supports keyboard navigation and enter selection", async () => {
+    const onActiveChange = vi.fn();
+    const onSelect = vi.fn();
+    const App = defineComponent({
+      name: "TLogSearchResultsKeyboardApp",
+      setup() {
+        return () =>
+          h(TLogSearchResults, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 3,
+            results: [
+              {
+                matchIndex: 0,
+                absoluteLineIndex: 10,
+                lineIndex: 10,
+                text: "alpha",
+                matchStartCell: 0,
+                matchEndCell: 5,
+              },
+              {
+                matchIndex: 1,
+                absoluteLineIndex: 11,
+                lineIndex: 11,
+                text: "bravo",
+                matchStartCell: 0,
+                matchEndCell: 5,
+              },
+              {
+                matchIndex: 2,
+                absoluteLineIndex: 12,
+                lineIndex: 12,
+                text: "charlie",
+                matchStartCell: 0,
+                matchEndCell: 7,
+              },
+            ] satisfies readonly TLogSearchResultItem[],
+            onActiveChange,
+            onSelect,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 3, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "click", cellX: 0, cellY: 0, time: Date.now() } as any);
+      app.events.dispatch({
+        type: "keydown",
+        key: "ArrowDown",
+        code: "ArrowDown",
+        time: Date.now(),
+      } as any);
+      app.events.dispatch({
+        type: "keydown",
+        key: "Enter",
+        code: "Enter",
+        time: Date.now(),
+      } as any);
+      await nextTick();
+
+      expect(onActiveChange).toHaveBeenLastCalledWith({
+        activeIndex: 1,
+        result: expect.objectContaining({
+          matchIndex: 1,
+          text: "bravo",
+        }),
+      });
+      expect(onSelect).toHaveBeenLastCalledWith({
+        matchIndex: 1,
+        result: expect.objectContaining({
+          absoluteLineIndex: 11,
+        }),
+      });
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("integrates with TLogView via selectSearchMatch", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const results = ref<readonly TLogSearchResultItem[]>([]);
+    const activeIndex = ref(-1);
+    const query = ref("error");
+    const source: TLogDataSource = {
+      lineCount: () => 6,
+      getLine: (index) =>
+        ["line-0", "line-1", "error line-2", "line-3", "error line-4", "line-5"][index] ?? "",
+      getLineKey: (index) => `line-${index}`,
+    };
+
+    const App = defineComponent({
+      name: "TLogSearchResultsIntegrationApp",
+      setup() {
+        function refreshResults(): void {
+          const raw =
+            logView.value?.getSearchResults({
+              offset: 0,
+              limit: 10,
+              includePreview: true,
+              previewWidth: 18,
+            }) ?? [];
+          const state = logView.value?.getSearchState();
+          results.value = raw.map((entry) => ({
+            matchIndex: entry.matchIndex,
+            absoluteLineIndex: entry.match.absoluteLineIndex,
+            lineIndex: entry.match.index,
+            text: entry.preview?.text ?? "",
+            matchStartCell: entry.preview?.matchStartCell ?? 0,
+            matchEndCell: entry.preview?.matchEndCell ?? 0,
+            current: entry.matchIndex === state?.currentMatchIndex,
+          }));
+          activeIndex.value = raw.findIndex(
+            (entry) => entry.matchIndex === state?.currentMatchIndex,
+          );
+        }
+
+        function onSelect(payload: { matchIndex: number }): void {
+          logView.value?.selectSearchMatch(payload.matchIndex);
+          refreshResults();
+        }
+
+        onMounted(() => {
+          refreshResults();
+        });
+
+        return () =>
+          h("span", [
+            h(TLogView, {
+              ref: logView,
+              x: 0,
+              y: 0,
+              w: 20,
+              h: 4,
+              source,
+              version: 1,
+              searchQuery: query.value,
+              searchOptions: { scanBudgetMs: 1000 },
+              onSearch: refreshResults,
+              onSearchMatch: refreshResults,
+            }),
+            h(TLogSearchResults, {
+              x: 21,
+              y: 0,
+              w: 19,
+              h: 4,
+              results: results.value,
+              activeIndex: activeIndex.value,
+              onSelect,
+            }),
+          ]);
+      },
+    });
+
+    const app = createTerminalApp({ cols: 40, rows: 4, component: App });
+    try {
+      app.mount();
+      await flushSearch(app, logView.value!);
+
+      expect(results.value).toHaveLength(2);
+      app.events.dispatch({ type: "click", cellX: 21, cellY: 1, time: Date.now() } as any);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(logView.value!.getSearchState().currentMatchIndex).toBe(1);
+      expect(results.value[1]).toMatchObject({ current: true });
+      expect(
+        Array.from({ length: 4 }, (_, index) => rowText(app, index)).some((line) =>
+          line.startsWith("error line-4"),
+        ),
+      ).toBe(true);
+    } finally {
+      app.dispose();
+    }
+  });
+});

--- a/test/tlog-view.test.ts
+++ b/test/tlog-view.test.ts
@@ -7,7 +7,7 @@ import type {
   TLogViewSearchMarker,
 } from "../src/experimental.js";
 import { describe, expect, it, vi } from "vitest";
-import { createTerminalApp } from "../src/index.js";
+import { createTerminalApp, textCellWidth } from "../src/index.js";
 import { createAppendOnlyLogStore, TLogScrollbar, TLogView } from "../src/experimental.js";
 import {
   defineComponent,
@@ -1918,6 +1918,144 @@ describe("TLogView", () => {
       expect(logView.value!.getScrollMetrics()).toEqual(beforeMetrics);
       expect(onSearchMatch).not.toHaveBeenCalled();
       expect(getLine).not.toHaveBeenCalled();
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("getSearchResults can include preview text for the requested page only", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const getLine = vi.fn((index: number) => `line-${index} ERROR tail`);
+    const source: TLogDataSource = {
+      lineCount: () => 1_000,
+      getLine,
+      getLineKey: (index) => `line-${index}`,
+    };
+
+    const App = defineComponent({
+      name: "TLogViewSearchPreviewPageApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            ref: logView,
+            x: 0,
+            y: 0,
+            w: 32,
+            h: 4,
+            source,
+            version: 1,
+            searchQuery: "ERROR",
+            searchOptions: { scanBudgetMs: 1000 },
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 32, rows: 4, component: App });
+    try {
+      app.mount();
+      await flushSearch(app, logView.value!);
+
+      getLine.mockClear();
+      expect(
+        logView.value!.getSearchResults({ offset: 10, limit: 5, includePreview: true }),
+      ).toEqual(
+        Array.from({ length: 5 }, (_, index) => ({
+          matchIndex: 10 + index,
+          match: expect.objectContaining({
+            index: 10 + index,
+            absoluteLineIndex: 10 + index,
+            text: "ERROR",
+          }),
+          preview: expect.objectContaining({
+            text: expect.stringContaining("ERROR"),
+          }),
+        })),
+      );
+      expect(getLine).toHaveBeenCalledTimes(5);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("getSearchResults preview uses visible ANSI text without escape sequences", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const source: TLogDataSource = {
+      lineCount: () => 1,
+      getLine: () => "\x1b[31mERROR\x1b[0m failed",
+      getLineKey: () => "line",
+    };
+
+    const App = defineComponent({
+      name: "TLogViewSearchPreviewAnsiApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            ref: logView,
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 1,
+            source,
+            version: 1,
+            ansi: true,
+            searchQuery: "ERROR",
+            searchOptions: { scanBudgetMs: 1000 },
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 2, component: App });
+    try {
+      app.mount();
+      await flushSearch(app, logView.value!);
+
+      expect(logView.value!.getSearchResults({ includePreview: true })[0]).toMatchObject({
+        preview: {
+          text: "ERROR failed",
+          matchStartCell: 0,
+          matchEndCell: 5,
+        },
+      });
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("getSearchResults preview preserves wide-character cell offsets", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const source: TLogDataSource = {
+      lineCount: () => 1,
+      getLine: () => "ab中ERROR tail",
+      getLineKey: () => "line",
+    };
+
+    const App = defineComponent({
+      name: "TLogViewSearchPreviewWideCharApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            ref: logView,
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 1,
+            source,
+            version: 1,
+            searchQuery: "ERROR",
+            searchOptions: { scanBudgetMs: 1000 },
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 2, component: App });
+    try {
+      app.mount();
+      await flushSearch(app, logView.value!);
+
+      const preview = logView.value!.getSearchResults({ includePreview: true })[0]!.preview!;
+      expect(preview.text).toBe("ab中ERROR tail");
+      expect(preview.matchStartCell).toBe(textCellWidth("ab中"));
+      expect(preview.matchEndCell).toBe(textCellWidth("ab中ERROR"));
     } finally {
       app.dispose();
     }


### PR DESCRIPTION
## Summary

Add `TLogSearchResults` component and extend `TLogView.getSearchResults` with preview support.

### Changes

- **New `TLogSearchResults` component** — renders paginated search result previews with:
  - Line numbers and match highlighting (configurable `activeStyle`, `matchStyle`, `currentStyle`)
  - Keyboard navigation (`ArrowUp`/`ArrowDown`/`Home`/`End`) and click selection
  - `select` and `activeChange` events for integration with `TLogView`

- **Extended `TLogView.getSearchResults`** — new options:
  - `includePreview: true` to generate preview text for each match (off by default for performance)
  - `previewWidth` and `contextCells` to control preview window sizing
  - Preview uses visible ANSI text (no escape sequences) and preserves wide-character cell offsets

- **Exports** — new component and types (`TLogSearchResultItem`, `TLogSearchResultsSelectPayload`, `TLogViewSearchResultPreview`, `TLogViewSearchResultsOptions`) from `@simon_he/vue-tui/experimental`

- **Tests** — unit tests for component rendering, style composition, click/keyboard interaction, and TLogView preview integration

- **Docs** — updated component docs and generated API docs

### Usage

```vue
<TLogSearchResults
  :x="61" :y="0" :w="19" :h="20"
  :results="results"
  :active-index="activeIndex"
  @select="onSelect"
/>
```

See `docs/components.md` for the full example with `TLogView` integration.