### PR TITLE
feat(TLogSearchPager): add search pager component and paginated results composable

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -719,9 +719,11 @@ onMounted(refreshOverview);
 
 ### TLogSearchResults
 
-`TLogSearchResults` 是一个 experimental search result panel，用来渲染分页后的搜索结果预览。它只消费外部准备好的 result items，不持有 search state，也不会直接读取 `TLogView` 或 log source。
+`TLogSearchResults` 是一个 experimental search result panel，用来渲染当前页搜索结果预览。它只消费外部准备好的 result items，不持有 search state，也不会直接读取 `TLogView` 或 log source。
 
-- 结果数据建议来自 `logView.value?.getSearchResults({ offset, limit, includePreview: true })`
+- 分页状态建议交给 `useTLogSearchResultsPage`
+- `TLogSearchResults` 仍然只负责结果列表渲染和 row-level 交互
+- `select` payload 里的 `matchIndex` 仍然是 global match index，父组件或 composable 负责调用 `selectSearchMatch(matchIndex)`
 - `includePreview` 默认是 `false`，避免每次 getter 都去读取结果行内容
 - preview 基于 visible text 生成；`ansi=true` 时不会把 ANSI escape sequences 带进结果面板
 - preview 和高亮 offset 都按 cell 计算，因此宽字符场景可以保持匹配位置正确
@@ -732,43 +734,24 @@ onMounted(refreshOverview);
 <script setup lang="ts">
 import { ref } from "vue";
 import {
+  TLogSearchPager,
   TLogSearchResults,
   TLogView,
-  type TLogSearchResultItem,
+  useTLogSearchResultsPage,
   type TLogSearchResultsSelectPayload,
   type TLogViewHandle,
 } from "@simon_he/vue-tui/experimental";
 
 const logView = ref<TLogViewHandle | null>(null);
-const results = ref<readonly TLogSearchResultItem[]>([]);
-const activeIndex = ref(-1);
 const query = ref("ERROR");
-
-function refreshResults() {
-  const raw =
-    logView.value?.getSearchResults({
-      offset: 0,
-      limit: 20,
-      includePreview: true,
-      previewWidth: 60,
-    }) ?? [];
-  const state = logView.value?.getSearchState();
-
-  results.value = raw.map((entry) => ({
-    matchIndex: entry.matchIndex,
-    absoluteLineIndex: entry.match.absoluteLineIndex,
-    lineIndex: entry.match.index,
-    text: entry.preview?.text ?? "",
-    matchStartCell: entry.preview?.matchStartCell ?? 0,
-    matchEndCell: entry.preview?.matchEndCell ?? 0,
-    current: entry.matchIndex === state?.currentMatchIndex,
-  }));
-  activeIndex.value = raw.findIndex((entry) => entry.matchIndex === state?.currentMatchIndex);
-}
+const { state, refresh, previousPage, nextPage, selectResult } = useTLogSearchResultsPage(logView, {
+  pageSize: 20,
+  includePreview: true,
+  previewWidth: 60,
+});
 
 function onSelect(payload: TLogSearchResultsSelectPayload) {
-  logView.value?.selectSearchMatch(payload.matchIndex);
-  refreshResults();
+  selectResult(payload.matchIndex);
 }
 </script>
 
@@ -781,20 +764,42 @@ function onSelect(payload: TLogSearchResultsSelectPayload) {
   :source="log.source"
   :version="log.version"
   :search-query="query"
-  @search="refreshResults"
-  @searchMatch="refreshResults"
+  @search="refresh"
+  @searchMatch="refresh"
 />
 
 <TLogSearchResults
   :x="61"
   :y="0"
   :w="19"
-  :h="20"
-  :results="results"
-  :active-index="activeIndex"
+  :h="19"
+  :results="state.results"
+  :active-index="state.activeIndex"
   @select="onSelect"
 />
+
+<TLogSearchPager
+  :x="61"
+  :y="19"
+  :w="19"
+  :state="state"
+  @previousPage="previousPage"
+  @nextPage="nextPage"
+/>
 ```
+
+### TLogSearchPager
+
+`TLogSearchPager` 是一个 experimental presentational pager companion，用来渲染搜索结果页码、match count 和上一页/下一页控制。它只消费外部传入的分页状态，不会直接读取 `TLogView`，也不会自己调用 search API。
+
+- `idle` 显示 `No search`
+- `scanning` 显示 `Scanning…` 和当前已发现 match count
+- `done + matchCount=0` 显示 `No matches`
+- `error` 显示 `Invalid regex`
+- `done` 显示单行 pager，例如 `◀ 2/13 245 matches ▶`
+- click `◀` / `▶` 和 `ArrowLeft` / `ArrowRight` / `PageUp` / `PageDown` 都只 emit，父组件负责接到 composable 或 handle
+
+`useTLogSearchResultsPage` 负责从 `TLogViewHandle` 拉取当前页结果、同步 page-local `activeIndex`、clamp 页码，并在 `selectResult(matchIndex)` 时调用 `selectSearchMatch(matchIndex)` 后刷新当前页状态。推荐把它和 `TLogSearchResults` / `TLogSearchPager` 一起使用，而不是在父组件里重复手写 `offset`、`pageSize`、`currentMatchIndex` 同步逻辑。
 
 ### Events
 

--- a/docs/generated/components-api.md
+++ b/docs/generated/components-api.md
@@ -16,6 +16,7 @@
 - [TList](#tlist)
 - [TLogMinimap](#tlogminimap)
 - [TLogScrollbar](#tlogscrollbar)
+- [TLogSearchPager](#tlogsearchpager)
 - [TLogSearchResults](#tlogsearchresults)
 - [TLogView](#tlogview)
 - [TMultilineModal](#tmultilinemodal)
@@ -448,6 +449,33 @@
 | <code>scrollTo</code>    | —       | —    |
 | <code>scrollBy</code>    | —       | —    |
 | <code>markerClick</code> | —       | —    |
+
+## TLogSearchPager
+
+源码：`src/vue/components/TLogSearchPager.ts`
+
+### Props
+
+| 名称                       | 类型                                          | 默认值                                                            | 必填 | 说明 |
+| -------------------------- | --------------------------------------------- | ----------------------------------------------------------------- | ---- | ---- |
+| <code>x</code>             | <code>number</code>                           | —                                                                 | 是   | —    |
+| <code>y</code>             | <code>number</code>                           | —                                                                 | 是   | —    |
+| <code>w</code>             | <code>number</code>                           | —                                                                 | 是   | —    |
+| <code>zIndex</code>        | <code>number</code>                           | <code>0</code>                                                    | 否   | —    |
+| <code>state</code>         | <code>TLogSearchPagerState &#124; null</code> | <code>null</code>                                                 | 否   | —    |
+| <code>style</code>         | <code>Style</code>                            | <code>undefined</code>                                            | 否   | —    |
+| <code>activeStyle</code>   | <code>Style</code>                            | <code>undefined</code>                                            | 否   | —    |
+| <code>disabledStyle</code> | <code>Style</code>                            | <code>() =&gt; ({ dim: true })</code>                             | 否   | —    |
+| <code>errorStyle</code>    | <code>Style</code>                            | <code>() =&gt; ({ fg: &quot;redBright&quot;, bold: true })</code> | 否   | —    |
+| <code>showCount</code>     | <code>boolean</code>                          | <code>true</code>                                                 | 否   | —    |
+
+### Events
+
+| 名称                      | Payload | 说明 |
+| ------------------------- | ------- | ---- |
+| <code>previousPage</code> | —       | —    |
+| <code>nextPage</code>     | —       | —    |
+| <code>pageChange</code>   | —       | —    |
 
 ## TLogSearchResults
 

--- a/src/experimental.ts
+++ b/src/experimental.ts
@@ -3,7 +3,9 @@ export { TLogView } from "./vue/components/TLogView.js";
 export { TLogScrollbar } from "./vue/components/TLogScrollbar.js";
 export { TLogMinimap } from "./vue/components/TLogMinimap.js";
 export { TLogSearchResults } from "./vue/components/TLogSearchResults.js";
+export { TLogSearchPager } from "./vue/components/TLogSearchPager.js";
 export { createAppendOnlyLogStore } from "./vue/log/append-only-log-store.js";
+export { useTLogSearchResultsPage } from "./vue/log/use-tlog-search-results-page.js";
 export type { RowScrollMode } from "./vue/components/TVirtualList.js";
 export type {
   TLogMinimapClickPayload,
@@ -19,6 +21,10 @@ export type {
   TLogScrollbarScrollByPayload,
   TLogScrollbarScrollToPayload,
 } from "./vue/components/TLogScrollbar.js";
+export type {
+  TLogSearchPagerPageChangePayload,
+  TLogSearchPagerState,
+} from "./vue/components/TLogSearchPager.js";
 export type {
   TLogSearchResultItem,
   TLogSearchResultsActiveChangePayload,
@@ -54,3 +60,7 @@ export type {
   TLogViewVisualIndexOptions,
   TLogViewVisualIndexStatus,
 } from "./vue/log/types.js";
+export type {
+  TLogSearchResultsPageState,
+  UseTLogSearchResultsPageOptions,
+} from "./vue/log/use-tlog-search-results-page.js";

--- a/src/vue/components/TLogSearchPager.ts
+++ b/src/vue/components/TLogSearchPager.ts
@@ -1,0 +1,288 @@
+import type { PropType } from "vue";
+import type { Style } from "../../core/types.js";
+import type { Rect, TerminalKeyboardEvent, TerminalPointerEvent } from "../../events/index.js";
+import type { TLogViewSearchError, TLogViewSearchState } from "./TLogView.js";
+import { computed, defineComponent, h, inject, ref } from "vue";
+import { useLayout } from "../composables/use-layout.js";
+import { useRenderNode } from "../composables/use-render-node.js";
+import { useTerminalNode } from "../composables/use-terminal-node.js";
+import { useTerminal } from "../composables/use-terminal.js";
+import { useVisibility } from "../composables/use-visibility.js";
+import { EventZIndexContextKey } from "../context.js";
+import { intersectRect, translateRect } from "../utils/rect.js";
+import { sliceByCellsRange, spaces, textCellWidth } from "../utils/text.js";
+
+const EMPTY_RECT: Rect = Object.freeze({ x: 0, y: 0, w: 0, h: 0 });
+const PREVIOUS_CHAR = "◀";
+const NEXT_CHAR = "▶";
+
+export type TLogSearchPagerState = Readonly<{
+  page: number;
+  pageCount: number;
+  matchCount: number;
+  status: TLogViewSearchState["status"];
+  error?: TLogViewSearchError | null;
+}>;
+
+export type TLogSearchPagerPageChangePayload = Readonly<{
+  page: number;
+}>;
+
+type PagerSegment = Readonly<{
+  text: string;
+  style: Style;
+  action?: "previous" | "next";
+}>;
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function normalizeInt(value: number): number {
+  const n = Math.floor(Number(value));
+  return Number.isFinite(n) ? n : 0;
+}
+
+function mergeStyle(base: Style, overlay?: Style): Style {
+  return overlay ? { ...base, ...overlay } : base;
+}
+
+function formatCount(matchCount: number): string {
+  return `${matchCount} ${matchCount === 1 ? "match" : "matches"}`;
+}
+
+function errorLabel(error: TLogViewSearchError | null | undefined): string {
+  if (error?.kind === "invalid-regex") return "Invalid regex";
+  return "Search error";
+}
+
+export const TLogSearchPager = defineComponent({
+  name: "TLogSearchPager",
+  props: {
+    x: { type: Number, required: true },
+    y: { type: Number, required: true },
+    w: { type: Number, required: true },
+    zIndex: { type: Number, default: 0 },
+    state: {
+      type: Object as PropType<TLogSearchPagerState | null>,
+      default: null,
+    },
+    style: { type: Object as PropType<Style>, default: undefined },
+    activeStyle: { type: Object as PropType<Style>, default: undefined },
+    disabledStyle: {
+      type: Object as PropType<Style>,
+      default: () => ({ dim: true }),
+    },
+    errorStyle: {
+      type: Object as PropType<Style>,
+      default: () => ({ fg: "redBright", bold: true }),
+    },
+    showCount: { type: Boolean, default: true },
+  },
+  emits: ["previousPage", "nextPage", "pageChange"],
+  setup(props, { emit }) {
+    const { terminal, scheduler, defaultStyle, events } = useTerminal();
+    const parent = useLayout();
+    const { visible, rootProps } = useVisibility();
+    const parentEventZ = inject(EventZIndexContextKey, computed(() => 0) as any);
+    const eventZ = computed(() => (parentEventZ.value ?? 0) + (props.zIndex ?? 0));
+    const focused = ref(false);
+
+    const fullRect = computed<Rect>(() =>
+      translateRect(
+        {
+          x: normalizeInt(props.x),
+          y: normalizeInt(props.y),
+          w: Math.max(0, normalizeInt(props.w)),
+          h: 1,
+        },
+        parent.originX,
+        parent.originY,
+      ),
+    );
+
+    const rect = computed<Rect>(() => {
+      const translated = fullRect.value;
+      if (!parent.clipRect) return translated;
+      return intersectRect(translated, parent.clipRect) ?? EMPTY_RECT;
+    });
+
+    const viewState = computed(() => props.state);
+
+    const segments = computed<readonly PagerSegment[]>(() => {
+      const base = props.style ?? defaultStyle.value;
+      const active = mergeStyle(base, props.activeStyle);
+      const disabled = mergeStyle(base, props.disabledStyle);
+      const error = mergeStyle(base, props.errorStyle);
+      const state = viewState.value;
+
+      if (!state || state.status === "idle") return [{ text: "No search", style: base }];
+      if (state.status === "error") return [{ text: errorLabel(state.error), style: error }];
+      if (state.status === "scanning") {
+        const text =
+          props.showCount && state.matchCount > 0
+            ? `Scanning… ${formatCount(state.matchCount)}`
+            : "Scanning…";
+        return [{ text, style: base }];
+      }
+      if (state.matchCount <= 0 || state.pageCount <= 0)
+        return [{ text: "No matches", style: base }];
+
+      const previousEnabled = state.page > 0;
+      const nextEnabled = state.page < state.pageCount - 1;
+      const parts: PagerSegment[] = [
+        {
+          text: PREVIOUS_CHAR,
+          style: previousEnabled ? active : disabled,
+          action: previousEnabled ? "previous" : undefined,
+        },
+        {
+          text: ` ${state.page + 1}/${state.pageCount}`,
+          style: base,
+        },
+      ];
+
+      if (props.showCount) {
+        parts.push({
+          text: ` ${formatCount(state.matchCount)} `,
+          style: base,
+        });
+      } else {
+        parts.push({ text: " ", style: base });
+      }
+
+      parts.push({
+        text: NEXT_CHAR,
+        style: nextEnabled ? active : disabled,
+        action: nextEnabled ? "next" : undefined,
+      });
+
+      return parts;
+    });
+
+    function emitPage(action: "previous" | "next"): void {
+      const state = viewState.value;
+      if (!state || state.status !== "done" || state.pageCount <= 0) return;
+      const target =
+        action === "previous"
+          ? clamp(state.page - 1, 0, Math.max(0, state.pageCount - 1))
+          : clamp(state.page + 1, 0, Math.max(0, state.pageCount - 1));
+      if (target === state.page) return;
+      emit(action === "previous" ? "previousPage" : "nextPage");
+      emit("pageChange", { page: target } satisfies TLogSearchPagerPageChangePayload);
+      scheduler.invalidate({ reason: "input" });
+    }
+
+    function focusSelf(): void {
+      const nodeId = eventNode.id.value;
+      if (nodeId) events.value?.focus(nodeId);
+    }
+
+    function actionAt(cellX: number): "previous" | "next" | null {
+      const full = fullRect.value;
+      const localX = cellX - full.x;
+      if (localX < 0 || localX >= full.w) return null;
+
+      let start = 0;
+      for (const segment of segments.value) {
+        const width = textCellWidth(segment.text);
+        if (localX >= start && localX < start + width) return segment.action ?? null;
+        start += width;
+      }
+
+      return null;
+    }
+
+    function onClick(e: TerminalPointerEvent): void {
+      const full = fullRect.value;
+      if (e.cellY !== full.y) return;
+      focusSelf();
+      const action = actionAt(e.cellX);
+      if (!action) return;
+      emitPage(action);
+      e.preventDefault?.();
+    }
+
+    function onKeydown(e: TerminalKeyboardEvent): void {
+      if (e.key === "ArrowLeft" || e.key === "PageUp") {
+        e.preventDefault();
+        emitPage("previous");
+        return;
+      }
+      if (e.key === "ArrowRight" || e.key === "PageDown") {
+        e.preventDefault();
+        emitPage("next");
+      }
+    }
+
+    const eventNode = useTerminalNode(() => ({
+      rect: rect.value,
+      zIndex: eventZ.value,
+      visible: visible.value,
+      focusable: true,
+      handlers: {
+        click: onClick,
+        focus: () => {
+          focused.value = true;
+          scheduler.invalidate();
+        },
+        blur: () => {
+          focused.value = false;
+          scheduler.invalidate();
+        },
+        keydown: onKeydown,
+      },
+    }));
+
+    useRenderNode(() => ({
+      zIndex: props.zIndex,
+      rect: visible.value ? rect.value : EMPTY_RECT,
+      deps: [
+        visible.value,
+        rect.value,
+        fullRect.value,
+        props.state,
+        props.style,
+        props.activeStyle,
+        props.disabledStyle,
+        props.errorStyle,
+        props.showCount,
+        defaultStyle.value,
+        focused.value,
+        segments.value,
+      ],
+      paint: () => {
+        if (!visible.value) return;
+        const r = rect.value;
+        if (r.w <= 0 || r.h <= 0) return;
+
+        const full = fullRect.value;
+        const base = props.style ?? defaultStyle.value;
+        terminal.write(spaces(r.w), { x: r.x, y: r.y, style: base });
+
+        let cursorX = full.x;
+        for (const segment of segments.value) {
+          const clippedStart = Math.max(0, r.x - cursorX);
+          const clippedEnd = Math.min(textCellWidth(segment.text), r.x + r.w - cursorX);
+          if (clippedEnd > clippedStart) {
+            const text = sliceByCellsRange(segment.text, clippedStart, clippedEnd);
+            if (text)
+              terminal.write(text, { x: Math.max(cursorX, r.x), y: r.y, style: segment.style });
+          }
+          cursorX += textCellWidth(segment.text);
+          if (cursorX >= r.x + r.w) break;
+        }
+      },
+    }));
+
+    return () =>
+      h(
+        "div",
+        {
+          ...rootProps,
+          "data-t-log-search-pager": true,
+        },
+        [],
+      );
+  },
+});

--- a/src/vue/log/use-tlog-search-results-page.ts
+++ b/src/vue/log/use-tlog-search-results-page.ts
@@ -1,0 +1,200 @@
+import type { Ref } from "vue";
+import type { TLogSearchResultItem } from "../components/TLogSearchResults.js";
+import type {
+  TLogViewHandle,
+  TLogViewSearchError,
+  TLogViewSearchState,
+} from "../components/TLogView.js";
+import { ref, watch } from "vue";
+
+const DEFAULT_PAGE_SIZE = 20;
+
+export type UseTLogSearchResultsPageOptions = Readonly<{
+  pageSize?: number;
+  includePreview?: boolean;
+  previewWidth?: number;
+  contextCells?: number;
+}>;
+
+export type TLogSearchResultsPageState = Readonly<{
+  page: number;
+  pageSize: number;
+  pageCount: number;
+  matchCount: number;
+  offset: number;
+  activeIndex: number;
+  currentMatchIndex: number;
+  status: TLogViewSearchState["status"];
+  error: TLogViewSearchError | null;
+  results: readonly TLogSearchResultItem[];
+}>;
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function normalizeInt(value: number, fallback = 0): number {
+  const n = Math.floor(Number(value));
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function normalizePageSize(value: number | undefined): number {
+  return Math.max(1, normalizeInt(value ?? DEFAULT_PAGE_SIZE, DEFAULT_PAGE_SIZE));
+}
+
+function normalizePage(value: number): number {
+  return Math.max(0, normalizeInt(value));
+}
+
+function clampPage(page: number, pageCount: number): number {
+  if (pageCount <= 0) return 0;
+  return clamp(normalizePage(page), 0, pageCount - 1);
+}
+
+function createEmptyState(
+  pageSize: number,
+  status: TLogViewSearchState["status"] = "idle",
+  error: TLogViewSearchError | null = null,
+): TLogSearchResultsPageState {
+  return {
+    page: 0,
+    pageSize,
+    pageCount: 0,
+    matchCount: 0,
+    offset: 0,
+    activeIndex: -1,
+    currentMatchIndex: -1,
+    status,
+    error,
+    results: [],
+  };
+}
+
+export function useTLogSearchResultsPage(
+  logView: Ref<TLogViewHandle | null>,
+  options: UseTLogSearchResultsPageOptions = {},
+): {
+  state: Ref<TLogSearchResultsPageState>;
+  refresh: () => void;
+  setPage: (page: number) => void;
+  nextPage: () => void;
+  previousPage: () => void;
+  syncPageToCurrentMatch: () => void;
+  selectResult: (matchIndex: number) => boolean;
+} {
+  const pageSize = normalizePageSize(options.pageSize);
+  const includePreview = options.includePreview === true;
+  const currentPage = ref(0);
+  const state = ref<TLogSearchResultsPageState>(createEmptyState(pageSize));
+
+  function refresh(): void {
+    const handle = logView.value;
+    if (!handle) {
+      currentPage.value = 0;
+      state.value = createEmptyState(pageSize);
+      return;
+    }
+
+    const search = handle.getSearchState();
+    const matchCount = Math.max(0, normalizeInt(search.matchCount));
+    const pageCount = matchCount > 0 ? Math.ceil(matchCount / pageSize) : 0;
+    const page = clampPage(currentPage.value, pageCount);
+    const offset = page * pageSize;
+    const shouldReadResults = search.status !== "error" && matchCount > 0;
+    const rawResults = shouldReadResults
+      ? handle.getSearchResults({
+          offset,
+          limit: pageSize,
+          includePreview,
+          previewWidth: options.previewWidth,
+          contextCells: options.contextCells,
+        })
+      : [];
+    const results = rawResults.map(
+      (entry): TLogSearchResultItem => ({
+        matchIndex: entry.matchIndex,
+        absoluteLineIndex: entry.match.absoluteLineIndex,
+        lineIndex: entry.match.index,
+        text: entry.preview?.text ?? "",
+        matchStartCell: entry.preview?.matchStartCell ?? 0,
+        matchEndCell: entry.preview?.matchEndCell ?? 0,
+        current: entry.matchIndex === search.currentMatchIndex,
+      }),
+    );
+    const activeIndex =
+      search.currentMatchIndex >= offset && search.currentMatchIndex < offset + results.length
+        ? search.currentMatchIndex - offset
+        : -1;
+
+    currentPage.value = page;
+    state.value = {
+      page,
+      pageSize,
+      pageCount,
+      matchCount,
+      offset,
+      activeIndex,
+      currentMatchIndex: normalizeInt(search.currentMatchIndex, -1),
+      status: search.status,
+      error: search.error ?? null,
+      results,
+    };
+  }
+
+  function setPage(page: number): void {
+    currentPage.value = normalizePage(page);
+    refresh();
+  }
+
+  function nextPage(): void {
+    setPage(currentPage.value + 1);
+  }
+
+  function previousPage(): void {
+    setPage(currentPage.value - 1);
+  }
+
+  function syncPageToCurrentMatch(): void {
+    const currentMatchIndex = logView.value?.getSearchState().currentMatchIndex ?? -1;
+    if (currentMatchIndex >= 0) currentPage.value = Math.floor(currentMatchIndex / pageSize);
+    refresh();
+  }
+
+  function selectResult(matchIndex: number): boolean {
+    const handle = logView.value;
+    if (!handle) {
+      refresh();
+      return false;
+    }
+
+    const normalizedMatchIndex = normalizeInt(matchIndex, -1);
+    const selected = handle.selectSearchMatch(normalizedMatchIndex);
+    if (!selected) {
+      refresh();
+      return false;
+    }
+
+    currentPage.value = Math.floor(normalizedMatchIndex / pageSize);
+    refresh();
+    return true;
+  }
+
+  watch(
+    () => logView.value,
+    () => {
+      currentPage.value = 0;
+      refresh();
+    },
+    { immediate: true },
+  );
+
+  return {
+    state,
+    refresh,
+    setPage,
+    nextPage,
+    previousPage,
+    syncPageToCurrentMatch,
+    selectResult,
+  };
+}

--- a/test/package-exports.test.ts
+++ b/test/package-exports.test.ts
@@ -20,6 +20,8 @@ describe("package exports", () => {
     expect("TLogScrollbar" in root).toBe(false);
     expect("TLogMinimap" in root).toBe(false);
     expect("TLogSearchResults" in root).toBe(false);
+    expect("TLogSearchPager" in root).toBe(false);
+    expect("useTLogSearchResultsPage" in root).toBe(false);
     expect("createAppendOnlyLogStore" in root).toBe(false);
     expect(root.createFramePerfStore).toBeTruthy();
     expect(root.framePerfNow).toBeTruthy();
@@ -28,6 +30,8 @@ describe("package exports", () => {
     expect(experimental.TLogScrollbar).toBeTruthy();
     expect(experimental.TLogMinimap).toBeTruthy();
     expect(experimental.TLogSearchResults).toBeTruthy();
+    expect(experimental.TLogSearchPager).toBeTruthy();
+    expect(experimental.useTLogSearchResultsPage).toBeTruthy();
     expect(experimental.createAppendOnlyLogStore).toBeTruthy();
   });
 
@@ -64,12 +68,16 @@ describe("package exports", () => {
     expect(experimental.TLogScrollbar).toBeTruthy();
     expect(experimental.TLogMinimap).toBeTruthy();
     expect(experimental.TLogSearchResults).toBeTruthy();
+    expect(experimental.TLogSearchPager).toBeTruthy();
+    expect(experimental.useTLogSearchResultsPage).toBeTruthy();
     expect(experimental.createAppendOnlyLogStore).toBeTruthy();
     expect(experimentalCjs.TVirtualList).toBeTruthy();
     expect(experimentalCjs.TLogView).toBeTruthy();
     expect(experimentalCjs.TLogScrollbar).toBeTruthy();
     expect(experimentalCjs.TLogMinimap).toBeTruthy();
     expect(experimentalCjs.TLogSearchResults).toBeTruthy();
+    expect(experimentalCjs.TLogSearchPager).toBeTruthy();
+    expect(experimentalCjs.useTLogSearchResultsPage).toBeTruthy();
     expect(experimentalCjs.createAppendOnlyLogStore).toBeTruthy();
   });
 });

--- a/test/tlog-search-pager.test.ts
+++ b/test/tlog-search-pager.test.ts
@@ -1,0 +1,501 @@
+import type {
+  TLogDataSource,
+  TLogSearchPagerState,
+  TLogSearchResultsSelectPayload,
+  TLogViewHandle,
+} from "../src/experimental.js";
+import { describe, expect, it, vi } from "vitest";
+import { createTerminalApp } from "../src/index.js";
+import {
+  TLogSearchPager,
+  TLogSearchResults,
+  TLogView,
+  useTLogSearchResultsPage,
+} from "../src/experimental.js";
+import {
+  createApp,
+  defineComponent,
+  h,
+  mountTerminal,
+  nextTick,
+  onMounted,
+  ref,
+} from "./ui-regressions-support.js";
+
+function rowText(
+  mounted: { terminal: ReturnType<typeof createTerminalApp>["terminal"] },
+  y: number,
+): string {
+  return mounted.terminal
+    .getRow(y)
+    .map((cell) => cell.ch)
+    .join("")
+    .trimEnd();
+}
+
+async function flushSearch(
+  app: ReturnType<typeof createTerminalApp>,
+  handle: TLogViewHandle,
+  maxFrames = 20,
+): Promise<void> {
+  for (let i = 0; i < maxFrames; i++) {
+    await nextTick();
+    app.scheduler.flushNow();
+    if (handle.getSearchState().status !== "scanning") return;
+  }
+}
+
+async function mountComposableHarness(
+  logView: ReturnType<typeof ref<TLogViewHandle | null>>,
+  options?: Parameters<typeof useTLogSearchResultsPage>[1],
+): Promise<{
+  api: ReturnType<typeof useTLogSearchResultsPage>;
+  unmount: () => void;
+}> {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  let api!: ReturnType<typeof useTLogSearchResultsPage>;
+
+  const App = defineComponent({
+    name: "UseTLogSearchResultsPageHarness",
+    setup() {
+      api = useTLogSearchResultsPage(logView, options);
+      return () => null;
+    },
+  });
+
+  const app = createApp(App);
+  app.mount(root);
+  await nextTick();
+
+  return {
+    api,
+    unmount: () => {
+      app.unmount();
+      root.remove();
+    },
+  };
+}
+
+describe("useTLogSearchResultsPage", () => {
+  it("pulls only the current page from the handle", async () => {
+    const searchState = {
+      query: "error",
+      status: "done" as const,
+      matchCount: 100,
+      currentMatchIndex: 41,
+      error: null,
+    };
+    const getSearchResults = vi.fn(({ offset = 0, limit = 0 } = {}) =>
+      Array.from({ length: limit }, (_, index) => ({
+        matchIndex: offset + index,
+        match: {
+          absoluteLineIndex: offset + index + 100,
+          index: offset + index,
+          startCell: 0,
+          endCell: 5,
+          text: `error line-${offset + index}`,
+        },
+        preview: {
+          text: `error line-${offset + index}`,
+          matchStartCell: 0,
+          matchEndCell: 5,
+        },
+      })),
+    );
+    const logView = ref<TLogViewHandle | null>({
+      getSearchState: () => searchState,
+      getSearchResults,
+      selectSearchMatch: vi.fn(() => true),
+    } as Partial<TLogViewHandle> as TLogViewHandle);
+    const harness = await mountComposableHarness(logView, {
+      pageSize: 20,
+      includePreview: true,
+      previewWidth: 60,
+    });
+
+    try {
+      harness.api.setPage(2);
+
+      expect(getSearchResults).toHaveBeenLastCalledWith({
+        offset: 40,
+        limit: 20,
+        includePreview: true,
+        previewWidth: 60,
+        contextCells: undefined,
+      });
+      expect(harness.api.state.value.page).toBe(2);
+      expect(harness.api.state.value.offset).toBe(40);
+      expect(harness.api.state.value.results).toHaveLength(20);
+      expect(harness.api.state.value.activeIndex).toBe(1);
+      expect(harness.api.state.value.results[1]).toMatchObject({
+        matchIndex: 41,
+        current: true,
+      });
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("clamps the current page when match count shrinks", async () => {
+    const searchState = {
+      query: "error",
+      status: "done" as const,
+      matchCount: 120,
+      currentMatchIndex: 110,
+      error: null,
+    };
+    const getSearchResults = vi.fn(({ offset = 0, limit = 0 } = {}) =>
+      Array.from(
+        { length: Math.min(limit, Math.max(0, searchState.matchCount - offset)) },
+        (_, index) => ({
+          matchIndex: offset + index,
+          match: {
+            absoluteLineIndex: offset + index,
+            index: offset + index,
+            startCell: 0,
+            endCell: 5,
+            text: `error-${offset + index}`,
+          },
+          preview: {
+            text: `error-${offset + index}`,
+            matchStartCell: 0,
+            matchEndCell: 5,
+          },
+        }),
+      ),
+    );
+    const logView = ref<TLogViewHandle | null>({
+      getSearchState: () => searchState,
+      getSearchResults,
+      selectSearchMatch: vi.fn(() => true),
+    } as Partial<TLogViewHandle> as TLogViewHandle);
+    const harness = await mountComposableHarness(logView, { pageSize: 20, includePreview: true });
+
+    try {
+      harness.api.setPage(5);
+      expect(harness.api.state.value.page).toBe(5);
+
+      searchState.matchCount = 1;
+      searchState.currentMatchIndex = 0;
+      harness.api.refresh();
+
+      expect(harness.api.state.value.page).toBe(0);
+      expect(harness.api.state.value.pageCount).toBe(1);
+      expect(harness.api.state.value.results).toHaveLength(1);
+      expect(getSearchResults).toHaveBeenLastCalledWith({
+        offset: 0,
+        limit: 20,
+        includePreview: true,
+        previewWidth: undefined,
+        contextCells: undefined,
+      });
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("clears stale results for regex errors", async () => {
+    const getSearchResults = vi.fn();
+    const logView = ref<TLogViewHandle | null>({
+      getSearchState: () => ({
+        query: "[",
+        status: "error",
+        matchCount: 0,
+        currentMatchIndex: -1,
+        error: {
+          kind: "invalid-regex",
+          query: "[",
+          flags: "",
+          message: "Invalid regular expression",
+        },
+      }),
+      getSearchResults,
+      selectSearchMatch: vi.fn(() => false),
+    } as Partial<TLogViewHandle> as TLogViewHandle);
+    const harness = await mountComposableHarness(logView, { pageSize: 20, includePreview: true });
+
+    try {
+      expect(harness.api.state.value).toMatchObject({
+        status: "error",
+        page: 0,
+        pageCount: 0,
+        matchCount: 0,
+        activeIndex: -1,
+        currentMatchIndex: -1,
+        error: {
+          kind: "invalid-regex",
+        },
+      });
+      expect(harness.api.state.value.results).toEqual([]);
+      expect(getSearchResults).not.toHaveBeenCalled();
+    } finally {
+      harness.unmount();
+    }
+  });
+});
+
+describe("TLogSearchPager", () => {
+  it("renders idle, scanning, no-match, done and error states", async () => {
+    const state = ref<TLogSearchPagerState | null>(null);
+    const mounted = await mountTerminal(
+      () =>
+        h(TLogSearchPager, {
+          x: 0,
+          y: 0,
+          w: 24,
+          state: state.value,
+        }),
+      24,
+      1,
+    );
+
+    try {
+      expect(rowText(mounted, 0)).toBe("No search");
+
+      state.value = { page: 0, pageCount: 2, matchCount: 42, status: "scanning", error: null };
+      await nextTick();
+      expect(rowText(mounted, 0)).toBe("Scanning… 42 matches");
+
+      state.value = { page: 0, pageCount: 0, matchCount: 0, status: "done", error: null };
+      await nextTick();
+      expect(rowText(mounted, 0)).toBe("No matches");
+
+      state.value = { page: 1, pageCount: 13, matchCount: 245, status: "done", error: null };
+      await nextTick();
+      expect(rowText(mounted, 0)).toBe("◀ 2/13 245 matches ▶");
+
+      state.value = {
+        page: 0,
+        pageCount: 0,
+        matchCount: 0,
+        status: "error",
+        error: {
+          kind: "invalid-regex",
+          query: "[",
+          flags: "",
+          message: "Invalid regular expression",
+        },
+      };
+      await nextTick();
+      expect(rowText(mounted, 0)).toBe("Invalid regex");
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("emits previousPage, nextPage and pageChange on click", async () => {
+    const onPreviousPage = vi.fn();
+    const onNextPage = vi.fn();
+    const onPageChange = vi.fn();
+    const app = createTerminalApp({
+      cols: 24,
+      rows: 1,
+      component: defineComponent({
+        name: "TLogSearchPagerClickApp",
+        setup() {
+          return () =>
+            h(TLogSearchPager, {
+              x: 0,
+              y: 0,
+              w: 24,
+              state: { page: 1, pageCount: 3, matchCount: 245, status: "done", error: null },
+              onPreviousPage,
+              onNextPage,
+              onPageChange,
+            });
+        },
+      }),
+    });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      const text = rowText(app, 0);
+      app.events.dispatch({
+        type: "click",
+        cellX: text.indexOf("◀"),
+        cellY: 0,
+        time: Date.now(),
+      });
+      app.events.dispatch({
+        type: "click",
+        cellX: text.lastIndexOf("▶"),
+        cellY: 0,
+        time: Date.now(),
+      });
+      await nextTick();
+
+      expect(onPreviousPage).toHaveBeenCalledTimes(1);
+      expect(onNextPage).toHaveBeenCalledTimes(1);
+      expect(onPageChange.mock.calls).toEqual([[{ page: 0 }], [{ page: 2 }]]);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("supports ArrowLeft, ArrowRight, PageUp and PageDown navigation", async () => {
+    const onPreviousPage = vi.fn();
+    const onNextPage = vi.fn();
+    const onPageChange = vi.fn();
+    const app = createTerminalApp({
+      cols: 24,
+      rows: 1,
+      component: defineComponent({
+        name: "TLogSearchPagerKeyboardApp",
+        setup() {
+          return () =>
+            h(TLogSearchPager, {
+              x: 0,
+              y: 0,
+              w: 24,
+              state: { page: 1, pageCount: 3, matchCount: 245, status: "done", error: null },
+              onPreviousPage,
+              onNextPage,
+              onPageChange,
+            });
+        },
+      }),
+    });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "click", cellX: 3, cellY: 0, time: Date.now() } as any);
+      app.events.dispatch({ type: "keydown", key: "ArrowLeft", code: "ArrowLeft" } as any);
+      app.events.dispatch({ type: "keydown", key: "ArrowRight", code: "ArrowRight" } as any);
+      app.events.dispatch({ type: "keydown", key: "PageUp", code: "PageUp" } as any);
+      app.events.dispatch({ type: "keydown", key: "PageDown", code: "PageDown" } as any);
+      await nextTick();
+
+      expect(onPreviousPage).toHaveBeenCalledTimes(2);
+      expect(onNextPage).toHaveBeenCalledTimes(2);
+      expect(onPageChange.mock.calls).toEqual([
+        [{ page: 0 }],
+        [{ page: 2 }],
+        [{ page: 0 }],
+        [{ page: 2 }],
+      ]);
+    } finally {
+      app.dispose();
+    }
+  });
+});
+
+describe("TLogSearchPager integration", () => {
+  it("wires TLogView, useTLogSearchResultsPage and TLogSearchResults together", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const query = ref("error");
+    let pageApi: ReturnType<typeof useTLogSearchResultsPage> | null = null;
+    const source: TLogDataSource = {
+      lineCount: () => 6,
+      getLine: (index) =>
+        ["line-0", "line-1", "error line-2", "line-3", "error line-4", "line-5"][index] ?? "",
+      getLineKey: (index) => `line-${index}`,
+    };
+
+    const App = defineComponent({
+      name: "TLogSearchPagerIntegrationApp",
+      setup() {
+        const api = useTLogSearchResultsPage(logView, {
+          pageSize: 1,
+          includePreview: true,
+          previewWidth: 18,
+        });
+        pageApi = api;
+
+        function refresh(): void {
+          api.refresh();
+        }
+
+        function onSelect(payload: TLogSearchResultsSelectPayload): void {
+          api.selectResult(payload.matchIndex);
+        }
+
+        onMounted(() => {
+          refresh();
+        });
+
+        return () =>
+          h("span", [
+            h(TLogView, {
+              ref: logView,
+              x: 0,
+              y: 0,
+              w: 18,
+              h: 4,
+              source,
+              version: 1,
+              searchQuery: query.value,
+              searchOptions: { scanBudgetMs: 1000 },
+              onSearch: refresh,
+              onSearchMatch: refresh,
+            }),
+            h(TLogSearchResults, {
+              x: 19,
+              y: 0,
+              w: 21,
+              h: 1,
+              results: api.state.value.results,
+              activeIndex: api.state.value.activeIndex,
+              onSelect,
+            }),
+            h(TLogSearchPager, {
+              x: 19,
+              y: 1,
+              w: 21,
+              state: api.state.value,
+              onPreviousPage: api.previousPage,
+              onNextPage: api.nextPage,
+            }),
+          ]);
+      },
+    });
+
+    const app = createTerminalApp({ cols: 40, rows: 4, component: App });
+    try {
+      app.mount();
+      await flushSearch(app, logView.value!);
+
+      expect(pageApi!.state.value.page).toBe(0);
+      expect(pageApi!.state.value.results[0]).toMatchObject({
+        matchIndex: 0,
+        text: "error line-2",
+      });
+
+      const pagerRow = rowText(app, 1);
+      app.events.dispatch({
+        type: "click",
+        cellX: pagerRow.lastIndexOf("▶"),
+        cellY: 1,
+        time: Date.now(),
+      } as any);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(pageApi!.state.value.page).toBe(1);
+      expect(pageApi!.state.value.results[0]).toMatchObject({
+        matchIndex: 1,
+        text: "error line-4",
+      });
+
+      app.events.dispatch({ type: "click", cellX: 19, cellY: 0, time: Date.now() } as any);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(logView.value!.getSearchState().currentMatchIndex).toBe(1);
+      expect(pageApi!.state.value.activeIndex).toBe(0);
+      expect(pageApi!.state.value.currentMatchIndex).toBe(1);
+      expect(pageApi!.state.value.results[0]).toMatchObject({
+        matchIndex: 1,
+        current: true,
+      });
+    } finally {
+      app.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Add `TLogSearchPager` component and `useTLogSearchResultsPage` composable for paginated navigation of log search results.

### TLogSearchPager component
- Renders page navigation bar with previous/next buttons (◀/▶), page indicator, and match count
- Supports keyboard navigation: ArrowLeft/Right and PageUp/Down
- Supports click interaction on navigation buttons
- Displays contextual states: idle, scanning, no matches, done, and error
- Configurable styles for active, disabled, and error states
- Emits `previousPage`, `nextPage`, and `pageChange` events

### useTLogSearchResultsPage composable
- Paginates search results from a `TLogViewHandle` with configurable `pageSize` and preview options
- Provides `refresh`, `setPage`, `nextPage`, `previousPage`, `syncPageToCurrentMatch`, and `selectResult` methods
- Automatically clamps the current page when match count shrinks
- Tracks active index and current match within the page

### Changes
- New: `src/vue/components/TLogSearchPager.ts`
- New: `src/vue/log/use-tlog-search-results-page.ts`
- New: `test/tlog-search-pager.test.ts` (7 tests including integration)
- Updated: `src/experimental.ts` (exports)
- Updated: `docs/components.md`, `docs/generated/components-api.md`
- Updated: `test/package-exports.test.ts`

## Test plan

- [x] Unit tests pass (7 tests in `tlog-search-pager.test.ts`)
- [x] Package export tests pass
- [x] Integration test validates TLogView + useTLogSearchResultsPage + TLogSearchPager + TLogSearchResults wiring