### PR TITLE
feat(TLogSearchBar): add search bar component and search controller composable

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -8,15 +8,15 @@
 
 ## 组件速读
 
-| 类别          | 组件                                                                                    | 典型用途                                        | 适配性判断                                         |
-| ------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------- |
-| Root          | `TerminalProvider`                                                                      | 创建 terminal / renderer / event manager 上下文 | 通用，适合所有宿主                                 |
-| Layout        | `TBox` `TView` `TAnchor` `TFlow` `TRenderLayer` `TRenderPlane`                          | 布局、裁剪、层级、分层组合                      | 通用，和 CLI 业务无关                              |
-| Text / Motion | `TText` `TTransition`                                                                   | 文本渲染、状态切换、动画插值                    | 通用                                               |
-| Input         | `TInput` `TInputBox` `TJsonEditor`                                                      | prompt、表单、结构化文本编辑                    | 通用，但推荐把补全/校验放到插件层                  |
-| Pickers       | `TList` `TVirtualList` `TLogView` `TLogScrollbar` `TLogMinimap` `TSelect` `TPathPicker` | palette、列表、日志、路径选择                   | `TPathPicker` 本体可复用，路径语义由 provider 注入 |
-| Overlay       | `TDialog` `TMultilineModal` `TDebugOverlay`                                             | 对话框、详情查看、调试覆盖层                    | 通用，适合多种宿主                                 |
-| Navigation    | `TRouterView` + `createTerminalRouter()`                                                | 多页面 TUI / shell                              | 通用                                               |
+| 类别          | 组件                                                                                                    | 典型用途                                        | 适配性判断                                         |
+| ------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------- |
+| Root          | `TerminalProvider`                                                                                      | 创建 terminal / renderer / event manager 上下文 | 通用，适合所有宿主                                 |
+| Layout        | `TBox` `TView` `TAnchor` `TFlow` `TRenderLayer` `TRenderPlane`                                          | 布局、裁剪、层级、分层组合                      | 通用，和 CLI 业务无关                              |
+| Text / Motion | `TText` `TTransition`                                                                                   | 文本渲染、状态切换、动画插值                    | 通用                                               |
+| Input         | `TInput` `TInputBox` `TJsonEditor`                                                                      | prompt、表单、结构化文本编辑                    | 通用，但推荐把补全/校验放到插件层                  |
+| Pickers       | `TList` `TVirtualList` `TLogView` `TLogSearchBar` `TLogScrollbar` `TLogMinimap` `TSelect` `TPathPicker` | palette、列表、日志、路径选择                   | `TPathPicker` 本体可复用，路径语义由 provider 注入 |
+| Overlay       | `TDialog` `TMultilineModal` `TDebugOverlay`                                                             | 对话框、详情查看、调试覆盖层                    | 通用，适合多种宿主                                 |
+| Navigation    | `TRouterView` + `createTerminalRouter()`                                                                | 多页面 TUI / shell                              | 通用                                               |
 
 如果你更关心“哪些地方还应该继续做插件化”，建议配合阅读：[扩展性与插件化](./extensibility.md)。
 
@@ -717,6 +717,93 @@ onMounted(refreshOverview);
 />
 ```
 
+### TLogSearchBar
+
+`TLogSearchBar` 是一个 experimental controlled search input companion。它只负责搜索 query / mode / toggle / navigation 的输入与展示，不会直接读取 `TLogView`，也不会自己执行搜索；父组件负责把 query/options 传给 `TLogView`，再把 `TLogViewHandle.getSearchState()` 回填给 search bar。
+
+- query 是受控值，组件内部只维护 cursor / focus / scroll offset
+- `Enter` emit `next`，`Shift+Enter` emit `previous`，`Esc` emit `clear`
+- click `[T]` / `[R]`、`[Aa]`、`[W]` 只 emit update events，不直接触发搜索
+- `mode="regex"` 时 `wholeWord` toggle 会渲染为 disabled，并且 click 不会 emit `update:wholeWord`
+- `state.status` 可以驱动 `Scanning…`、`current/matchCount`、`Invalid regex` 等展示
+
+```vue
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import {
+  TLogSearchBar,
+  TLogView,
+  type TLogSearchBarState,
+  type TLogViewHandle,
+} from "@simon_he/vue-tui/experimental";
+
+const logView = ref<TLogViewHandle | null>(null);
+const query = ref("");
+const mode = ref<"text" | "regex">("text");
+const caseSensitive = ref(false);
+const wholeWord = ref(false);
+const searchState = ref({
+  status: "idle",
+  matchCount: 0,
+  currentMatchIndex: -1,
+  error: null,
+});
+
+function refreshSearchUi() {
+  const next = logView.value?.getSearchState();
+  searchState.value = {
+    status: next?.status ?? "idle",
+    matchCount: next?.matchCount ?? 0,
+    currentMatchIndex: next?.currentMatchIndex ?? -1,
+    error: next?.error ?? null,
+  };
+}
+
+const barState = computed<TLogSearchBarState>(() => ({
+  query: query.value,
+  mode: mode.value,
+  caseSensitive: caseSensitive.value,
+  wholeWord: wholeWord.value,
+  status: searchState.value.status,
+  matchCount: searchState.value.matchCount,
+  currentMatchIndex: searchState.value.currentMatchIndex,
+  error: searchState.value.error,
+}));
+</script>
+
+<TLogSearchBar
+  :x="0"
+  :y="0"
+  :w="80"
+  :state="barState"
+  @update:query="query = $event"
+  @update:mode="mode = $event"
+  @update:caseSensitive="caseSensitive = $event"
+  @update:wholeWord="wholeWord = $event"
+  @previous="logView?.findPrevious()"
+  @next="logView?.findNext()"
+  @clear="query = ''"
+/>
+
+<TLogView
+  ref="logView"
+  :x="0"
+  :y="1"
+  :w="80"
+  :h="20"
+  :source="log.source"
+  :version="log.version"
+  :search-query="query"
+  :search-options="{
+    mode,
+    caseSensitive,
+    wholeWord,
+  }"
+  @search="refreshSearchUi"
+  @searchMatch="refreshSearchUi"
+/>
+```
+
 ### TLogSearchResults
 
 `TLogSearchResults` 是一个 experimental search result panel，用来渲染当前页搜索结果预览。它只消费外部准备好的 result items，不持有 search state，也不会直接读取 `TLogView` 或 log source。
@@ -800,6 +887,116 @@ function onSelect(payload: TLogSearchResultsSelectPayload) {
 - click `◀` / `▶` 和 `ArrowLeft` / `ArrowRight` / `PageUp` / `PageDown` 都只 emit，父组件负责接到 composable 或 handle
 
 `useTLogSearchResultsPage` 负责从 `TLogViewHandle` 拉取当前页结果、同步 page-local `activeIndex`、clamp 页码，并在 `selectResult(matchIndex)` 时调用 `selectSearchMatch(matchIndex)` 后刷新当前页状态。推荐把它和 `TLogSearchResults` / `TLogSearchPager` 一起使用，而不是在父组件里重复手写 `offset`、`pageSize`、`currentMatchIndex` 同步逻辑。
+
+### Search UX suite wiring
+
+如果你希望把 `TLogSearchBar`、`TLogSearchResults`、`TLogSearchPager`、`TLogScrollbar` 和 `TLogMinimap` 一起接成完整搜索体验，推荐直接使用 `useTLogSearchController`。它会集中管理：
+
+- `query` / `mode` / `caseSensitive` / `wholeWord`
+- `searchBarState`
+- `resultsPage`
+- `markers`
+- `metrics`
+- `searchHistory` / `savedSearches`
+
+```vue
+<script setup lang="ts">
+import { ref } from "vue";
+import {
+  TLogMinimap,
+  TLogScrollbar,
+  TLogSearchBar,
+  TLogSearchPager,
+  TLogSearchResults,
+  TLogView,
+  useTLogSearchController,
+  type TLogViewHandle,
+} from "@simon_he/vue-tui/experimental";
+
+const logView = ref<TLogViewHandle | null>(null);
+const search = useTLogSearchController(logView, {
+  pageSize: 20,
+  includePreview: true,
+  previewWidth: 64,
+});
+
+function refreshSuite() {
+  search.refresh();
+}
+</script>
+
+<TLogSearchBar
+  :x="0"
+  :y="0"
+  :w="80"
+  :state="search.searchBarState"
+  @update:query="search.updateQuery"
+  @update:mode="search.updateMode"
+  @update:caseSensitive="search.updateCaseSensitive"
+  @update:wholeWord="search.updateWholeWord"
+  @previous="search.previousMatch"
+  @next="search.nextMatch"
+  @clear="search.clearSearch"
+/>
+
+<TLogView
+  ref="logView"
+  :x="0"
+  :y="1"
+  :w="60"
+  :h="20"
+  :source="log.source"
+  :version="log.version"
+  :search-query="search.query"
+  :search-options="{
+    mode: search.mode,
+    caseSensitive: search.caseSensitive,
+    wholeWord: search.wholeWord,
+    regexFlags: search.regexFlags,
+  }"
+  @scroll="refreshSuite"
+  @visualIndex="refreshSuite"
+  @search="refreshSuite"
+  @searchMatch="refreshSuite"
+  @searchMarkers="refreshSuite"
+/>
+
+<TLogSearchResults
+  :x="61"
+  :y="1"
+  :w="19"
+  :h="17"
+  :results="search.resultsPage.state.results"
+  :active-index="search.resultsPage.state.activeIndex"
+  @select="({ matchIndex }) => search.selectMatch(matchIndex)"
+/>
+
+<TLogSearchPager
+  :x="61"
+  :y="18"
+  :w="19"
+  :state="search.resultsPage.state"
+  @previousPage="search.resultsPage.previousPage"
+  @nextPage="search.resultsPage.nextPage"
+/>
+
+<TLogScrollbar
+  :x="80"
+  :y="1"
+  :h="20"
+  :metrics="search.metrics"
+  :markers="search.markers.map((marker) => ({ visualRow: marker.visualRow, current: marker.current }))"
+/>
+
+<TLogMinimap
+  :x="81"
+  :y="1"
+  :w="2"
+  :h="20"
+  :metrics="search.metrics"
+  :markers="search.markers.map((marker) => ({ visualRow: marker.visualRow, current: marker.current }))"
+/>
+```
 
 ### Events
 

--- a/docs/generated/components-api.md
+++ b/docs/generated/components-api.md
@@ -16,6 +16,7 @@
 - [TList](#tlist)
 - [TLogMinimap](#tlogminimap)
 - [TLogScrollbar](#tlogscrollbar)
+- [TLogSearchBar](#tlogsearchbar)
 - [TLogSearchPager](#tlogsearchpager)
 - [TLogSearchResults](#tlogsearchresults)
 - [TLogView](#tlogview)
@@ -449,6 +450,49 @@
 | <code>scrollTo</code>    | —       | —    |
 | <code>scrollBy</code>    | —       | —    |
 | <code>markerClick</code> | —       | —    |
+
+## TLogSearchBar
+
+源码：`src/vue/components/TLogSearchBar.ts`
+
+### Props
+
+| 名称                             | 类型                            | 默认值                                                            | 必填 | 说明 |
+| -------------------------------- | ------------------------------- | ----------------------------------------------------------------- | ---- | ---- |
+| <code>x</code>                   | <code>number</code>             | —                                                                 | 是   | —    |
+| <code>y</code>                   | <code>number</code>             | —                                                                 | 是   | —    |
+| <code>w</code>                   | <code>number</code>             | —                                                                 | 是   | —    |
+| <code>zIndex</code>              | <code>number</code>             | <code>0</code>                                                    | 否   | —    |
+| <code>state</code>               | <code>TLogSearchBarState</code> | —                                                                 | 是   | —    |
+| <code>placeholder</code>         | <code>string</code>             | <code>&quot;Search…&quot;</code>                                  | 否   | —    |
+| <code>style</code>               | <code>Style</code>              | <code>undefined</code>                                            | 否   | —    |
+| <code>inputStyle</code>          | <code>Style</code>              | <code>undefined</code>                                            | 否   | —    |
+| <code>activeStyle</code>         | <code>Style</code>              | <code>() =&gt; ({ inverse: true })</code>                         | 否   | —    |
+| <code>errorStyle</code>          | <code>Style</code>              | <code>() =&gt; ({ fg: &quot;redBright&quot;, bold: true })</code> | 否   | —    |
+| <code>disabledStyle</code>       | <code>Style</code>              | <code>() =&gt; ({ dim: true })</code>                             | 否   | —    |
+| <code>toggleStyle</code>         | <code>Style</code>              | <code>undefined</code>                                            | 否   | —    |
+| <code>focusable</code>           | <code>boolean</code>            | <code>true</code>                                                 | 否   | —    |
+| <code>showModeToggle</code>      | <code>boolean</code>            | <code>true</code>                                                 | 否   | —    |
+| <code>showCaseToggle</code>      | <code>boolean</code>            | <code>true</code>                                                 | 否   | —    |
+| <code>showWholeWordToggle</code> | <code>boolean</code>            | <code>true</code>                                                 | 否   | —    |
+| <code>showCount</code>           | <code>boolean</code>            | <code>true</code>                                                 | 否   | —    |
+| <code>showNavigation</code>      | <code>boolean</code>            | <code>true</code>                                                 | 否   | —    |
+
+### Events
+
+| 名称                              | Payload | 说明 |
+| --------------------------------- | ------- | ---- |
+| <code>update</code>               | —       | —    |
+| <code>update:query</code>         | —       | —    |
+| <code>update:mode</code>          | —       | —    |
+| <code>update:caseSensitive</code> | —       | —    |
+| <code>update:wholeWord</code>     | —       | —    |
+| <code>previous</code>             | —       | —    |
+| <code>next</code>                 | —       | —    |
+| <code>clear</code>                | —       | —    |
+| <code>focus</code>                | —       | —    |
+| <code>blur</code>                 | —       | —    |
+| <code>keydown</code>              | —       | —    |
 
 ## TLogSearchPager
 

--- a/src/experimental.ts
+++ b/src/experimental.ts
@@ -2,9 +2,11 @@ export { TVirtualList } from "./vue/components/TVirtualList.js";
 export { TLogView } from "./vue/components/TLogView.js";
 export { TLogScrollbar } from "./vue/components/TLogScrollbar.js";
 export { TLogMinimap } from "./vue/components/TLogMinimap.js";
+export { TLogSearchBar } from "./vue/components/TLogSearchBar.js";
 export { TLogSearchResults } from "./vue/components/TLogSearchResults.js";
 export { TLogSearchPager } from "./vue/components/TLogSearchPager.js";
 export { createAppendOnlyLogStore } from "./vue/log/append-only-log-store.js";
+export { useTLogSearchController } from "./vue/log/use-tlog-search-controller.js";
 export { useTLogSearchResultsPage } from "./vue/log/use-tlog-search-results-page.js";
 export type { RowScrollMode } from "./vue/components/TVirtualList.js";
 export type {
@@ -21,6 +23,12 @@ export type {
   TLogScrollbarScrollByPayload,
   TLogScrollbarScrollToPayload,
 } from "./vue/components/TLogScrollbar.js";
+export type {
+  TLogSearchBarMode,
+  TLogSearchBarNavigatePayload,
+  TLogSearchBarState,
+  TLogSearchBarUpdatePayload,
+} from "./vue/components/TLogSearchBar.js";
 export type {
   TLogSearchPagerPageChangePayload,
   TLogSearchPagerState,
@@ -60,6 +68,10 @@ export type {
   TLogViewVisualIndexOptions,
   TLogViewVisualIndexStatus,
 } from "./vue/log/types.js";
+export type {
+  TLogSavedSearch,
+  UseTLogSearchControllerOptions,
+} from "./vue/log/use-tlog-search-controller.js";
 export type {
   TLogSearchResultsPageState,
   UseTLogSearchResultsPageOptions,

--- a/src/vue/components/TLogSearchBar.ts
+++ b/src/vue/components/TLogSearchBar.ts
@@ -1,0 +1,646 @@
+import type { PropType } from "vue";
+import type { Style } from "../../core/types.js";
+import type { Rect, TerminalKeyboardEvent, TerminalPointerEvent } from "../../events/index.js";
+import type { TLogViewSearchError } from "./TLogView.js";
+import { computed, defineComponent, h, inject, ref, watch } from "vue";
+import { useLayout } from "../composables/use-layout.js";
+import { useRenderNode } from "../composables/use-render-node.js";
+import { useTerminalNode } from "../composables/use-terminal-node.js";
+import { useTerminal } from "../composables/use-terminal.js";
+import { useVisibility } from "../composables/use-visibility.js";
+import { EventZIndexContextKey } from "../context.js";
+import { intersectRect, translateRect } from "../utils/rect.js";
+import { padEndByCells, sliceByCellsRange, spaces, textCellWidth } from "../utils/text.js";
+
+const EMPTY_RECT: Rect = Object.freeze({ x: 0, y: 0, w: 0, h: 0 });
+const PREVIOUS_CHAR = "◀";
+const NEXT_CHAR = "▶";
+
+export type TLogSearchBarMode = "text" | "regex";
+
+export type TLogSearchBarState = Readonly<{
+  query: string;
+  mode: TLogSearchBarMode;
+  caseSensitive: boolean;
+  wholeWord: boolean;
+  status: "idle" | "scanning" | "done" | "error";
+  matchCount: number;
+  currentMatchIndex: number;
+  error?: TLogViewSearchError | null;
+}>;
+
+export type TLogSearchBarUpdatePayload = Readonly<{
+  query: string;
+  mode: TLogSearchBarMode;
+  caseSensitive: boolean;
+  wholeWord: boolean;
+}>;
+
+export type TLogSearchBarNavigatePayload = Readonly<{
+  direction: "previous" | "next";
+}>;
+
+type Action = "mode" | "case" | "wholeWord" | "previous" | "next";
+type PaintPiece = Readonly<{
+  start: number;
+  text: string;
+  style: Style;
+}>;
+type HitTarget = Readonly<{
+  start: number;
+  end: number;
+  action: Action;
+}>;
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function normalizeInt(value: number): number {
+  const n = Math.floor(Number(value));
+  return Number.isFinite(n) ? n : 0;
+}
+
+function mergeStyle(base: Style, overlay?: Style): Style {
+  return overlay ? { ...base, ...overlay } : base;
+}
+
+function isPrintableKey(e: TerminalKeyboardEvent): boolean {
+  if (e.ctrlKey || e.metaKey || e.altKey) return false;
+  return e.key.length === 1;
+}
+
+function stringIndexToCell(text: string, index: number): number {
+  return textCellWidth(text.slice(0, clamp(index, 0, text.length)));
+}
+
+function cellToStringIndex(text: string, cell: number): number {
+  const target = Math.max(0, Math.floor(cell));
+  let index = 0;
+  let used = 0;
+  for (const char of text) {
+    const cells = Math.max(1, textCellWidth(char));
+    const midpoint = used + Math.floor(cells / 2);
+    if (target <= midpoint) return index;
+    used += cells;
+    index += char.length;
+    if (target < used) return index;
+  }
+  return text.length;
+}
+
+function errorLabel(error: TLogViewSearchError | null | undefined): string {
+  if (error?.kind === "invalid-regex") return "Invalid regex";
+  return "Search error";
+}
+
+export const TLogSearchBar = defineComponent({
+  name: "TLogSearchBar",
+  props: {
+    x: { type: Number, required: true },
+    y: { type: Number, required: true },
+    w: { type: Number, required: true },
+    zIndex: { type: Number, default: 0 },
+    state: {
+      type: Object as PropType<TLogSearchBarState>,
+      required: true,
+    },
+    placeholder: {
+      type: String,
+      default: "Search…",
+    },
+    style: { type: Object as PropType<Style>, default: undefined },
+    inputStyle: { type: Object as PropType<Style>, default: undefined },
+    activeStyle: {
+      type: Object as PropType<Style>,
+      default: () => ({ inverse: true }),
+    },
+    errorStyle: {
+      type: Object as PropType<Style>,
+      default: () => ({ fg: "redBright", bold: true }),
+    },
+    disabledStyle: {
+      type: Object as PropType<Style>,
+      default: () => ({ dim: true }),
+    },
+    toggleStyle: { type: Object as PropType<Style>, default: undefined },
+    focusable: { type: Boolean, default: true },
+    showModeToggle: { type: Boolean, default: true },
+    showCaseToggle: { type: Boolean, default: true },
+    showWholeWordToggle: { type: Boolean, default: true },
+    showCount: { type: Boolean, default: true },
+    showNavigation: { type: Boolean, default: true },
+  },
+  emits: [
+    "update",
+    "update:query",
+    "update:mode",
+    "update:caseSensitive",
+    "update:wholeWord",
+    "previous",
+    "next",
+    "clear",
+    "focus",
+    "blur",
+    "keydown",
+  ],
+  setup(props, { emit }) {
+    const { terminal, scheduler, defaultStyle, events } = useTerminal();
+    const parent = useLayout();
+    const { visible, rootProps } = useVisibility();
+    const parentEventZ = inject(EventZIndexContextKey, computed(() => 0) as any);
+    const eventZ = computed(() => (parentEventZ.value ?? 0) + (props.zIndex ?? 0));
+    const focused = ref(false);
+    const cursor = ref(0);
+    const scrollCellOffset = ref(0);
+    const pendingUpdate = ref<TLogSearchBarUpdatePayload | null>(null);
+
+    const fullRect = computed<Rect>(() =>
+      translateRect(
+        {
+          x: normalizeInt(props.x),
+          y: normalizeInt(props.y),
+          w: Math.max(0, normalizeInt(props.w)),
+          h: 1,
+        },
+        parent.originX,
+        parent.originY,
+      ),
+    );
+
+    const rect = computed<Rect>(() => {
+      const translated = fullRect.value;
+      if (!parent.clipRect) return translated;
+      return intersectRect(translated, parent.clipRect) ?? EMPTY_RECT;
+    });
+
+    function liveUpdateState(): TLogSearchBarUpdatePayload {
+      return (
+        pendingUpdate.value ?? {
+          query: props.state.query,
+          mode: props.state.mode,
+          caseSensitive: props.state.caseSensitive,
+          wholeWord: props.state.wholeWord,
+        }
+      );
+    }
+
+    function ensureCursorVisible(query: string, inputWidth: number): void {
+      if (inputWidth <= 0) {
+        scrollCellOffset.value = 0;
+        return;
+      }
+      const totalCells = textCellWidth(query);
+      const maxScroll = Math.max(0, totalCells - inputWidth);
+      const cursorCell = stringIndexToCell(query, cursor.value);
+      let nextScroll = clamp(scrollCellOffset.value, 0, maxScroll);
+      if (cursorCell < nextScroll) nextScroll = cursorCell;
+      if (cursorCell >= nextScroll + inputWidth) nextScroll = cursorCell - inputWidth + 1;
+      scrollCellOffset.value = clamp(nextScroll, 0, maxScroll);
+    }
+
+    const statusText = computed(() => {
+      if (props.state.status === "error") return errorLabel(props.state.error);
+      if (props.state.status === "scanning") {
+        if (!props.showCount || props.state.matchCount <= 0) return "Scanning…";
+        return `Scanning… ${props.state.matchCount}`;
+      }
+      if (!props.showCount) return "";
+      if (!props.state.query) return "";
+      const current =
+        props.state.matchCount > 0 && props.state.currentMatchIndex >= 0
+          ? props.state.currentMatchIndex + 1
+          : 0;
+      return `${current}/${props.state.matchCount}`;
+    });
+
+    const rowLayout = computed(() => {
+      const width = Math.max(0, normalizeInt(props.w));
+      const base = props.style ?? defaultStyle.value;
+      const toggleBase = mergeStyle(base, props.toggleStyle);
+      const active = mergeStyle(toggleBase, props.activeStyle);
+      const disabled = mergeStyle(toggleBase, props.disabledStyle);
+      const error = mergeStyle(base, props.errorStyle);
+      const navigationEnabled =
+        props.state.matchCount > 0 &&
+        props.state.status !== "error" &&
+        props.state.query.length > 0;
+
+      const prefixPieces: PaintPiece[] = [];
+      const suffixSpecs: Array<{
+        text: string;
+        style: Style;
+        action?: Action;
+      }> = [];
+      const hits: HitTarget[] = [];
+
+      let prefixWidth = 0;
+      const pushPrefix = (text: string, style: Style, action?: Action): void => {
+        if (!text) return;
+        const pieceWidth = textCellWidth(text);
+        prefixPieces.push({ start: prefixWidth, text, style });
+        if (action) hits.push({ start: prefixWidth, end: prefixWidth + pieceWidth, action });
+        prefixWidth += pieceWidth;
+      };
+
+      if (props.showModeToggle) {
+        pushPrefix(
+          props.state.mode === "regex" ? "[R]" : "[T]",
+          props.state.mode === "regex" ? active : toggleBase,
+          "mode",
+        );
+        pushPrefix(" ", base);
+      }
+
+      if (props.showCaseToggle) {
+        pushPrefix("[Aa]", props.state.caseSensitive ? active : toggleBase, "case");
+        pushPrefix(" ", base);
+      }
+
+      if (props.showWholeWordToggle) {
+        const wholeWordEnabled = props.state.mode !== "regex";
+        pushPrefix(
+          "[W]",
+          wholeWordEnabled ? (props.state.wholeWord ? active : toggleBase) : disabled,
+          "wholeWord",
+        );
+        pushPrefix(" ", base);
+      }
+
+      let suffixWidth = 0;
+      const pushSuffix = (text: string, style: Style, action?: Action): void => {
+        if (!text) return;
+        const pieceWidth = textCellWidth(text);
+        suffixSpecs.push({ text, style, action });
+        suffixWidth += pieceWidth;
+      };
+
+      const status = statusText.value;
+      if (status) {
+        pushSuffix(` ${status}`, props.state.status === "error" ? error : base);
+      }
+      if (props.showNavigation) {
+        pushSuffix(" ", base);
+        pushSuffix(
+          PREVIOUS_CHAR,
+          navigationEnabled ? active : disabled,
+          navigationEnabled ? "previous" : undefined,
+        );
+        pushSuffix(" ", base);
+        pushSuffix(
+          NEXT_CHAR,
+          navigationEnabled ? active : disabled,
+          navigationEnabled ? "next" : undefined,
+        );
+      }
+
+      const inputWidth = width > 0 ? Math.max(1, width - prefixWidth - suffixWidth) : 0;
+      const inputStart = prefixWidth;
+      const suffixStart = inputStart + inputWidth;
+
+      const pieces: PaintPiece[] = [...prefixPieces];
+      let suffixOffset = 0;
+      for (const piece of suffixSpecs) {
+        const start = suffixStart + suffixOffset;
+        const pieceWidth = textCellWidth(piece.text);
+        pieces.push({ start, text: piece.text, style: piece.style });
+        if (piece.action) hits.push({ start, end: start + pieceWidth, action: piece.action });
+        suffixOffset += pieceWidth;
+      }
+
+      return {
+        base,
+        error,
+        inputStart,
+        inputWidth,
+        pieces,
+        hits: hits.filter((hit) => hit.end > hit.start),
+      };
+    });
+
+    function focusSelf(): void {
+      const nodeId = eventNode.id.value;
+      if (nodeId) events.value?.focus(nodeId);
+    }
+
+    function applyUpdate(
+      next: TLogSearchBarUpdatePayload,
+      field:
+        | Readonly<{ name: "query"; value: string }>
+        | Readonly<{ name: "mode"; value: TLogSearchBarMode }>
+        | Readonly<{ name: "caseSensitive"; value: boolean }>
+        | Readonly<{ name: "wholeWord"; value: boolean }>,
+    ): void {
+      pendingUpdate.value = next;
+      emit(`update:${field.name}`, field.value);
+      emit("update", next satisfies TLogSearchBarUpdatePayload);
+      scheduler.invalidate({ reason: "input" });
+    }
+
+    function emitNavigation(direction: "previous" | "next"): void {
+      emit(direction, { direction } satisfies TLogSearchBarNavigatePayload);
+      scheduler.invalidate({ reason: "input" });
+    }
+
+    function setCursorFromLocalX(localX: number): void {
+      const layout = rowLayout.value;
+      if (layout.inputWidth <= 0) return;
+      const query = props.state.query;
+      if (!query) {
+        cursor.value = 0;
+        scrollCellOffset.value = 0;
+        scheduler.invalidate({ reason: "input" });
+        return;
+      }
+      const relativeCell = clamp(localX - layout.inputStart, 0, layout.inputWidth);
+      cursor.value = cellToStringIndex(query, scrollCellOffset.value + relativeCell);
+      ensureCursorVisible(query, layout.inputWidth);
+      scheduler.invalidate({ reason: "input" });
+    }
+
+    function toggleMode(): void {
+      const current = liveUpdateState();
+      const mode = current.mode === "regex" ? "text" : "regex";
+      applyUpdate({ ...current, mode }, { name: "mode", value: mode });
+    }
+
+    function toggleCaseSensitive(): void {
+      const current = liveUpdateState();
+      const caseSensitive = !current.caseSensitive;
+      applyUpdate({ ...current, caseSensitive }, { name: "caseSensitive", value: caseSensitive });
+    }
+
+    function toggleWholeWord(): void {
+      const current = liveUpdateState();
+      if (current.mode === "regex") return;
+      const wholeWord = !current.wholeWord;
+      applyUpdate({ ...current, wholeWord }, { name: "wholeWord", value: wholeWord });
+    }
+
+    function updateQuery(nextQuery: string, nextCursor = cursor.value): void {
+      const current = liveUpdateState();
+      cursor.value = clamp(nextCursor, 0, nextQuery.length);
+      applyUpdate({ ...current, query: nextQuery }, { name: "query", value: nextQuery });
+      ensureCursorVisible(nextQuery, rowLayout.value.inputWidth);
+    }
+
+    function onClick(e: TerminalPointerEvent): void {
+      const full = fullRect.value;
+      if (e.cellY !== full.y) return;
+      focusSelf();
+      const localX = e.cellX - full.x;
+      if (localX < 0 || localX >= full.w) return;
+      const layout = rowLayout.value;
+
+      for (const hit of layout.hits) {
+        if (localX < hit.start || localX >= hit.end) continue;
+        if (hit.action === "mode") toggleMode();
+        else if (hit.action === "case") toggleCaseSensitive();
+        else if (hit.action === "wholeWord") toggleWholeWord();
+        else emitNavigation(hit.action);
+        e.preventDefault?.();
+        return;
+      }
+
+      if (localX >= layout.inputStart && localX < layout.inputStart + layout.inputWidth) {
+        setCursorFromLocalX(localX);
+        e.preventDefault?.();
+      }
+    }
+
+    function onKeydown(e: TerminalKeyboardEvent): void {
+      emit("keydown", e);
+
+      if (e.key === "Enter") {
+        e.preventDefault();
+        emitNavigation(e.shiftKey ? "previous" : "next");
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        cursor.value = 0;
+        scrollCellOffset.value = 0;
+        emit("clear");
+        scheduler.invalidate({ reason: "input" });
+        return;
+      }
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        cursor.value = clamp(cursor.value - 1, 0, props.state.query.length);
+        ensureCursorVisible(props.state.query, rowLayout.value.inputWidth);
+        scheduler.invalidate({ reason: "input" });
+        return;
+      }
+      if (e.key === "ArrowRight") {
+        e.preventDefault();
+        cursor.value = clamp(cursor.value + 1, 0, props.state.query.length);
+        ensureCursorVisible(props.state.query, rowLayout.value.inputWidth);
+        scheduler.invalidate({ reason: "input" });
+        return;
+      }
+      if (e.key === "Home") {
+        e.preventDefault();
+        cursor.value = 0;
+        ensureCursorVisible(props.state.query, rowLayout.value.inputWidth);
+        scheduler.invalidate({ reason: "input" });
+        return;
+      }
+      if (e.key === "End") {
+        e.preventDefault();
+        cursor.value = props.state.query.length;
+        ensureCursorVisible(props.state.query, rowLayout.value.inputWidth);
+        scheduler.invalidate({ reason: "input" });
+        return;
+      }
+      if (e.key === "Backspace") {
+        const query = liveUpdateState().query;
+        if (cursor.value <= 0 || !query) return;
+        e.preventDefault();
+        updateQuery(query.slice(0, cursor.value - 1) + query.slice(cursor.value), cursor.value - 1);
+        return;
+      }
+      if (e.key === "Delete") {
+        const query = liveUpdateState().query;
+        if (cursor.value >= query.length) return;
+        e.preventDefault();
+        updateQuery(query.slice(0, cursor.value) + query.slice(cursor.value + 1), cursor.value);
+        return;
+      }
+
+      const lowerKey = e.key.toLowerCase();
+      if (e.ctrlKey && !e.altKey && !e.metaKey && lowerKey === "r") {
+        e.preventDefault();
+        toggleMode();
+        return;
+      }
+      if (
+        ((e.altKey && !e.ctrlKey && !e.metaKey && lowerKey === "c") ||
+          (e.ctrlKey && !e.altKey && !e.metaKey && lowerKey === "i")) &&
+        !e.shiftKey
+      ) {
+        e.preventDefault();
+        toggleCaseSensitive();
+        return;
+      }
+      if (e.altKey && !e.ctrlKey && !e.metaKey && lowerKey === "w") {
+        e.preventDefault();
+        toggleWholeWord();
+        return;
+      }
+
+      if (isPrintableKey(e)) {
+        e.preventDefault();
+        const query = liveUpdateState().query;
+        updateQuery(
+          query.slice(0, cursor.value) + e.key + query.slice(cursor.value),
+          cursor.value + e.key.length,
+        );
+      }
+    }
+
+    watch(
+      () => [
+        props.state.query,
+        props.state.mode,
+        props.state.caseSensitive,
+        props.state.wholeWord,
+        props.w,
+      ],
+      () => {
+        pendingUpdate.value = null;
+        cursor.value = clamp(cursor.value, 0, props.state.query.length);
+        ensureCursorVisible(props.state.query, rowLayout.value.inputWidth);
+      },
+      { immediate: true },
+    );
+
+    const eventNode = useTerminalNode(() => ({
+      rect: rect.value,
+      zIndex: eventZ.value,
+      visible: visible.value,
+      focusable: props.focusable,
+      handlers: {
+        click: onClick,
+        focus: () => {
+          focused.value = true;
+          emit("focus");
+          scheduler.invalidate();
+        },
+        blur: () => {
+          focused.value = false;
+          emit("blur");
+          scheduler.invalidate();
+        },
+        keydown: onKeydown,
+      },
+    }));
+
+    useRenderNode(() => ({
+      zIndex: props.zIndex,
+      rect: visible.value ? rect.value : EMPTY_RECT,
+      deps: [
+        visible.value,
+        rect.value,
+        fullRect.value,
+        props.state,
+        props.placeholder,
+        props.style,
+        props.inputStyle,
+        props.activeStyle,
+        props.errorStyle,
+        props.disabledStyle,
+        props.toggleStyle,
+        props.showModeToggle,
+        props.showCaseToggle,
+        props.showWholeWordToggle,
+        props.showCount,
+        props.showNavigation,
+        defaultStyle.value,
+        focused.value,
+        cursor.value,
+        scrollCellOffset.value,
+        rowLayout.value,
+      ],
+      paint: () => {
+        if (!visible.value) return;
+        const r = rect.value;
+        if (r.w <= 0 || r.h <= 0) return;
+
+        const full = fullRect.value;
+        const layout = rowLayout.value;
+        terminal.write(spaces(r.w), { x: r.x, y: r.y, style: layout.base });
+
+        const query = props.state.query;
+        const isPlaceholder = !query;
+        const inputStyle =
+          props.state.status === "error"
+            ? mergeStyle(layout.base, props.errorStyle)
+            : mergeStyle(layout.base, props.inputStyle);
+        const placeholderStyle = mergeStyle(inputStyle, props.disabledStyle);
+        const cursorStyle = { inverse: true, ...inputStyle, ...props.activeStyle } satisfies Style;
+
+        if (layout.inputWidth > 0) {
+          const visibleText = isPlaceholder
+            ? sliceByCellsRange(props.placeholder, 0, layout.inputWidth)
+            : sliceByCellsRange(
+                query,
+                scrollCellOffset.value,
+                scrollCellOffset.value + layout.inputWidth,
+              );
+          const padded = padEndByCells(visibleText, layout.inputWidth);
+          const drawX = full.x + layout.inputStart;
+          const drawStyle = isPlaceholder ? placeholderStyle : inputStyle;
+          const clippedStart = Math.max(0, r.x - drawX);
+          const clippedEnd = Math.min(layout.inputWidth, r.x + r.w - drawX);
+          if (clippedEnd > clippedStart) {
+            const clipped = sliceByCellsRange(padded, clippedStart, clippedEnd);
+            terminal.write(clipped, { x: Math.max(drawX, r.x), y: r.y, style: drawStyle });
+          }
+
+          if (focused.value) {
+            const cursorLocal = isPlaceholder
+              ? 0
+              : clamp(
+                  stringIndexToCell(query, cursor.value) - scrollCellOffset.value,
+                  0,
+                  Math.max(0, layout.inputWidth - 1),
+                );
+            const cursorX = drawX + cursorLocal;
+            if (cursorX >= r.x && cursorX < r.x + r.w) {
+              const cursorChar =
+                !isPlaceholder && cursor.value < query.length
+                  ? sliceByCellsRange(
+                      query,
+                      stringIndexToCell(query, cursor.value),
+                      stringIndexToCell(query, cursor.value) + 1,
+                    ) || " "
+                  : " ";
+              terminal.write(cursorChar, { x: cursorX, y: r.y, style: cursorStyle });
+            }
+          }
+        }
+
+        for (const piece of layout.pieces) {
+          const drawX = full.x + piece.start;
+          const pieceWidth = textCellWidth(piece.text);
+          const clippedStart = Math.max(0, r.x - drawX);
+          const clippedEnd = Math.min(pieceWidth, r.x + r.w - drawX);
+          if (clippedEnd <= clippedStart) continue;
+          const clipped = sliceByCellsRange(piece.text, clippedStart, clippedEnd);
+          if (!clipped) continue;
+          terminal.write(clipped, { x: Math.max(drawX, r.x), y: r.y, style: piece.style });
+        }
+      },
+    }));
+
+    return () =>
+      h(
+        "div",
+        {
+          ...rootProps,
+          "data-t-log-search-bar": true,
+        },
+        [],
+      );
+  },
+});

--- a/src/vue/log/use-tlog-search-controller.ts
+++ b/src/vue/log/use-tlog-search-controller.ts
@@ -1,0 +1,277 @@
+import type { Ref } from "vue";
+import type { TLogSearchBarMode, TLogSearchBarState } from "../components/TLogSearchBar.js";
+import type {
+  TLogViewHandle,
+  TLogViewScrollMetrics,
+  TLogViewSearchMarker,
+  TLogViewSearchState,
+} from "../components/TLogView.js";
+import type { UseTLogSearchResultsPageOptions } from "./use-tlog-search-results-page.js";
+import { computed, ref, watch } from "vue";
+import { useTLogSearchResultsPage } from "./use-tlog-search-results-page.js";
+
+const DEFAULT_HISTORY_LIMIT = 20;
+
+export type TLogSavedSearch = Readonly<{
+  id: string;
+  label?: string;
+  query: string;
+  mode: TLogSearchBarMode;
+  caseSensitive?: boolean;
+  wholeWord?: boolean;
+  regexFlags?: string;
+}>;
+
+export type UseTLogSearchControllerOptions = Readonly<
+  UseTLogSearchResultsPageOptions & {
+    initialQuery?: string;
+    initialMode?: TLogSearchBarMode;
+    initialCaseSensitive?: boolean;
+    initialWholeWord?: boolean;
+    initialRegexFlags?: string;
+    maxHistory?: number;
+    initialSavedSearches?: readonly TLogSavedSearch[];
+  }
+>;
+
+function normalizeHistoryLimit(value: number | undefined): number {
+  const n = Math.floor(Number(value ?? DEFAULT_HISTORY_LIMIT));
+  if (!Number.isFinite(n)) return DEFAULT_HISTORY_LIMIT;
+  return Math.max(1, n);
+}
+
+function normalizeSearchState(query = ""): TLogViewSearchState {
+  return {
+    query,
+    status: query ? "done" : "idle",
+    matchCount: 0,
+    currentMatchIndex: -1,
+    error: null,
+  };
+}
+
+function sameSavedSearch(a: TLogSavedSearch, b: Omit<TLogSavedSearch, "id">): boolean {
+  return (
+    a.query === b.query &&
+    a.mode === b.mode &&
+    Boolean(a.caseSensitive) === Boolean(b.caseSensitive) &&
+    Boolean(a.wholeWord) === Boolean(b.wholeWord) &&
+    (a.regexFlags ?? "") === (b.regexFlags ?? "")
+  );
+}
+
+export function useTLogSearchController(
+  logView: Ref<TLogViewHandle | null>,
+  options: UseTLogSearchControllerOptions = {},
+): {
+  query: Ref<string>;
+  mode: Ref<TLogSearchBarMode>;
+  caseSensitive: Ref<boolean>;
+  wholeWord: Ref<boolean>;
+  regexFlags: Ref<string>;
+  searchState: Ref<TLogViewSearchState>;
+  searchBarState: Ref<TLogSearchBarState>;
+  resultsPage: ReturnType<typeof useTLogSearchResultsPage>;
+  markers: Ref<readonly TLogViewSearchMarker[]>;
+  metrics: Ref<TLogViewScrollMetrics | null>;
+  searchHistory: Ref<readonly string[]>;
+  savedSearches: Ref<readonly TLogSavedSearch[]>;
+  updateQuery: (value: string) => void;
+  updateMode: (value: TLogSearchBarMode) => void;
+  updateCaseSensitive: (value: boolean) => void;
+  updateWholeWord: (value: boolean) => void;
+  updateRegexFlags: (value: string) => void;
+  nextMatch: () => void;
+  previousMatch: () => void;
+  clearSearch: () => void;
+  selectMatch: (matchIndex: number) => boolean;
+  refresh: () => void;
+  saveCurrentSearch: (label?: string) => TLogSavedSearch | null;
+  applySavedSearch: (id: string) => boolean;
+} {
+  const query = ref(options.initialQuery ?? "");
+  const mode = ref<TLogSearchBarMode>(options.initialMode === "regex" ? "regex" : "text");
+  const caseSensitive = ref(options.initialCaseSensitive === true);
+  const wholeWord = ref(options.initialWholeWord === true);
+  const regexFlags = ref(options.initialRegexFlags ?? "");
+  const searchState = ref<TLogViewSearchState>(normalizeSearchState(query.value));
+  const markers = ref<readonly TLogViewSearchMarker[]>([]);
+  const metrics = ref<TLogViewScrollMetrics | null>(null);
+  const searchHistory = ref<readonly string[]>([]);
+  const savedSearches = ref<readonly TLogSavedSearch[]>(options.initialSavedSearches ?? []);
+  const historyLimit = normalizeHistoryLimit(options.maxHistory);
+  const resultsPage = useTLogSearchResultsPage(logView, options);
+  let nextSavedSearchId = 0;
+
+  const searchBarState = computed<TLogSearchBarState>(() => ({
+    query: query.value,
+    mode: mode.value,
+    caseSensitive: caseSensitive.value,
+    wholeWord: wholeWord.value,
+    status: searchState.value.status,
+    matchCount: searchState.value.matchCount,
+    currentMatchIndex: searchState.value.currentMatchIndex,
+    error: searchState.value.error ?? null,
+  }));
+
+  function recordHistory(value = query.value): void {
+    const normalized = String(value ?? "").trim();
+    if (!normalized) return;
+    searchHistory.value = [
+      normalized,
+      ...searchHistory.value.filter((entry) => entry !== normalized),
+    ].slice(0, historyLimit);
+  }
+
+  function refresh(): void {
+    const handle = logView.value;
+    if (!handle) {
+      searchState.value = normalizeSearchState(query.value);
+      markers.value = [];
+      metrics.value = null;
+      resultsPage.refresh();
+      return;
+    }
+
+    const next = handle.getSearchState();
+    searchState.value = {
+      query: query.value,
+      status: next.status,
+      matchCount: next.matchCount,
+      currentMatchIndex: next.currentMatchIndex,
+      error: next.error ?? null,
+    };
+    markers.value = handle.getSearchMarkers();
+    metrics.value = handle.getScrollMetrics();
+    resultsPage.refresh();
+  }
+
+  function updateQuery(value: string): void {
+    query.value = String(value ?? "");
+  }
+
+  function updateMode(value: TLogSearchBarMode): void {
+    mode.value = value === "regex" ? "regex" : "text";
+  }
+
+  function updateCaseSensitive(value: boolean): void {
+    caseSensitive.value = value === true;
+  }
+
+  function updateWholeWord(value: boolean): void {
+    wholeWord.value = value === true;
+  }
+
+  function updateRegexFlags(value: string): void {
+    regexFlags.value = String(value ?? "");
+  }
+
+  function nextMatch(): void {
+    recordHistory();
+    logView.value?.findNext();
+    resultsPage.syncPageToCurrentMatch();
+    refresh();
+  }
+
+  function previousMatch(): void {
+    recordHistory();
+    logView.value?.findPrevious();
+    resultsPage.syncPageToCurrentMatch();
+    refresh();
+  }
+
+  function clearSearch(): void {
+    query.value = "";
+    searchState.value = normalizeSearchState("");
+    markers.value = [];
+    resultsPage.refresh();
+  }
+
+  function selectMatch(matchIndex: number): boolean {
+    recordHistory();
+    const selected = resultsPage.selectResult(matchIndex);
+    refresh();
+    return selected;
+  }
+
+  function saveCurrentSearch(label?: string): TLogSavedSearch | null {
+    const normalizedQuery = query.value.trim();
+    if (!normalizedQuery) return null;
+
+    recordHistory(normalizedQuery);
+    const candidate = {
+      label: label?.trim() || undefined,
+      query: normalizedQuery,
+      mode: mode.value,
+      caseSensitive: caseSensitive.value,
+      wholeWord: wholeWord.value,
+      regexFlags: regexFlags.value || undefined,
+    } satisfies Omit<TLogSavedSearch, "id">;
+    const existing = savedSearches.value.find((entry) => sameSavedSearch(entry, candidate));
+    if (existing) {
+      const updated =
+        candidate.label && candidate.label !== existing.label
+          ? { ...existing, label: candidate.label }
+          : existing;
+      savedSearches.value = [
+        updated,
+        ...savedSearches.value.filter((entry) => entry.id !== existing.id),
+      ];
+      return updated;
+    }
+
+    const savedSearch: TLogSavedSearch = {
+      id: `saved-search-${nextSavedSearchId++}`,
+      ...candidate,
+    };
+    savedSearches.value = [savedSearch, ...savedSearches.value];
+    return savedSearch;
+  }
+
+  function applySavedSearch(id: string): boolean {
+    const match = savedSearches.value.find((entry) => entry.id === id);
+    if (!match) return false;
+    query.value = match.query;
+    mode.value = match.mode;
+    caseSensitive.value = match.caseSensitive === true;
+    wholeWord.value = match.wholeWord === true;
+    regexFlags.value = match.regexFlags ?? "";
+    recordHistory(match.query);
+    return true;
+  }
+
+  watch(
+    () => logView.value,
+    () => {
+      refresh();
+    },
+    { immediate: true },
+  );
+
+  return {
+    query,
+    mode,
+    caseSensitive,
+    wholeWord,
+    regexFlags,
+    searchState,
+    searchBarState,
+    resultsPage,
+    markers,
+    metrics,
+    searchHistory,
+    savedSearches,
+    updateQuery,
+    updateMode,
+    updateCaseSensitive,
+    updateWholeWord,
+    updateRegexFlags,
+    nextMatch,
+    previousMatch,
+    clearSearch,
+    selectMatch,
+    refresh,
+    saveCurrentSearch,
+    applySavedSearch,
+  };
+}

--- a/test/package-exports.test.ts
+++ b/test/package-exports.test.ts
@@ -19,8 +19,10 @@ describe("package exports", () => {
     expect("TLogView" in root).toBe(false);
     expect("TLogScrollbar" in root).toBe(false);
     expect("TLogMinimap" in root).toBe(false);
+    expect("TLogSearchBar" in root).toBe(false);
     expect("TLogSearchResults" in root).toBe(false);
     expect("TLogSearchPager" in root).toBe(false);
+    expect("useTLogSearchController" in root).toBe(false);
     expect("useTLogSearchResultsPage" in root).toBe(false);
     expect("createAppendOnlyLogStore" in root).toBe(false);
     expect(root.createFramePerfStore).toBeTruthy();
@@ -29,8 +31,10 @@ describe("package exports", () => {
     expect(experimental.TLogView).toBeTruthy();
     expect(experimental.TLogScrollbar).toBeTruthy();
     expect(experimental.TLogMinimap).toBeTruthy();
+    expect(experimental.TLogSearchBar).toBeTruthy();
     expect(experimental.TLogSearchResults).toBeTruthy();
     expect(experimental.TLogSearchPager).toBeTruthy();
+    expect(experimental.useTLogSearchController).toBeTruthy();
     expect(experimental.useTLogSearchResultsPage).toBeTruthy();
     expect(experimental.createAppendOnlyLogStore).toBeTruthy();
   });
@@ -42,6 +46,10 @@ describe("package exports", () => {
     expect(experimentalSource).toContain("TLogViewLinkActivatePayload");
     expect(experimentalSource).toContain("TLogViewSearchMode");
     expect(experimentalSource).toContain("TLogViewSearchError");
+    expect(experimentalSource).toContain("TLogSearchBarState");
+    expect(experimentalSource).toContain("TLogSearchBarMode");
+    expect(experimentalSource).toContain("TLogSavedSearch");
+    expect(experimentalSource).toContain("useTLogSearchController");
   });
 
   it.skipIf(!requireDistExports)("keeps built ESM/CJS experimental exports usable", async () => {
@@ -67,16 +75,20 @@ describe("package exports", () => {
     expect(experimental.TLogView).toBeTruthy();
     expect(experimental.TLogScrollbar).toBeTruthy();
     expect(experimental.TLogMinimap).toBeTruthy();
+    expect(experimental.TLogSearchBar).toBeTruthy();
     expect(experimental.TLogSearchResults).toBeTruthy();
     expect(experimental.TLogSearchPager).toBeTruthy();
+    expect(experimental.useTLogSearchController).toBeTruthy();
     expect(experimental.useTLogSearchResultsPage).toBeTruthy();
     expect(experimental.createAppendOnlyLogStore).toBeTruthy();
     expect(experimentalCjs.TVirtualList).toBeTruthy();
     expect(experimentalCjs.TLogView).toBeTruthy();
     expect(experimentalCjs.TLogScrollbar).toBeTruthy();
     expect(experimentalCjs.TLogMinimap).toBeTruthy();
+    expect(experimentalCjs.TLogSearchBar).toBeTruthy();
     expect(experimentalCjs.TLogSearchResults).toBeTruthy();
     expect(experimentalCjs.TLogSearchPager).toBeTruthy();
+    expect(experimentalCjs.useTLogSearchController).toBeTruthy();
     expect(experimentalCjs.useTLogSearchResultsPage).toBeTruthy();
     expect(experimentalCjs.createAppendOnlyLogStore).toBeTruthy();
   });

--- a/test/tlog-search-bar.test.ts
+++ b/test/tlog-search-bar.test.ts
@@ -1,0 +1,529 @@
+import type { TLogDataSource, TLogSearchBarState, TLogViewHandle } from "../src/experimental.js";
+import { describe, expect, it, vi } from "vitest";
+import { createTerminalApp } from "../src/index.js";
+import { TLogSearchBar, TLogView } from "../src/experimental.js";
+import {
+  defineComponent,
+  h,
+  mountTerminal,
+  nextTick,
+  onMounted,
+  ref,
+} from "./ui-regressions-support.js";
+
+function rowText(
+  mounted: { terminal: ReturnType<typeof createTerminalApp>["terminal"] },
+  y: number,
+): string {
+  return mounted.terminal
+    .getRow(y)
+    .map((cell) => cell.ch)
+    .join("")
+    .trimEnd();
+}
+
+async function flushSearch(
+  app: ReturnType<typeof createTerminalApp>,
+  handle: TLogViewHandle,
+  maxFrames = 20,
+): Promise<void> {
+  for (let i = 0; i < maxFrames; i++) {
+    await nextTick();
+    app.scheduler.flushNow();
+    if (handle.getSearchState().status !== "scanning") return;
+  }
+}
+
+function createState(overrides: Partial<TLogSearchBarState> = {}): TLogSearchBarState {
+  return {
+    query: "",
+    mode: "text",
+    caseSensitive: false,
+    wholeWord: false,
+    status: "idle",
+    matchCount: 0,
+    currentMatchIndex: -1,
+    error: null,
+    ...overrides,
+  };
+}
+
+describe("TLogSearchBar", () => {
+  it("renders idle, scanning, done and error states", async () => {
+    const state = ref<TLogSearchBarState>(createState());
+    const mounted = await mountTerminal(
+      () =>
+        h(TLogSearchBar, {
+          x: 0,
+          y: 0,
+          w: 32,
+          state: state.value,
+        }),
+      32,
+      1,
+    );
+
+    try {
+      expect(rowText(mounted, 0)).toContain("Search…");
+
+      state.value = createState({ query: "error", status: "scanning", matchCount: 5 });
+      await nextTick();
+      expect(rowText(mounted, 0)).toContain("Scanning… 5");
+
+      state.value = createState({
+        query: "error",
+        status: "done",
+        matchCount: 42,
+        currentMatchIndex: 2,
+      });
+      await nextTick();
+      expect(rowText(mounted, 0)).toContain("3/42");
+
+      state.value = createState({
+        query: "[",
+        mode: "regex",
+        status: "error",
+        error: {
+          kind: "invalid-regex",
+          query: "[",
+          flags: "g",
+          message: "Invalid regular expression",
+        },
+      });
+      await nextTick();
+      expect(rowText(mounted, 0)).toContain("Invalid regex");
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("emits controlled query updates while typing", async () => {
+    const onUpdateQuery = vi.fn();
+    const onUpdate = vi.fn();
+    const state = ref<TLogSearchBarState>(createState());
+    const app = createTerminalApp({
+      cols: 24,
+      rows: 1,
+      component: defineComponent({
+        name: "TLogSearchBarTypingApp",
+        setup() {
+          function updateQuery(query: string): void {
+            state.value = createState({ ...state.value, query });
+            onUpdateQuery(query);
+          }
+
+          return () =>
+            h(TLogSearchBar, {
+              x: 0,
+              y: 0,
+              w: 24,
+              state: state.value,
+              onUpdate,
+              "onUpdate:query": updateQuery,
+            });
+        },
+      }),
+    });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "click", cellX: 13, cellY: 0, time: Date.now() } as any);
+      app.events.dispatch({ type: "keydown", key: "E", code: "KeyE", time: Date.now() } as any);
+      await nextTick();
+
+      expect(onUpdateQuery).toHaveBeenCalledWith("E");
+      expect(onUpdate).toHaveBeenCalledWith({
+        query: "E",
+        mode: "text",
+        caseSensitive: false,
+        wholeWord: false,
+      });
+      expect(state.value.query).toBe("E");
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("supports Backspace, Delete and cursor movement", async () => {
+    const state = ref<TLogSearchBarState>(createState());
+    const app = createTerminalApp({
+      cols: 24,
+      rows: 1,
+      component: defineComponent({
+        name: "TLogSearchBarEditingApp",
+        setup() {
+          return () =>
+            h(TLogSearchBar, {
+              x: 0,
+              y: 0,
+              w: 24,
+              state: state.value,
+              "onUpdate:query": (query: string) => {
+                state.value = createState({ ...state.value, query });
+              },
+            });
+        },
+      }),
+    });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "click", cellX: 13, cellY: 0, time: Date.now() } as any);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      for (const key of "ERROR") {
+        app.events.dispatch({
+          type: "keydown",
+          key,
+          code: `Key${key}`,
+          time: Date.now(),
+        } as any);
+        await nextTick();
+        app.scheduler.flushNow();
+      }
+
+      app.events.dispatch({ type: "keydown", key: "Backspace", code: "Backspace" } as any);
+      await nextTick();
+      app.scheduler.flushNow();
+      expect(state.value.query).toBe("ERRO");
+
+      app.events.dispatch({ type: "keydown", key: "ArrowLeft", code: "ArrowLeft" } as any);
+      app.events.dispatch({ type: "keydown", key: "Delete", code: "Delete" } as any);
+      await nextTick();
+      app.scheduler.flushNow();
+      expect(state.value.query).toBe("ERR");
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("emits next, previous and clear from keyboard shortcuts", async () => {
+    const onPrevious = vi.fn();
+    const onNext = vi.fn();
+    const onClear = vi.fn();
+    const app = createTerminalApp({
+      cols: 24,
+      rows: 1,
+      component: defineComponent({
+        name: "TLogSearchBarNavigationApp",
+        setup() {
+          return () =>
+            h(TLogSearchBar, {
+              x: 0,
+              y: 0,
+              w: 24,
+              state: createState({
+                query: "error",
+                status: "done",
+                matchCount: 2,
+                currentMatchIndex: 0,
+              }),
+              onPrevious,
+              onNext,
+              onClear,
+            });
+        },
+      }),
+    });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "click", cellX: 13, cellY: 0, time: Date.now() } as any);
+      app.events.dispatch({ type: "keydown", key: "Enter", code: "Enter" } as any);
+      app.events.dispatch({
+        type: "keydown",
+        key: "Enter",
+        code: "Enter",
+        shiftKey: true,
+      } as any);
+      app.events.dispatch({ type: "keydown", key: "Escape", code: "Escape" } as any);
+      await nextTick();
+
+      expect(onNext).toHaveBeenCalledWith({ direction: "next" });
+      expect(onPrevious).toHaveBeenCalledWith({ direction: "previous" });
+      expect(onClear).toHaveBeenCalledTimes(1);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("emits toggle updates from click targets", async () => {
+    const onUpdateMode = vi.fn();
+    const onUpdateCaseSensitive = vi.fn();
+    const onUpdateWholeWord = vi.fn();
+    const state = ref<TLogSearchBarState>(createState());
+    const app = createTerminalApp({
+      cols: 32,
+      rows: 1,
+      component: defineComponent({
+        name: "TLogSearchBarToggleApp",
+        setup() {
+          return () =>
+            h(TLogSearchBar, {
+              x: 0,
+              y: 0,
+              w: 32,
+              state: state.value,
+              "onUpdate:mode": (mode: "text" | "regex") => {
+                state.value = createState({ ...state.value, mode });
+                onUpdateMode(mode);
+              },
+              "onUpdate:caseSensitive": (caseSensitive: boolean) => {
+                state.value = createState({ ...state.value, caseSensitive });
+                onUpdateCaseSensitive(caseSensitive);
+              },
+              "onUpdate:wholeWord": (wholeWord: boolean) => {
+                state.value = createState({ ...state.value, wholeWord });
+                onUpdateWholeWord(wholeWord);
+              },
+            });
+        },
+      }),
+    });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      const text = rowText(app, 0);
+      app.events.dispatch({
+        type: "click",
+        cellX: text.indexOf("[Aa]"),
+        cellY: 0,
+        time: Date.now(),
+      } as any);
+      app.events.dispatch({
+        type: "click",
+        cellX: text.indexOf("[W]"),
+        cellY: 0,
+        time: Date.now(),
+      } as any);
+      app.events.dispatch({
+        type: "click",
+        cellX: text.indexOf("[T]"),
+        cellY: 0,
+        time: Date.now(),
+      } as any);
+      await nextTick();
+
+      expect(onUpdateCaseSensitive).toHaveBeenCalledWith(true);
+      expect(onUpdateWholeWord).toHaveBeenCalledWith(true);
+      expect(onUpdateMode).toHaveBeenCalledWith("regex");
+    } finally {
+      app.dispose();
+    }
+  });
+});
+
+describe("TLogSearchBar integration", () => {
+  it("wires controlled query state to TLogView search and navigation", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const query = ref("");
+    const mode = ref<"text" | "regex">("text");
+    const caseSensitive = ref(false);
+    const wholeWord = ref(false);
+    const searchState = ref(createState());
+    const source: TLogDataSource = {
+      lineCount: () => 6,
+      getLine: (index) =>
+        ["line-0", "line-1", "error line-2", "line-3", "error line-4", "line-5"][index] ?? "",
+      getLineKey: (index) => `line-${index}`,
+    };
+
+    const App = defineComponent({
+      name: "TLogSearchBarIntegrationApp",
+      setup() {
+        function refresh(): void {
+          const next = logView.value?.getSearchState();
+          searchState.value = createState({
+            query: query.value,
+            mode: mode.value,
+            caseSensitive: caseSensitive.value,
+            wholeWord: wholeWord.value,
+            status: next?.status ?? "idle",
+            matchCount: next?.matchCount ?? 0,
+            currentMatchIndex: next?.currentMatchIndex ?? -1,
+            error: next?.error ?? null,
+          });
+        }
+
+        onMounted(refresh);
+
+        return () =>
+          h("span", [
+            h(TLogSearchBar, {
+              x: 0,
+              y: 0,
+              w: 40,
+              state: createState({
+                query: query.value,
+                mode: mode.value,
+                caseSensitive: caseSensitive.value,
+                wholeWord: wholeWord.value,
+                status: searchState.value.status,
+                matchCount: searchState.value.matchCount,
+                currentMatchIndex: searchState.value.currentMatchIndex,
+                error: searchState.value.error,
+              }),
+              "onUpdate:query": (nextQuery: string) => {
+                query.value = nextQuery;
+              },
+              "onUpdate:mode": (nextMode: "text" | "regex") => {
+                mode.value = nextMode;
+              },
+              "onUpdate:caseSensitive": (nextCaseSensitive: boolean) => {
+                caseSensitive.value = nextCaseSensitive;
+              },
+              "onUpdate:wholeWord": (nextWholeWord: boolean) => {
+                wholeWord.value = nextWholeWord;
+              },
+              onPrevious: () => logView.value?.findPrevious(),
+              onNext: () => logView.value?.findNext(),
+              onClear: () => {
+                query.value = "";
+              },
+            }),
+            h(TLogView, {
+              ref: logView,
+              x: 0,
+              y: 1,
+              w: 20,
+              h: 4,
+              source,
+              version: 1,
+              searchQuery: query.value,
+              searchOptions: {
+                mode: mode.value,
+                caseSensitive: caseSensitive.value,
+                wholeWord: wholeWord.value,
+                scanBudgetMs: 1000,
+              },
+              onSearch: refresh,
+              onSearchMatch: refresh,
+            }),
+          ]);
+      },
+    });
+
+    const app = createTerminalApp({ cols: 40, rows: 5, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "click", cellX: 13, cellY: 0, time: Date.now() } as any);
+      for (const key of "error") {
+        app.events.dispatch({
+          type: "keydown",
+          key,
+          code: `Key${key.toUpperCase()}`,
+          time: Date.now(),
+        } as any);
+        await nextTick();
+      }
+      await flushSearch(app, logView.value!);
+
+      expect(logView.value!.getSearchState().matchCount).toBe(2);
+      expect(rowText(app, 0)).toContain("0/2");
+
+      app.events.dispatch({
+        type: "keydown",
+        key: "Enter",
+        code: "Enter",
+        time: Date.now(),
+      } as any);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(logView.value!.getSearchState().currentMatchIndex).toBe(0);
+      expect(rowText(app, 0)).toContain("1/2");
+
+      app.events.dispatch({
+        type: "keydown",
+        key: "Enter",
+        code: "Enter",
+        time: Date.now(),
+      } as any);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(logView.value!.getSearchState().currentMatchIndex).toBe(1);
+      expect(rowText(app, 0)).toContain("2/2");
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("shows regex errors pushed from TLogView", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const query = ref("[");
+    const searchState = ref(createState({ query: "[", mode: "regex", status: "idle" }));
+    const source: TLogDataSource = {
+      lineCount: () => 2,
+      getLine: (index) => ["error line-0", "line-1"][index] ?? "",
+      getLineKey: (index) => `line-${index}`,
+    };
+
+    const App = defineComponent({
+      name: "TLogSearchBarRegexErrorApp",
+      setup() {
+        function refresh(): void {
+          const next = logView.value?.getSearchState();
+          searchState.value = createState({
+            query: query.value,
+            mode: "regex",
+            status: next?.status ?? "idle",
+            matchCount: next?.matchCount ?? 0,
+            currentMatchIndex: next?.currentMatchIndex ?? -1,
+            error: next?.error ?? null,
+          });
+        }
+
+        onMounted(refresh);
+
+        return () =>
+          h("span", [
+            h(TLogSearchBar, {
+              x: 0,
+              y: 0,
+              w: 32,
+              state: searchState.value,
+            }),
+            h(TLogView, {
+              ref: logView,
+              x: 0,
+              y: 1,
+              w: 20,
+              h: 2,
+              source,
+              version: 1,
+              searchQuery: query.value,
+              searchOptions: { mode: "regex", scanBudgetMs: 1000 },
+              onSearch: refresh,
+              onSearchMatch: refresh,
+            }),
+          ]);
+      },
+    });
+
+    const app = createTerminalApp({ cols: 32, rows: 3, component: App });
+    try {
+      app.mount();
+      await flushSearch(app, logView.value!);
+      expect(rowText(app, 0)).toContain("Invalid regex");
+    } finally {
+      app.dispose();
+    }
+  });
+});

--- a/test/tlog-search-controller.test.ts
+++ b/test/tlog-search-controller.test.ts
@@ -1,0 +1,216 @@
+import type { TLogViewHandle, TLogViewScrollMetrics } from "../src/experimental.js";
+import { describe, expect, it, vi } from "vitest";
+import { createApp, defineComponent, nextTick, ref } from "./ui-regressions-support.js";
+import { useTLogSearchController } from "../src/experimental.js";
+
+async function mountHarness(
+  logView: ReturnType<typeof ref<TLogViewHandle | null>>,
+  options?: Parameters<typeof useTLogSearchController>[1],
+): Promise<{
+  api: ReturnType<typeof useTLogSearchController>;
+  unmount: () => void;
+}> {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  let api!: ReturnType<typeof useTLogSearchController>;
+
+  const App = defineComponent({
+    name: "UseTLogSearchControllerHarness",
+    setup() {
+      api = useTLogSearchController(logView, options);
+      return () => null;
+    },
+  });
+
+  const app = createApp(App);
+  app.mount(root);
+  await nextTick();
+
+  return {
+    api,
+    unmount: () => {
+      app.unmount();
+      root.remove();
+    },
+  };
+}
+
+function createMetrics(): TLogViewScrollMetrics {
+  return {
+    scrollTop: 10,
+    maxScrollTop: 100,
+    viewportRows: 20,
+    lineCount: 200,
+    firstLineIndex: 10,
+    estimatedVisualRowCount: 200,
+    visualRowCount: 200,
+    measuredVisualRowCount: 200,
+    measuredLineCount: 200,
+    visualIndexStatus: "exact",
+    atTop: false,
+    atBottom: false,
+  };
+}
+
+describe("useTLogSearchController", () => {
+  it("derives search bar state, markers, metrics and paged results from the handle", async () => {
+    const searchState = {
+      query: "error",
+      status: "done" as const,
+      matchCount: 3,
+      currentMatchIndex: 1,
+      error: null,
+    };
+    const logView = ref<TLogViewHandle | null>({
+      getSearchState: () => searchState,
+      getSearchResults: ({ offset = 0, limit = 20 } = {}) =>
+        Array.from(
+          { length: Math.min(limit, Math.max(0, searchState.matchCount - offset)) },
+          (_, index) => ({
+            matchIndex: offset + index,
+            match: {
+              absoluteLineIndex: 100 + offset + index,
+              index: offset + index,
+              startCell: 0,
+              endCell: 5,
+              text: `error-${offset + index}`,
+            },
+            preview: {
+              text: `error-${offset + index}`,
+              matchStartCell: 0,
+              matchEndCell: 5,
+            },
+          }),
+        ),
+      getSearchMarkers: () => [
+        {
+          matchIndex: 1,
+          absoluteLineIndex: 101,
+          index: 1,
+          visualRow: 11,
+          estimated: false,
+          current: true,
+        },
+      ],
+      getScrollMetrics: () => createMetrics(),
+    } as Partial<TLogViewHandle> as TLogViewHandle);
+    const harness = await mountHarness(logView, {
+      initialQuery: "error",
+      pageSize: 2,
+      includePreview: true,
+    });
+
+    try {
+      harness.api.refresh();
+
+      expect(harness.api.searchBarState.value).toMatchObject({
+        query: "error",
+        mode: "text",
+        matchCount: 3,
+        currentMatchIndex: 1,
+        status: "done",
+      });
+      expect(harness.api.resultsPage.state.value).toMatchObject({
+        page: 0,
+        pageCount: 2,
+        activeIndex: 1,
+      });
+      expect(harness.api.markers.value).toEqual([
+        expect.objectContaining({
+          matchIndex: 1,
+          current: true,
+        }),
+      ]);
+      expect(harness.api.metrics.value).toMatchObject({
+        scrollTop: 10,
+        visualIndexStatus: "exact",
+      });
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("records history and syncs page-local state when navigating matches", async () => {
+    const searchState = {
+      query: "error",
+      status: "done" as const,
+      matchCount: 4,
+      currentMatchIndex: 0,
+      error: null,
+    };
+    const findNext = vi.fn(() => {
+      searchState.currentMatchIndex = 2;
+    });
+    const logView = ref<TLogViewHandle | null>({
+      findNext,
+      getSearchState: () => searchState,
+      getSearchResults: ({ offset = 0, limit = 20 } = {}) =>
+        Array.from(
+          { length: Math.min(limit, Math.max(0, searchState.matchCount - offset)) },
+          (_, index) => ({
+            matchIndex: offset + index,
+            match: {
+              absoluteLineIndex: 100 + offset + index,
+              index: offset + index,
+              startCell: 0,
+              endCell: 5,
+              text: `error-${offset + index}`,
+            },
+            preview: {
+              text: `error-${offset + index}`,
+              matchStartCell: 0,
+              matchEndCell: 5,
+            },
+          }),
+        ),
+      getSearchMarkers: () => [],
+      getScrollMetrics: () => createMetrics(),
+    } as Partial<TLogViewHandle> as TLogViewHandle);
+    const harness = await mountHarness(logView, {
+      initialQuery: "error",
+      pageSize: 1,
+      includePreview: true,
+    });
+
+    try {
+      harness.api.nextMatch();
+
+      expect(findNext).toHaveBeenCalledTimes(1);
+      expect(harness.api.searchHistory.value).toEqual(["error"]);
+      expect(harness.api.resultsPage.state.value.page).toBe(2);
+      expect(harness.api.searchState.value.currentMatchIndex).toBe(2);
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("saves and reapplies named searches", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const harness = await mountHarness(logView, {
+      initialQuery: "error\\s+\\d+",
+      initialMode: "regex",
+      initialCaseSensitive: true,
+    });
+
+    try {
+      const saved = harness.api.saveCurrentSearch("Errors");
+      expect(saved).toMatchObject({
+        label: "Errors",
+        query: "error\\s+\\d+",
+        mode: "regex",
+        caseSensitive: true,
+      });
+
+      harness.api.updateQuery("warn");
+      harness.api.updateMode("text");
+      harness.api.updateCaseSensitive(false);
+      expect(harness.api.applySavedSearch(saved!.id)).toBe(true);
+      expect(harness.api.query.value).toBe("error\\s+\\d+");
+      expect(harness.api.mode.value).toBe("regex");
+      expect(harness.api.caseSensitive.value).toBe(true);
+      expect(harness.api.searchHistory.value).toEqual(["error\\s+\\d+"]);
+    } finally {
+      harness.unmount();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Add **TLogSearchBar** — a controlled search input component for TLogView that manages query, mode (text/regex), case sensitivity, and whole-word toggles. It emits update events so the parent syncs state to TLogView search props.

Add **useTLogSearchController** — a composable that wires TLogSearchBar, TLogSearchResults, TLogSearchPager, TLogScrollbar and TLogMinimap into a unified search UX, centralizing:
- query / mode / caseSensitive / wholeWord / regexFlags
- searchBarState (computed TLogSearchBarState)
- resultsPage (via useTLogSearchResultsPage)
- markers and metrics from TLogViewHandle
- searchHistory and savedSearches

Both are exported from the `@simon_he/vue-tui/experimental` entrypoint.

## Changes

| File | Change |
|------|--------|
| `src/vue/components/TLogSearchBar.ts` | New controlled search bar component |
| `src/vue/log/use-tlog-search-controller.ts` | New unified search controller composable |
| `src/experimental.ts` | Export TLogSearchBar, useTLogSearchController, and related types |
| `test/tlog-search-bar.test.ts` | Unit tests for TLogSearchBar (states, typing, navigation, toggles, integration) |
| `test/tlog-search-controller.test.ts` | Unit tests for useTLogSearchController (state derivation, history, saved searches) |
| `test/package-exports.test.ts` | Updated export checks for new symbols |
| `docs/components.md` | TLogSearchBar docs + search UX suite wiring example |
| `docs/generated/components-api.md` | Generated API docs for TLogSearchBar |

## Validation

- 12 tests pass (3 test files, 1 skipped)
- Typecheck clean
- Lint clean