### PR TITLE
feat(TLogMinimap): add compact overview minimap component

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -8,15 +8,15 @@
 
 ## 组件速读
 
-| 类别          | 组件                                                                      | 典型用途                                        | 适配性判断                                         |
-| ------------- | ------------------------------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------- |
-| Root          | `TerminalProvider`                                                        | 创建 terminal / renderer / event manager 上下文 | 通用，适合所有宿主                                 |
-| Layout        | `TBox` `TView` `TAnchor` `TFlow` `TRenderLayer` `TRenderPlane`            | 布局、裁剪、层级、分层组合                      | 通用，和 CLI 业务无关                              |
-| Text / Motion | `TText` `TTransition`                                                     | 文本渲染、状态切换、动画插值                    | 通用                                               |
-| Input         | `TInput` `TInputBox` `TJsonEditor`                                        | prompt、表单、结构化文本编辑                    | 通用，但推荐把补全/校验放到插件层                  |
-| Pickers       | `TList` `TVirtualList` `TLogView` `TLogScrollbar` `TSelect` `TPathPicker` | palette、列表、日志、路径选择                   | `TPathPicker` 本体可复用，路径语义由 provider 注入 |
-| Overlay       | `TDialog` `TMultilineModal` `TDebugOverlay`                               | 对话框、详情查看、调试覆盖层                    | 通用，适合多种宿主                                 |
-| Navigation    | `TRouterView` + `createTerminalRouter()`                                  | 多页面 TUI / shell                              | 通用                                               |
+| 类别          | 组件                                                                                    | 典型用途                                        | 适配性判断                                         |
+| ------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------- |
+| Root          | `TerminalProvider`                                                                      | 创建 terminal / renderer / event manager 上下文 | 通用，适合所有宿主                                 |
+| Layout        | `TBox` `TView` `TAnchor` `TFlow` `TRenderLayer` `TRenderPlane`                          | 布局、裁剪、层级、分层组合                      | 通用，和 CLI 业务无关                              |
+| Text / Motion | `TText` `TTransition`                                                                   | 文本渲染、状态切换、动画插值                    | 通用                                               |
+| Input         | `TInput` `TInputBox` `TJsonEditor`                                                      | prompt、表单、结构化文本编辑                    | 通用，但推荐把补全/校验放到插件层                  |
+| Pickers       | `TList` `TVirtualList` `TLogView` `TLogScrollbar` `TLogMinimap` `TSelect` `TPathPicker` | palette、列表、日志、路径选择                   | `TPathPicker` 本体可复用，路径语义由 provider 注入 |
+| Overlay       | `TDialog` `TMultilineModal` `TDebugOverlay`                                             | 对话框、详情查看、调试覆盖层                    | 通用，适合多种宿主                                 |
+| Navigation    | `TRouterView` + `createTerminalRouter()`                                                | 多页面 TUI / shell                              | 通用                                               |
 
 如果你更关心“哪些地方还应该继续做插件化”，建议配合阅读：[扩展性与插件化](./extensibility.md)。
 
@@ -599,6 +599,97 @@ onMounted(refreshMetrics);
   :markers="markers"
   @scrollTo="scrollTo"
   @scrollBy="scrollBy"
+  @markerClick="onMarkerClick"
+/>
+```
+
+### TLogMinimap
+
+`TLogMinimap` 是一个 experimental compact overview companion 组件，用来把 retained visual rows 压缩成 1 列或多列 overview。它只消费父组件传入的 `metrics`、`markers` 和可选 `density` buckets，不会直接读取 `TLogView` 或 log source，也不会尝试渲染真实文本缩略图。
+
+- `metrics` 通常来自 `logView.value?.getScrollMetrics()`
+- `markers` 通常来自 `logView.value?.getSearchMarkers()`；minimap 只根据 `visualRow` / `current` / `estimated` 渲染
+- `density` 是应用层聚合结果，例如日志密度、错误密度或搜索结果密度；`TLogView` 不会自动生成
+- 点击空白 row 会 emit `{ visualRow, cellX, cellY }` 的 `scrollTo`
+- 点击 marker row 会 emit `markerClick`，且不会额外触发 `scrollTo`
+- 第一版只做 overview，不做 hover tooltip、拖拽 viewport 或 content minimap
+
+```vue
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import {
+  TLogMinimap,
+  TLogView,
+  type TLogMinimapDensityBucket,
+  type TLogMinimapMarker,
+  type TLogViewHandle,
+  type TLogViewScrollMetrics,
+  type TLogViewSearchMarker,
+} from "@simon_he/vue-tui/experimental";
+
+const logView = ref<TLogViewHandle | null>(null);
+const metrics = ref<TLogViewScrollMetrics | null>(null);
+const markers = ref<readonly TLogMinimapMarker[]>([]);
+const density = ref<readonly TLogMinimapDensityBucket[]>([]);
+const query = ref("ERROR");
+
+function refreshOverview() {
+  metrics.value = logView.value?.getScrollMetrics() ?? null;
+  markers.value =
+    logView.value?.getSearchMarkers().map((marker) => ({
+      id: marker.matchIndex,
+      visualRow: marker.visualRow,
+      current: marker.current,
+      estimated: marker.estimated,
+      payload: marker,
+    })) ?? [];
+  density.value = [
+    { startVisualRow: 0, endVisualRow: 40, value: 0.15 },
+    { startVisualRow: 41, endVisualRow: 120, value: 0.55 },
+    { startVisualRow: 121, endVisualRow: 200, value: 0.9 },
+  ];
+}
+
+function onMarkerClick(payload: {
+  marker: TLogMinimapMarker & { payload?: TLogViewSearchMarker };
+}) {
+  const marker = payload.marker.payload;
+  if (!marker) return;
+  logView.value?.selectSearchMatch(marker.matchIndex, {
+    align: "center",
+  });
+  refreshOverview();
+}
+
+onMounted(refreshOverview);
+</script>
+
+<TLogView
+  ref="logView"
+  :x="0"
+  :y="0"
+  :w="78"
+  :h="20"
+  :source="log.source"
+  :version="log.version"
+  wrap
+  visual-index-mode="exact"
+  :search-query="query"
+  @scroll="refreshOverview"
+  @visualIndex="refreshOverview"
+  @searchMarkers="refreshOverview"
+  @searchMatch="refreshOverview"
+/>
+
+<TLogMinimap
+  :x="78"
+  :y="0"
+  :w="2"
+  :h="20"
+  :metrics="metrics"
+  :markers="markers"
+  :density="density"
+  @scrollTo="({ visualRow }) => logView?.scrollToVisualRow(visualRow)"
   @markerClick="onMarkerClick"
 />
 ```

--- a/docs/generated/components-api.md
+++ b/docs/generated/components-api.md
@@ -14,6 +14,7 @@
 - [TInputBox](#tinputbox)
 - [TJsonEditor](#tjsoneditor)
 - [TList](#tlist)
+- [TLogMinimap](#tlogminimap)
 - [TLogScrollbar](#tlogscrollbar)
 - [TLogSearchResults](#tlogsearchresults)
 - [TLogView](#tlogview)
@@ -383,6 +384,39 @@
 | <code>focus</code>             | —       | —    |
 | <code>blur</code>              | —       | —    |
 | <code>keydown</code>           | —       | —    |
+
+## TLogMinimap
+
+源码：`src/vue/components/TLogMinimap.ts`
+
+### Props
+
+| 名称                            | 类型                                             | 默认值                   | 必填 | 说明 |
+| ------------------------------- | ------------------------------------------------ | ------------------------ | ---- | ---- |
+| <code>x</code>                  | <code>number</code>                              | —                        | 是   | —    |
+| <code>y</code>                  | <code>number</code>                              | —                        | 是   | —    |
+| <code>w</code>                  | <code>number</code>                              | —                        | 是   | —    |
+| <code>h</code>                  | <code>number</code>                              | —                        | 是   | —    |
+| <code>zIndex</code>             | <code>number</code>                              | <code>0</code>           | 否   | —    |
+| <code>metrics</code>            | <code>TLogMinimapMetrics &#124; null</code>      | <code>null</code>        | 否   | —    |
+| <code>markers</code>            | <code>readonly TLogMinimapMarker[]</code>        | <code>() =&gt; []</code> | 否   | —    |
+| <code>density</code>            | <code>readonly TLogMinimapDensityBucket[]</code> | <code>() =&gt; []</code> | 否   | —    |
+| <code>style</code>              | <code>Style</code>                               | <code>undefined</code>   | 否   | —    |
+| <code>densityStyle</code>       | <code>Style</code>                               | <code>undefined</code>   | 否   | —    |
+| <code>markerStyle</code>        | <code>Style</code>                               | <code>undefined</code>   | 否   | —    |
+| <code>currentMarkerStyle</code> | <code>Style</code>                               | <code>undefined</code>   | 否   | —    |
+| <code>viewportStyle</code>      | <code>Style</code>                               | <code>undefined</code>   | 否   | —    |
+| <code>estimatedStyle</code>     | <code>Style</code>                               | <code>undefined</code>   | 否   | —    |
+| <code>showMarkers</code>        | <code>boolean</code>                             | <code>true</code>        | 否   | —    |
+| <code>showDensity</code>        | <code>boolean</code>                             | <code>true</code>        | 否   | —    |
+| <code>showViewport</code>       | <code>boolean</code>                             | <code>true</code>        | 否   | —    |
+
+### Events
+
+| 名称                     | Payload | 说明 |
+| ------------------------ | ------- | ---- |
+| <code>scrollTo</code>    | —       | —    |
+| <code>markerClick</code> | —       | —    |
 
 ## TLogScrollbar
 

--- a/src/experimental.ts
+++ b/src/experimental.ts
@@ -1,9 +1,17 @@
 export { TVirtualList } from "./vue/components/TVirtualList.js";
 export { TLogView } from "./vue/components/TLogView.js";
 export { TLogScrollbar } from "./vue/components/TLogScrollbar.js";
+export { TLogMinimap } from "./vue/components/TLogMinimap.js";
 export { TLogSearchResults } from "./vue/components/TLogSearchResults.js";
 export { createAppendOnlyLogStore } from "./vue/log/append-only-log-store.js";
 export type { RowScrollMode } from "./vue/components/TVirtualList.js";
+export type {
+  TLogMinimapClickPayload,
+  TLogMinimapDensityBucket,
+  TLogMinimapMarker,
+  TLogMinimapMarkerClickPayload,
+  TLogMinimapMetrics,
+} from "./vue/components/TLogMinimap.js";
 export type {
   TLogScrollbarMetrics,
   TLogScrollbarMarker,

--- a/src/vue/components/TLogMinimap.ts
+++ b/src/vue/components/TLogMinimap.ts
@@ -1,0 +1,418 @@
+import type { PropType } from "vue";
+import type { Style } from "../../core/types.js";
+import type { Rect, TerminalPointerEvent } from "../../events/index.js";
+import type { TLogViewScrollMetrics } from "./TLogView.js";
+import { computed, defineComponent, h, inject } from "vue";
+import { useLayout } from "../composables/use-layout.js";
+import { useRenderNode } from "../composables/use-render-node.js";
+import { useTerminalNode } from "../composables/use-terminal-node.js";
+import { useTerminal } from "../composables/use-terminal.js";
+import { useVisibility } from "../composables/use-visibility.js";
+import { EventZIndexContextKey } from "../context.js";
+import { intersectRect, translateRect } from "../utils/rect.js";
+
+const EMPTY_RECT: Rect = Object.freeze({ x: 0, y: 0, w: 0, h: 0 });
+const CURRENT_MARKER_CHAR = "◆";
+const MARKER_CHAR = "•";
+const ESTIMATED_MARKER_CHAR = "·";
+const VIEWPORT_CHAR = "█";
+const DENSITY_HIGH_CHAR = "▓";
+const DENSITY_MEDIUM_CHAR = "▒";
+const DENSITY_LOW_CHAR = "░";
+
+export type TLogMinimapMetrics = TLogViewScrollMetrics;
+export type TLogMinimapMarker = Readonly<{
+  id?: string | number;
+  visualRow: number;
+  current?: boolean;
+  estimated?: boolean;
+  payload?: unknown;
+}>;
+export type TLogMinimapDensityBucket = Readonly<{
+  startVisualRow: number;
+  endVisualRow: number;
+  value: number;
+}>;
+export type TLogMinimapClickPayload = Readonly<{
+  visualRow: number;
+  cellX: number;
+  cellY: number;
+}>;
+export type TLogMinimapMarkerClickPayload = Readonly<{
+  marker: TLogMinimapMarker;
+  markerIndex: number;
+  visualRow: number;
+  cellX: number;
+  cellY: number;
+}>;
+
+type TLogMinimapMarkerHit = Readonly<{
+  marker: TLogMinimapMarker;
+  index: number;
+}>;
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function normalizeInt(value: number): number {
+  const n = Math.floor(Number(value));
+  return Number.isFinite(n) ? n : 0;
+}
+
+function normalizeDensity(value: number): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? clamp(n, 0, 1) : 0;
+}
+
+function mergeStyle(base: Style, overlay?: Style): Style {
+  return overlay ? { ...base, ...overlay } : base;
+}
+
+function totalVisualRows(metrics: TLogMinimapMetrics): number {
+  return Math.max(normalizeInt(metrics.visualRowCount), normalizeInt(metrics.viewportRows), 1);
+}
+
+function visualToLocalY(
+  visualRow: number,
+  metrics: TLogMinimapMetrics,
+  height: number,
+): number | null {
+  const normalizedHeight = normalizeInt(height);
+  if (normalizedHeight <= 0) return null;
+
+  const total = totalVisualRows(metrics);
+  const maxVisual = Math.max(1, total - 1);
+  const row = clamp(normalizeInt(visualRow), 0, maxVisual);
+  return Math.round((row / maxVisual) * (normalizedHeight - 1));
+}
+
+function localYToVisualRow(localY: number, metrics: TLogMinimapMetrics, height: number): number {
+  const normalizedHeight = normalizeInt(height);
+  if (normalizedHeight <= 1) return 0;
+
+  const total = totalVisualRows(metrics);
+  const ratio = clamp(normalizeInt(localY), 0, normalizedHeight - 1) / (normalizedHeight - 1);
+  return Math.round(ratio * Math.max(0, total - 1));
+}
+
+function visualRangeToLocalRange(
+  startVisualRow: number,
+  endVisualRow: number,
+  metrics: TLogMinimapMetrics,
+  height: number,
+): Readonly<{
+  top: number;
+  bottom: number;
+}> | null {
+  const start = visualToLocalY(startVisualRow, metrics, height);
+  const end = visualToLocalY(endVisualRow, metrics, height);
+  if (start == null || end == null) return null;
+  return {
+    top: Math.min(start, end),
+    bottom: Math.max(start, end),
+  };
+}
+
+function viewportRange(
+  metrics: TLogMinimapMetrics | null | undefined,
+  height: number,
+): Readonly<{
+  top: number;
+  bottom: number;
+}> | null {
+  if (!metrics) return null;
+  const scrollTop = clamp(
+    normalizeInt(metrics.scrollTop),
+    0,
+    Math.max(0, totalVisualRows(metrics) - 1),
+  );
+  const viewportRows = Math.max(1, normalizeInt(metrics.viewportRows));
+  return visualRangeToLocalRange(scrollTop, scrollTop + viewportRows - 1, metrics, height);
+}
+
+function markerPriority(marker: TLogMinimapMarker): number {
+  if (marker.current) return 2;
+  if (!marker.estimated) return 1;
+  return 0;
+}
+
+function collectMarkersByRow(
+  markers: readonly TLogMinimapMarker[],
+  metrics: TLogMinimapMetrics | null | undefined,
+  height: number,
+): ReadonlyMap<number, TLogMinimapMarkerHit> {
+  if (!metrics || !markers.length || normalizeInt(height) <= 0) return new Map();
+
+  const rows = new Map<number, TLogMinimapMarkerHit>();
+  for (let i = 0; i < markers.length; i++) {
+    const marker = markers[i]!;
+    const row = visualToLocalY(marker.visualRow, metrics, height);
+    if (row == null) continue;
+
+    const previous = rows.get(row);
+    if (!previous || markerPriority(marker) > markerPriority(previous.marker)) {
+      rows.set(row, { marker, index: i });
+    }
+  }
+
+  return rows;
+}
+
+function collectDensityByRow(
+  density: readonly TLogMinimapDensityBucket[],
+  metrics: TLogMinimapMetrics | null | undefined,
+  height: number,
+): readonly number[] {
+  const normalizedHeight = normalizeInt(height);
+  if (!metrics || !density.length || normalizedHeight <= 0) return [];
+
+  const rows = Array.from({ length: normalizedHeight }, () => 0);
+  for (const bucket of density) {
+    const range = visualRangeToLocalRange(
+      bucket.startVisualRow,
+      bucket.endVisualRow,
+      metrics,
+      normalizedHeight,
+    );
+    if (!range) continue;
+    const value = normalizeDensity(bucket.value);
+    for (let row = range.top; row <= range.bottom; row++) {
+      rows[row] = Math.max(rows[row] ?? 0, value);
+    }
+  }
+
+  return rows;
+}
+
+function densityChar(value: number): string {
+  if (value >= 0.66) return DENSITY_HIGH_CHAR;
+  if (value >= 0.33) return DENSITY_MEDIUM_CHAR;
+  if (value > 0) return DENSITY_LOW_CHAR;
+  return " ";
+}
+
+export const TLogMinimap = defineComponent({
+  name: "TLogMinimap",
+  props: {
+    x: { type: Number, required: true },
+    y: { type: Number, required: true },
+    w: { type: Number, required: true },
+    h: { type: Number, required: true },
+    zIndex: { type: Number, default: 0 },
+    metrics: {
+      type: Object as PropType<TLogMinimapMetrics | null>,
+      default: null,
+    },
+    markers: {
+      type: Array as PropType<readonly TLogMinimapMarker[]>,
+      default: () => [],
+    },
+    density: {
+      type: Array as PropType<readonly TLogMinimapDensityBucket[]>,
+      default: () => [],
+    },
+    style: { type: Object as PropType<Style>, default: undefined },
+    densityStyle: { type: Object as PropType<Style>, default: undefined },
+    markerStyle: { type: Object as PropType<Style>, default: undefined },
+    currentMarkerStyle: { type: Object as PropType<Style>, default: undefined },
+    viewportStyle: { type: Object as PropType<Style>, default: undefined },
+    estimatedStyle: { type: Object as PropType<Style>, default: undefined },
+    showMarkers: { type: Boolean, default: true },
+    showDensity: { type: Boolean, default: true },
+    showViewport: { type: Boolean, default: true },
+  },
+  emits: ["scrollTo", "markerClick"],
+  setup(props, { emit }) {
+    const { terminal, defaultStyle } = useTerminal();
+    const parent = useLayout();
+    const { visible, rootProps } = useVisibility();
+    const parentEventZ = inject(EventZIndexContextKey, computed(() => 0) as any);
+    const eventZ = computed(() => (parentEventZ.value ?? 0) + (props.zIndex ?? 0));
+
+    const fullRect = computed<Rect>(() =>
+      translateRect(
+        {
+          x: normalizeInt(props.x),
+          y: normalizeInt(props.y),
+          w: Math.max(0, normalizeInt(props.w)),
+          h: Math.max(0, normalizeInt(props.h)),
+        },
+        parent.originX,
+        parent.originY,
+      ),
+    );
+
+    const rect = computed<Rect>(() => {
+      const translated = fullRect.value;
+      if (!parent.clipRect) return translated;
+      return intersectRect(translated, parent.clipRect) ?? EMPTY_RECT;
+    });
+
+    function onClick(e: TerminalPointerEvent): void {
+      const metrics = props.metrics;
+      if (!metrics) return;
+
+      const full = fullRect.value;
+      const localY = e.cellY - full.y;
+      if (localY < 0 || localY >= full.h) return;
+
+      const markerHit = props.showMarkers
+        ? collectMarkersByRow(props.markers, metrics, full.h).get(localY)
+        : undefined;
+      if (markerHit) {
+        emit("markerClick", {
+          marker: markerHit.marker,
+          markerIndex: markerHit.index,
+          visualRow: markerHit.marker.visualRow,
+          cellX: e.cellX,
+          cellY: e.cellY,
+        } satisfies TLogMinimapMarkerClickPayload);
+        e.preventDefault?.();
+        return;
+      }
+
+      emit("scrollTo", {
+        visualRow: localYToVisualRow(localY, metrics, full.h),
+        cellX: e.cellX,
+        cellY: e.cellY,
+      } satisfies TLogMinimapClickPayload);
+      e.preventDefault?.();
+    }
+
+    useTerminalNode(() => ({
+      rect: rect.value,
+      zIndex: eventZ.value,
+      visible: visible.value,
+      focusable: false,
+      handlers: {
+        click: onClick,
+      },
+    }));
+
+    useRenderNode(() => ({
+      zIndex: props.zIndex,
+      rect: visible.value ? rect.value : EMPTY_RECT,
+      deps: [
+        visible.value,
+        rect.value,
+        fullRect.value,
+        props.metrics,
+        props.markers,
+        props.density,
+        props.style,
+        props.densityStyle,
+        props.markerStyle,
+        props.currentMarkerStyle,
+        props.viewportStyle,
+        props.estimatedStyle,
+        props.showMarkers,
+        props.showDensity,
+        props.showViewport,
+        defaultStyle.value,
+      ],
+      paint: (dirtyRows) => {
+        if (!visible.value) return;
+        const r = rect.value;
+        if (r.w <= 0 || r.h <= 0) return;
+
+        const full = fullRect.value;
+        const baseStyle = props.style ?? defaultStyle.value;
+        const densityStyle = mergeStyle(baseStyle, props.densityStyle ?? { dim: true });
+        const viewportStyle = mergeStyle(baseStyle, props.viewportStyle ?? { inverse: true });
+        const markerStyle = mergeStyle(baseStyle, props.markerStyle ?? { fg: "yellowBright" });
+        const currentMarkerStyle = mergeStyle(
+          baseStyle,
+          props.currentMarkerStyle ?? { fg: "redBright", bold: true },
+        );
+        const estimatedMarkerStyle = mergeStyle(markerStyle, props.estimatedStyle ?? { dim: true });
+        const viewport = props.showViewport ? viewportRange(props.metrics, full.h) : null;
+        const markersByRow = props.showMarkers
+          ? collectMarkersByRow(props.markers, props.metrics, full.h)
+          : new Map<number, TLogMinimapMarkerHit>();
+        const densityByRow = props.showDensity
+          ? collectDensityByRow(props.density, props.metrics, full.h)
+          : [];
+        const overviewColumn = full.w <= 0 ? -1 : full.w - 1;
+
+        const paintRow = (y: number): void => {
+          if (y < r.y || y >= r.y + r.h) return;
+          const localY = y - full.y;
+          if (localY < 0 || localY >= full.h) return;
+
+          const markerHit = markersByRow.get(localY);
+          const densityValue = densityByRow[localY] ?? 0;
+          const inViewport =
+            viewport != null && localY >= viewport.top && localY <= viewport.bottom;
+
+          for (let x = r.x; x < r.x + r.w; x++) {
+            const localX = x - full.x;
+            if (localX < 0 || localX >= full.w) continue;
+
+            let char = " ";
+            let style = baseStyle;
+            if (full.w <= 1) {
+              if (densityValue > 0) {
+                char = densityChar(densityValue);
+                style = mergeStyle(style, densityStyle);
+              }
+              if (inViewport) {
+                char = VIEWPORT_CHAR;
+                style = mergeStyle(style, viewportStyle);
+              }
+              if (markerHit) {
+                char = markerHit.marker.current
+                  ? CURRENT_MARKER_CHAR
+                  : markerHit.marker.estimated
+                    ? ESTIMATED_MARKER_CHAR
+                    : MARKER_CHAR;
+                style = mergeStyle(
+                  style,
+                  markerHit.marker.current
+                    ? currentMarkerStyle
+                    : markerHit.marker.estimated
+                      ? estimatedMarkerStyle
+                      : markerStyle,
+                );
+              }
+            } else {
+              if (inViewport) style = mergeStyle(style, viewportStyle);
+              if (localX === overviewColumn) {
+                if (markerHit) {
+                  char = markerHit.marker.current
+                    ? CURRENT_MARKER_CHAR
+                    : markerHit.marker.estimated
+                      ? ESTIMATED_MARKER_CHAR
+                      : MARKER_CHAR;
+                  style = mergeStyle(
+                    style,
+                    markerHit.marker.current
+                      ? currentMarkerStyle
+                      : markerHit.marker.estimated
+                        ? estimatedMarkerStyle
+                        : markerStyle,
+                  );
+                } else if (inViewport) {
+                  char = VIEWPORT_CHAR;
+                }
+              } else if (densityValue > 0) {
+                char = densityChar(densityValue);
+                style = mergeStyle(style, densityStyle);
+              }
+            }
+
+            terminal.put(x, y, char, style);
+          }
+        };
+
+        if (!dirtyRows) {
+          for (let y = r.y; y < r.y + r.h; y++) paintRow(y);
+          return;
+        }
+        for (const y of dirtyRows) paintRow(y);
+      },
+    }));
+
+    return () => h("span", rootProps);
+  },
+});

--- a/test/package-exports.test.ts
+++ b/test/package-exports.test.ts
@@ -18,6 +18,7 @@ describe("package exports", () => {
     expect("TVirtualList" in root).toBe(false);
     expect("TLogView" in root).toBe(false);
     expect("TLogScrollbar" in root).toBe(false);
+    expect("TLogMinimap" in root).toBe(false);
     expect("TLogSearchResults" in root).toBe(false);
     expect("createAppendOnlyLogStore" in root).toBe(false);
     expect(root.createFramePerfStore).toBeTruthy();
@@ -25,6 +26,7 @@ describe("package exports", () => {
     expect(experimental.TVirtualList).toBeTruthy();
     expect(experimental.TLogView).toBeTruthy();
     expect(experimental.TLogScrollbar).toBeTruthy();
+    expect(experimental.TLogMinimap).toBeTruthy();
     expect(experimental.TLogSearchResults).toBeTruthy();
     expect(experimental.createAppendOnlyLogStore).toBeTruthy();
   });
@@ -51,11 +53,13 @@ describe("package exports", () => {
     expect(experimental.TVirtualList).toBeTruthy();
     expect(experimental.TLogView).toBeTruthy();
     expect(experimental.TLogScrollbar).toBeTruthy();
+    expect(experimental.TLogMinimap).toBeTruthy();
     expect(experimental.TLogSearchResults).toBeTruthy();
     expect(experimental.createAppendOnlyLogStore).toBeTruthy();
     expect(experimentalCjs.TVirtualList).toBeTruthy();
     expect(experimentalCjs.TLogView).toBeTruthy();
     expect(experimentalCjs.TLogScrollbar).toBeTruthy();
+    expect(experimentalCjs.TLogMinimap).toBeTruthy();
     expect(experimentalCjs.TLogSearchResults).toBeTruthy();
     expect(experimentalCjs.createAppendOnlyLogStore).toBeTruthy();
   });

--- a/test/tlog-minimap.test.ts
+++ b/test/tlog-minimap.test.ts
@@ -1,0 +1,396 @@
+import type {
+  TLogDataSource,
+  TLogMinimapClickPayload,
+  TLogMinimapMarker,
+  TLogViewHandle,
+  TLogViewScrollMetrics,
+  TLogViewSearchMarker,
+} from "../src/experimental.js";
+import { describe, expect, it, vi } from "vitest";
+import { createTerminalApp } from "../src/index.js";
+import { TLogMinimap, TLogView } from "../src/experimental.js";
+import {
+  defineComponent,
+  h,
+  mountTerminal,
+  nextTick,
+  onMounted,
+  ref,
+} from "./ui-regressions-support.js";
+
+function cell(
+  mounted: { terminal: ReturnType<typeof createTerminalApp>["terminal"] },
+  x: number,
+  y: number,
+) {
+  return mounted.terminal.getRow(y)[x]!;
+}
+
+function columnChars(
+  mounted: { terminal: ReturnType<typeof createTerminalApp>["terminal"] },
+  x: number,
+  height: number,
+): string {
+  return Array.from({ length: height }, (_, y) => cell(mounted, x, y).ch).join("");
+}
+
+function rowText(
+  mounted: { terminal: ReturnType<typeof createTerminalApp>["terminal"] },
+  y: number,
+  width?: number,
+): string {
+  const row = mounted.terminal.getRow(y);
+  return row
+    .slice(0, width ?? row.length)
+    .map((entry) => entry.ch)
+    .join("")
+    .trimEnd();
+}
+
+function createMetrics(overrides: Partial<TLogViewScrollMetrics> = {}): TLogViewScrollMetrics {
+  const scrollTop = overrides.scrollTop ?? 0;
+  const maxScrollTop = overrides.maxScrollTop ?? 10;
+  return {
+    scrollTop,
+    maxScrollTop,
+    viewportRows: overrides.viewportRows ?? 10,
+    lineCount: overrides.lineCount ?? 20,
+    firstLineIndex: overrides.firstLineIndex ?? 0,
+    estimatedVisualRowCount: overrides.estimatedVisualRowCount ?? 20,
+    visualRowCount: overrides.visualRowCount ?? 20,
+    measuredVisualRowCount: overrides.measuredVisualRowCount ?? 20,
+    measuredLineCount: overrides.measuredLineCount ?? 20,
+    visualIndexStatus: overrides.visualIndexStatus ?? "exact",
+    atTop: overrides.atTop ?? scrollTop <= 0,
+    atBottom: overrides.atBottom ?? scrollTop >= maxScrollTop,
+  };
+}
+
+async function flushSearch(
+  app: ReturnType<typeof createTerminalApp>,
+  handle: TLogViewHandle,
+  maxFrames = 20,
+): Promise<void> {
+  for (let i = 0; i < maxFrames; i++) {
+    await nextTick();
+    app.scheduler.flushNow();
+    if (handle.getSearchState().status !== "scanning") return;
+  }
+}
+
+describe("TLogMinimap", () => {
+  it("renders the viewport window in the overview column", async () => {
+    const mounted = await mountTerminal(
+      () =>
+        h(TLogMinimap, {
+          x: 0,
+          y: 0,
+          w: 2,
+          h: 10,
+          metrics: createMetrics({
+            scrollTop: 40,
+            maxScrollTop: 70,
+            viewportRows: 30,
+            visualRowCount: 100,
+            estimatedVisualRowCount: 100,
+            measuredVisualRowCount: 100,
+          }),
+        }),
+      2,
+      10,
+    );
+
+    try {
+      expect(columnChars(mounted, 1, 10)).toBe("    ███   ");
+      expect(cell(mounted, 0, 5).style).toMatchObject({ inverse: true });
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("renders estimated exact and current markers with stable row priority", async () => {
+    const mounted = await mountTerminal(
+      () =>
+        h(TLogMinimap, {
+          x: 0,
+          y: 0,
+          w: 1,
+          h: 10,
+          metrics: createMetrics({
+            maxScrollTop: 90,
+            viewportRows: 10,
+            visualRowCount: 100,
+            estimatedVisualRowCount: 100,
+            measuredVisualRowCount: 100,
+          }),
+          markers: [
+            { visualRow: 25, estimated: true },
+            { visualRow: 50 },
+            { visualRow: 80, current: true },
+          ] satisfies readonly TLogMinimapMarker[],
+          showViewport: false,
+        }),
+      1,
+      10,
+    );
+
+    try {
+      expect(columnChars(mounted, 0, 10)).toBe("  ·  • ◆  ");
+      expect(cell(mounted, 0, 2).style).toMatchObject({ fg: "yellowBright", dim: true });
+      expect(cell(mounted, 0, 5).style).toMatchObject({ fg: "yellowBright" });
+      expect(cell(mounted, 0, 7).style).toMatchObject({ fg: "redBright", bold: true });
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("renders density buckets on dedicated density columns", async () => {
+    const mounted = await mountTerminal(
+      () =>
+        h(TLogMinimap, {
+          x: 0,
+          y: 0,
+          w: 2,
+          h: 10,
+          metrics: createMetrics({
+            maxScrollTop: 90,
+            viewportRows: 10,
+            visualRowCount: 100,
+            estimatedVisualRowCount: 100,
+            measuredVisualRowCount: 100,
+          }),
+          density: [
+            { startVisualRow: 0, endVisualRow: 32, value: 0.2 },
+            { startVisualRow: 33, endVisualRow: 65, value: 0.5 },
+            { startVisualRow: 66, endVisualRow: 99, value: 0.9 },
+          ],
+          showViewport: false,
+        }),
+      2,
+      10,
+    );
+
+    try {
+      expect(columnChars(mounted, 0, 10)).toBe("░░░▒▒▒▓▓▓▓");
+      expect(columnChars(mounted, 1, 10)).toBe("          ");
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("emits markerClick instead of scrollTo when a marker row is clicked", async () => {
+    const onScrollTo = vi.fn();
+    const onMarkerClick = vi.fn();
+    const markers = [{ id: "m1", visualRow: 50, payload: { kind: "match" } }] as const;
+    const App = defineComponent({
+      name: "TLogMinimapMarkerClickApp",
+      setup() {
+        return () =>
+          h(TLogMinimap, {
+            x: 0,
+            y: 0,
+            w: 2,
+            h: 10,
+            metrics: createMetrics({
+              maxScrollTop: 90,
+              viewportRows: 10,
+              visualRowCount: 100,
+              estimatedVisualRowCount: 100,
+              measuredVisualRowCount: 100,
+            }),
+            markers,
+            onScrollTo,
+            onMarkerClick,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 2, rows: 10, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "click", cellX: 0, cellY: 5 } as any);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(onMarkerClick).toHaveBeenCalledWith({
+        marker: markers[0],
+        markerIndex: 0,
+        visualRow: 50,
+        cellX: 0,
+        cellY: 5,
+      });
+      expect(onScrollTo).not.toHaveBeenCalled();
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("emits scrollTo for non-marker rows", async () => {
+    const onScrollTo = vi.fn();
+    const App = defineComponent({
+      name: "TLogMinimapScrollToApp",
+      setup() {
+        return () =>
+          h(TLogMinimap, {
+            x: 0,
+            y: 0,
+            w: 2,
+            h: 10,
+            metrics: createMetrics({
+              maxScrollTop: 90,
+              viewportRows: 10,
+              visualRowCount: 100,
+              estimatedVisualRowCount: 100,
+              measuredVisualRowCount: 100,
+            }),
+            onScrollTo,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 2, rows: 10, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "click", cellX: 0, cellY: 5 } as any);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(onScrollTo).toHaveBeenCalledWith({
+        visualRow: 55,
+        cellX: 0,
+        cellY: 5,
+      } satisfies TLogMinimapClickPayload);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("renders safely when metrics are null", async () => {
+    const mounted = await mountTerminal(
+      () =>
+        h(TLogMinimap, {
+          x: 0,
+          y: 0,
+          w: 2,
+          h: 4,
+          metrics: null,
+          density: [{ startVisualRow: 0, endVisualRow: 10, value: 1 }],
+        }),
+      2,
+      4,
+    );
+
+    try {
+      expect(columnChars(mounted, 0, 4)).toBe("    ");
+      expect(columnChars(mounted, 1, 4)).toBe("    ");
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("integrates TLogView search markers through parent-managed wiring", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const metrics = ref<TLogViewScrollMetrics | null>(null);
+    const markers = ref<readonly TLogMinimapMarker[]>([]);
+    const source: TLogDataSource = {
+      lineCount: () => 8,
+      getLine: (index) =>
+        [
+          "ok line-0",
+          "ok line-1",
+          "error line-2",
+          "ok line-3",
+          "ok line-4",
+          "ok line-5",
+          "error line-6",
+          "ok line-7",
+        ][index] ?? "",
+      getLineKey: (index) => index,
+    };
+
+    const App = defineComponent({
+      name: "TLogMinimapIntegrationApp",
+      setup() {
+        const refresh = () => {
+          metrics.value = logView.value?.getScrollMetrics() ?? null;
+          markers.value =
+            logView.value?.getSearchMarkers().map((marker) => ({
+              id: marker.matchIndex,
+              visualRow: marker.visualRow,
+              current: marker.current,
+              estimated: marker.estimated,
+              payload: marker,
+            })) ?? [];
+        };
+
+        onMounted(refresh);
+
+        return () => [
+          h(TLogView, {
+            ref: logView,
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 4,
+            source,
+            version: 1,
+            defaultScrollTop: 0,
+            searchQuery: "error",
+            searchOptions: { scanBudgetMs: 1000 },
+            onScroll: refresh,
+            onVisualIndex: refresh,
+            onSearchMarkers: refresh,
+            onSearchMatch: refresh,
+          }),
+          h(TLogMinimap, {
+            x: 20,
+            y: 0,
+            w: 2,
+            h: 4,
+            metrics: metrics.value,
+            markers: markers.value,
+            onMarkerClick: (payload: {
+              marker: TLogMinimapMarker & { payload?: TLogViewSearchMarker };
+            }) => {
+              const marker = payload.marker.payload;
+              if (!marker) return;
+              logView.value?.selectSearchMatch(marker.matchIndex, { align: "center" });
+              refresh();
+            },
+          }),
+        ];
+      },
+    });
+
+    const app = createTerminalApp({ cols: 22, rows: 4, component: App });
+    try {
+      app.mount();
+      await flushSearch(app, logView.value!);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(markers.value).toHaveLength(2);
+      expect(markers.value[0]).toMatchObject({ visualRow: 2 });
+
+      app.events.dispatch({ type: "click", cellX: 20, cellY: 3, time: Date.now() } as any);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(logView.value!.getSearchState().currentMatchIndex).toBe(1);
+      expect(markers.value[1]).toMatchObject({ current: true, visualRow: 6 });
+      expect(
+        Array.from({ length: 4 }, (_, index) => rowText(app, index, 20)).some((line) =>
+          line.startsWith("error line-6"),
+        ),
+      ).toBe(true);
+    } finally {
+      app.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Add `TLogMinimap` — an experimental compact overview companion component that compresses retained visual rows into a 1-column or multi-column overview.

### Features
- Renders viewport window, search markers (exact / estimated / current), and density buckets
- Supports `scrollTo` event for clicking empty rows and `markerClick` event for clicking marker rows
- Fully renderer-agnostic: consumes `metrics`, `markers`, and `density` props from parent
- Style overrides via `style`, `densityStyle`, `markerStyle`, `currentMarkerStyle`, `viewportStyle`, `estimatedStyle` props
- Toggle visibility of markers / density / viewport via `showMarkers`, `showDensity`, `showViewport`

### Changes
| File | Description |
|------|-------------|
| `src/vue/components/TLogMinimap.ts` | New component implementation |
| `src/experimental.ts` | Export component and types |
| `test/tlog-minimap.test.ts` | Unit tests (viewport, markers, density, clicks, null metrics, TLogView integration) |
| `test/package-exports.test.ts` | Verify export presence in both ESM and CJS |
| `docs/components.md` | Component guide documentation |
| `docs/generated/components-api.md` | Generated API docs |

### Test plan
- [x] Unit tests pass (`vitest`)
- [x] Package export tests verify `TLogMinimap` in experimental entry
- [x] Integration test with `TLogView` search markers and `selectSearchMatch`