### PR TITLE
feat(TLogLinksPanel): add links panel component and link controller composable

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -8,15 +8,15 @@
 
 ## 组件速读
 
-| 类别          | 组件                                                                                                    | 典型用途                                        | 适配性判断                                         |
-| ------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------- |
-| Root          | `TerminalProvider`                                                                                      | 创建 terminal / renderer / event manager 上下文 | 通用，适合所有宿主                                 |
-| Layout        | `TBox` `TView` `TAnchor` `TFlow` `TRenderLayer` `TRenderPlane`                                          | 布局、裁剪、层级、分层组合                      | 通用，和 CLI 业务无关                              |
-| Text / Motion | `TText` `TTransition`                                                                                   | 文本渲染、状态切换、动画插值                    | 通用                                               |
-| Input         | `TInput` `TInputBox` `TJsonEditor`                                                                      | prompt、表单、结构化文本编辑                    | 通用，但推荐把补全/校验放到插件层                  |
-| Pickers       | `TList` `TVirtualList` `TLogView` `TLogSearchBar` `TLogScrollbar` `TLogMinimap` `TSelect` `TPathPicker` | palette、列表、日志、路径选择                   | `TPathPicker` 本体可复用，路径语义由 provider 注入 |
-| Overlay       | `TDialog` `TMultilineModal` `TDebugOverlay`                                                             | 对话框、详情查看、调试覆盖层                    | 通用，适合多种宿主                                 |
-| Navigation    | `TRouterView` + `createTerminalRouter()`                                                                | 多页面 TUI / shell                              | 通用                                               |
+| 类别          | 组件                                                                                                                                                           | 典型用途                                        | 适配性判断                                         |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------- |
+| Root          | `TerminalProvider`                                                                                                                                             | 创建 terminal / renderer / event manager 上下文 | 通用，适合所有宿主                                 |
+| Layout        | `TBox` `TView` `TAnchor` `TFlow` `TRenderLayer` `TRenderPlane`                                                                                                 | 布局、裁剪、层级、分层组合                      | 通用，和 CLI 业务无关                              |
+| Text / Motion | `TText` `TTransition`                                                                                                                                          | 文本渲染、状态切换、动画插值                    | 通用                                               |
+| Input         | `TInput` `TInputBox` `TJsonEditor`                                                                                                                             | prompt、表单、结构化文本编辑                    | 通用，但推荐把补全/校验放到插件层                  |
+| Pickers       | `TList` `TVirtualList` `TLogView` `TLogSearchBar` `TLogSearchResults` `TLogSearchPager` `TLogLinksPanel` `TLogScrollbar` `TLogMinimap` `TSelect` `TPathPicker` | palette、列表、日志、路径选择                   | `TPathPicker` 本体可复用，路径语义由 provider 注入 |
+| Overlay       | `TDialog` `TMultilineModal` `TDebugOverlay`                                                                                                                    | 对话框、详情查看、调试覆盖层                    | 通用，适合多种宿主                                 |
+| Navigation    | `TRouterView` + `createTerminalRouter()`                                                                                                                       | 多页面 TUI / shell                              | 通用                                               |
 
 如果你更关心“哪些地方还应该继续做插件化”，建议配合阅读：[扩展性与插件化](./extensibility.md)。
 
@@ -985,7 +985,9 @@ function refreshSuite() {
   :y="1"
   :h="20"
   :metrics="search.metrics"
-  :markers="search.markers.map((marker) => ({ visualRow: marker.visualRow, current: marker.current }))"
+  :markers="
+    search.markers.map((marker) => ({ visualRow: marker.visualRow, current: marker.current }))
+  "
 />
 
 <TLogMinimap
@@ -994,9 +996,92 @@ function refreshSuite() {
   :w="2"
   :h="20"
   :metrics="search.metrics"
-  :markers="search.markers.map((marker) => ({ visualRow: marker.visualRow, current: marker.current }))"
+  :markers="
+    search.markers.map((marker) => ({ visualRow: marker.visualRow, current: marker.current }))
+  "
 />
 ```
+
+### TLogLinksPanel
+
+`TLogLinksPanel` 是一个 experimental visible-link panel，只渲染 **当前 viewport 内可见的 OSC8 links**。它不扫描 retained window，也不直接读取 `TLogView`；父组件负责把 `getVisibleLinks()` 或 `useTLogLinkController.visibleLinks` 回填给它。
+
+- 每行展示 `absoluteLineIndex + text + href`
+- `activeIndex` 表示 panel 当前选中行
+- `current` 用来标记 `TLogView` 当前 focused visible link
+- `Enter` 只 emit `activate`，不会自动打开浏览器
+
+### Link UX suite wiring
+
+如果你希望把 `TLogView` 的 visible OSC8 link 导航、panel 展示和应用层 action 统一起来，推荐直接使用 `useTLogLinkController`。它会集中管理：
+
+- `visibleLinks`
+- `activeIndex`
+- `focusVisibleLink` / `focusNextLink` / `focusPreviousLink`
+- `activateVisibleLink` / `activateFocusedLink`
+- `handleLinkClick` / `handleLinkActivate`
+
+`useTLogLinkController` 不会建立 global link index，也不会自动打开链接。`onAction` 只把 `{ href, text, source, absoluteLineIndex, index, startCell, endCell }` 交回应用层，由应用决定 open/copy/preview。
+
+```vue
+<script setup lang="ts">
+import { ref } from "vue";
+import {
+  TLogLinksPanel,
+  TLogView,
+  useTLogLinkController,
+  type TLogLinksPanelActiveChangePayload,
+  type TLogViewHandle,
+} from "@simon_he/vue-tui/experimental";
+
+const logView = ref<TLogViewHandle | null>(null);
+const links = useTLogLinkController(logView, {
+  onAction(action) {
+    console.log("Link action:", action.href, action.source);
+  },
+});
+
+function refreshLinks() {
+  links.refresh();
+}
+
+function onPanelActiveChange(payload: TLogLinksPanelActiveChangePayload) {
+  if (payload.activeIndex >= 0) links.focusVisibleLink(payload.activeIndex);
+  else links.clearFocus();
+}
+</script>
+
+<TLogView
+  ref="logView"
+  :x="0"
+  :y="0"
+  :w="60"
+  :h="20"
+  :source="log.source"
+  :version="log.version"
+  ansi
+  links
+  keyboard-links
+  @scroll="refreshLinks"
+  @linkFocus="refreshLinks"
+  @linkClick="links.handleLinkClick"
+  @linkActivate="links.handleLinkActivate"
+/>
+
+<TLogLinksPanel
+  :x="61"
+  :y="0"
+  :w="19"
+  :h="20"
+  :links="links.visibleLinks"
+  :active-index="links.activeIndex"
+  @select="({ visibleIndex }) => links.focusVisibleLink(visibleIndex)"
+  @activeChange="onPanelActiveChange"
+  @activate="({ visibleIndex }) => links.activateVisibleLink(visibleIndex)"
+/>
+```
+
+启用 `keyboardLinks=true` 后，`Tab` / `Shift+Tab` / `Enter` 仍然只作用于当前 visible links；`TLogLinksPanel` 也同样只操作当前 visible 列表，不会越过 viewport 建立 retained-window 级别的历史索引。
 
 ### Events
 
@@ -1007,6 +1092,8 @@ function refreshSuite() {
 - `searchMatch`: `{ match, currentMatchIndex, matchCount }`
 - `searchMarkers`: `{ markers, visualIndexStatus, matchCount, currentMatchIndex }`
 - `linkClick`: `{ href, text, absoluteLineIndex, index, startCell, endCell, cellX, cellY }`
+- `linkFocus`: `{ link, focusedLinkIndex }`
+- `linkActivate`: `{ link, source }`
 - `focus` / `blur` / `keydown`
 
 ## TSelect

--- a/docs/components.md
+++ b/docs/components.md
@@ -1035,19 +1035,29 @@ import {
 } from "@simon_he/vue-tui/experimental";
 
 const logView = ref<TLogViewHandle | null>(null);
-const links = useTLogLinkController(logView, {
+const linkController = useTLogLinkController(logView, {
   onAction(action) {
     console.log("Link action:", action.href, action.source);
   },
 });
+const {
+  visibleLinks,
+  activeIndex,
+  refresh,
+  focusVisibleLink,
+  clearFocus,
+  activateVisibleLink,
+  handleLinkClick,
+  handleLinkActivate,
+} = linkController;
 
 function refreshLinks() {
-  links.refresh();
+  refresh();
 }
 
 function onPanelActiveChange(payload: TLogLinksPanelActiveChangePayload) {
-  if (payload.activeIndex >= 0) links.focusVisibleLink(payload.activeIndex);
-  else links.clearFocus();
+  if (payload.item) focusVisibleLink(payload.item.visibleIndex);
+  else clearFocus();
 }
 </script>
 
@@ -1064,8 +1074,8 @@ function onPanelActiveChange(payload: TLogLinksPanelActiveChangePayload) {
   keyboard-links
   @scroll="refreshLinks"
   @linkFocus="refreshLinks"
-  @linkClick="links.handleLinkClick"
-  @linkActivate="links.handleLinkActivate"
+  @linkClick="handleLinkClick"
+  @linkActivate="handleLinkActivate"
 />
 
 <TLogLinksPanel
@@ -1073,11 +1083,11 @@ function onPanelActiveChange(payload: TLogLinksPanelActiveChangePayload) {
   :y="0"
   :w="19"
   :h="20"
-  :links="links.visibleLinks"
-  :active-index="links.activeIndex"
-  @select="({ visibleIndex }) => links.focusVisibleLink(visibleIndex)"
+  :links="visibleLinks"
+  :active-index="activeIndex"
+  @select="({ visibleIndex }) => focusVisibleLink(visibleIndex)"
   @activeChange="onPanelActiveChange"
-  @activate="({ visibleIndex }) => links.activateVisibleLink(visibleIndex)"
+  @activate="({ visibleIndex }) => activateVisibleLink(visibleIndex)"
 />
 ```
 

--- a/docs/generated/components-api.md
+++ b/docs/generated/components-api.md
@@ -14,6 +14,7 @@
 - [TInputBox](#tinputbox)
 - [TJsonEditor](#tjsoneditor)
 - [TList](#tlist)
+- [TLogLinksPanel](#tloglinkspanel)
 - [TLogMinimap](#tlogminimap)
 - [TLogScrollbar](#tlogscrollbar)
 - [TLogSearchBar](#tlogsearchbar)
@@ -386,6 +387,41 @@
 | <code>focus</code>             | —       | —    |
 | <code>blur</code>              | —       | —    |
 | <code>keydown</code>           | —       | —    |
+
+## TLogLinksPanel
+
+源码：`src/vue/components/TLogLinksPanel.ts`
+
+### Props
+
+| 名称                         | 类型                                      | 默认值                                      | 必填 | 说明 |
+| ---------------------------- | ----------------------------------------- | ------------------------------------------- | ---- | ---- |
+| <code>x</code>               | <code>number</code>                       | —                                           | 是   | —    |
+| <code>y</code>               | <code>number</code>                       | —                                           | 是   | —    |
+| <code>w</code>               | <code>number</code>                       | —                                           | 是   | —    |
+| <code>h</code>               | <code>number</code>                       | —                                           | 是   | —    |
+| <code>zIndex</code>          | <code>number</code>                       | <code>0</code>                              | 否   | —    |
+| <code>links</code>           | <code>readonly TLogLinkPanelItem[]</code> | <code>() =&gt; []</code>                    | 否   | —    |
+| <code>activeIndex</code>     | <code>number</code>                       | <code>-1</code>                             | 否   | —    |
+| <code>style</code>           | <code>Style</code>                        | <code>undefined</code>                      | 否   | —    |
+| <code>activeStyle</code>     | <code>Style</code>                        | <code>() =&gt; ({ inverse: true })</code>   | 否   | —    |
+| <code>currentStyle</code>    | <code>Style</code>                        | <code>() =&gt; ({ bold: true })</code>      | 否   | —    |
+| <code>hrefStyle</code>       | <code>Style</code>                        | <code>() =&gt; ({ underline: true })</code> | 否   | —    |
+| <code>disabledStyle</code>   | <code>Style</code>                        | <code>() =&gt; ({ dim: true })</code>       | 否   | —    |
+| <code>showLineNumbers</code> | <code>boolean</code>                      | <code>true</code>                           | 否   | —    |
+| <code>showHref</code>        | <code>boolean</code>                      | <code>true</code>                           | 否   | —    |
+| <code>focusable</code>       | <code>boolean</code>                      | <code>true</code>                           | 否   | —    |
+
+### Events
+
+| 名称                      | Payload | 说明 |
+| ------------------------- | ------- | ---- |
+| <code>select</code>       | —       | —    |
+| <code>activate</code>     | —       | —    |
+| <code>activeChange</code> | —       | —    |
+| <code>focus</code>        | —       | —    |
+| <code>blur</code>         | —       | —    |
+| <code>keydown</code>      | —       | —    |
 
 ## TLogMinimap
 

--- a/src/experimental.ts
+++ b/src/experimental.ts
@@ -5,10 +5,18 @@ export { TLogMinimap } from "./vue/components/TLogMinimap.js";
 export { TLogSearchBar } from "./vue/components/TLogSearchBar.js";
 export { TLogSearchResults } from "./vue/components/TLogSearchResults.js";
 export { TLogSearchPager } from "./vue/components/TLogSearchPager.js";
+export { TLogLinksPanel } from "./vue/components/TLogLinksPanel.js";
 export { createAppendOnlyLogStore } from "./vue/log/append-only-log-store.js";
+export { useTLogLinkController } from "./vue/log/use-tlog-link-controller.js";
 export { useTLogSearchController } from "./vue/log/use-tlog-search-controller.js";
 export { useTLogSearchResultsPage } from "./vue/log/use-tlog-search-results-page.js";
 export type { RowScrollMode } from "./vue/components/TVirtualList.js";
+export type {
+  TLogLinkPanelItem,
+  TLogLinksPanelSelectPayload,
+  TLogLinksPanelActivatePayload,
+  TLogLinksPanelActiveChangePayload,
+} from "./vue/components/TLogLinksPanel.js";
 export type {
   TLogMinimapClickPayload,
   TLogMinimapDensityBucket,
@@ -68,6 +76,11 @@ export type {
   TLogViewVisualIndexOptions,
   TLogViewVisualIndexStatus,
 } from "./vue/log/types.js";
+export type {
+  TLogLinkAction,
+  TLogLinkActionSource,
+  UseTLogLinkControllerOptions,
+} from "./vue/log/use-tlog-link-controller.js";
 export type {
   TLogSavedSearch,
   UseTLogSearchControllerOptions,

--- a/src/vue/components/TLogLinksPanel.ts
+++ b/src/vue/components/TLogLinksPanel.ts
@@ -1,0 +1,345 @@
+import type { PropType } from "vue";
+import type { Style } from "../../core/types.js";
+import type { Rect, TerminalKeyboardEvent, TerminalPointerEvent } from "../../events/index.js";
+import { computed, defineComponent, h, inject, ref, watch } from "vue";
+import { useLayout } from "../composables/use-layout.js";
+import { useRenderNode } from "../composables/use-render-node.js";
+import { useTerminalNode } from "../composables/use-terminal-node.js";
+import { useTerminal } from "../composables/use-terminal.js";
+import { useVisibility } from "../composables/use-visibility.js";
+import { EventZIndexContextKey } from "../context.js";
+import { intersectRect, translateRect } from "../utils/rect.js";
+import { sliceByCellsRange, spaces, textCellWidth } from "../utils/text.js";
+
+const EMPTY_RECT: Rect = Object.freeze({ x: 0, y: 0, w: 0, h: 0 });
+const EMPTY_LABEL = "No visible links";
+
+export type TLogLinkPanelItem = Readonly<{
+  visibleIndex: number;
+  href: string;
+  text: string;
+  absoluteLineIndex: number;
+  index: number;
+  startCell: number;
+  endCell: number;
+  current?: boolean;
+}>;
+
+export type TLogLinksPanelSelectPayload = Readonly<{
+  visibleIndex: number;
+  item: TLogLinkPanelItem;
+}>;
+
+export type TLogLinksPanelActivatePayload = Readonly<{
+  visibleIndex: number;
+  item: TLogLinkPanelItem;
+}>;
+
+export type TLogLinksPanelActiveChangePayload = Readonly<{
+  activeIndex: number;
+  item: TLogLinkPanelItem | null;
+}>;
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function normalizeInt(value: number): number {
+  const n = Math.floor(Number(value));
+  return Number.isFinite(n) ? n : 0;
+}
+
+function mergeStyle(base: Style, overlay?: Style): Style {
+  return overlay ? { ...base, ...overlay } : base;
+}
+
+function normalizeActiveIndex(value: number, count: number): number {
+  if (count <= 0) return -1;
+  const n = Math.floor(Number(value));
+  if (!Number.isFinite(n)) return -1;
+  if (n < 0) return -1;
+  return clamp(n, 0, count - 1);
+}
+
+export const TLogLinksPanel = defineComponent({
+  name: "TLogLinksPanel",
+  props: {
+    x: { type: Number, required: true },
+    y: { type: Number, required: true },
+    w: { type: Number, required: true },
+    h: { type: Number, required: true },
+    zIndex: { type: Number, default: 0 },
+    links: {
+      type: Array as PropType<readonly TLogLinkPanelItem[]>,
+      default: () => [],
+    },
+    activeIndex: { type: Number, default: -1 },
+    style: { type: Object as PropType<Style>, default: undefined },
+    activeStyle: {
+      type: Object as PropType<Style>,
+      default: () => ({ inverse: true }),
+    },
+    currentStyle: {
+      type: Object as PropType<Style>,
+      default: () => ({ bold: true }),
+    },
+    hrefStyle: {
+      type: Object as PropType<Style>,
+      default: () => ({ underline: true }),
+    },
+    disabledStyle: {
+      type: Object as PropType<Style>,
+      default: () => ({ dim: true }),
+    },
+    showLineNumbers: { type: Boolean, default: true },
+    showHref: { type: Boolean, default: true },
+    focusable: { type: Boolean, default: true },
+  },
+  emits: ["select", "activate", "activeChange", "focus", "blur", "keydown"],
+  setup(props, { emit }) {
+    const { terminal, scheduler, defaultStyle, events } = useTerminal();
+    const parent = useLayout();
+    const { visible, rootProps } = useVisibility();
+    const parentEventZ = inject(EventZIndexContextKey, computed(() => 0) as any);
+    const eventZ = computed(() => (parentEventZ.value ?? 0) + (props.zIndex ?? 0));
+    const focused = ref(false);
+    const internalActiveIndex = ref(-1);
+
+    const fullRect = computed<Rect>(() =>
+      translateRect(
+        {
+          x: normalizeInt(props.x),
+          y: normalizeInt(props.y),
+          w: Math.max(0, normalizeInt(props.w)),
+          h: Math.max(0, normalizeInt(props.h)),
+        },
+        parent.originX,
+        parent.originY,
+      ),
+    );
+
+    const rect = computed<Rect>(() => {
+      const translated = fullRect.value;
+      if (!parent.clipRect) return translated;
+      return intersectRect(translated, parent.clipRect) ?? EMPTY_RECT;
+    });
+
+    const lineNumberDigits = computed(() =>
+      props.showLineNumbers
+        ? props.links.reduce((max, link) => Math.max(max, String(link.absoluteLineIndex).length), 1)
+        : 0,
+    );
+
+    watch(
+      [() => props.activeIndex, () => props.links.length],
+      () => {
+        internalActiveIndex.value = normalizeActiveIndex(props.activeIndex, props.links.length);
+      },
+      { immediate: true },
+    );
+
+    function activeItem(index = internalActiveIndex.value): TLogLinkPanelItem | null {
+      return index >= 0 ? (props.links[index] ?? null) : null;
+    }
+
+    function emitActiveChange(): void {
+      emit("activeChange", {
+        activeIndex: internalActiveIndex.value,
+        item: activeItem(),
+      } satisfies TLogLinksPanelActiveChangePayload);
+    }
+
+    function setActiveIndex(index: number): void {
+      const next = normalizeActiveIndex(index, props.links.length);
+      if (next === internalActiveIndex.value) return;
+      internalActiveIndex.value = next;
+      emitActiveChange();
+      scheduler.invalidate({ reason: "input" });
+    }
+
+    function emitSelect(index: number): void {
+      const item = props.links[index];
+      if (!item) return;
+      emit("select", {
+        visibleIndex: item.visibleIndex,
+        item,
+      } satisfies TLogLinksPanelSelectPayload);
+    }
+
+    function emitActivate(index: number): void {
+      const item = props.links[index];
+      if (!item) return;
+      emit("activate", {
+        visibleIndex: item.visibleIndex,
+        item,
+      } satisfies TLogLinksPanelActivatePayload);
+    }
+
+    function onKeydown(e: TerminalKeyboardEvent): void {
+      emit("keydown", e);
+      if (!props.links.length) {
+        if (e.key === "Escape") {
+          e.preventDefault();
+          setActiveIndex(-1);
+        }
+        return;
+      }
+
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActiveIndex((internalActiveIndex.value < 0 ? -1 : internalActiveIndex.value) + 1);
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActiveIndex(internalActiveIndex.value < 0 ? 0 : internalActiveIndex.value - 1);
+        return;
+      }
+      if (e.key === "Home") {
+        e.preventDefault();
+        setActiveIndex(0);
+        return;
+      }
+      if (e.key === "End") {
+        e.preventDefault();
+        setActiveIndex(props.links.length - 1);
+        return;
+      }
+      if (e.key === "Enter") {
+        e.preventDefault();
+        if (internalActiveIndex.value >= 0) emitActivate(internalActiveIndex.value);
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setActiveIndex(-1);
+      }
+    }
+
+    function onClick(e: TerminalPointerEvent): void {
+      const full = fullRect.value;
+      const localY = e.cellY - full.y;
+      if (localY < 0 || localY >= full.h) return;
+      const item = props.links[localY];
+      if (!item) return;
+      const nodeId = eventNode.id.value;
+      if (props.focusable && nodeId) events.value?.focus(nodeId);
+      setActiveIndex(localY);
+      emitSelect(localY);
+      e.preventDefault?.();
+    }
+
+    const eventNode = useTerminalNode(() => ({
+      rect: rect.value,
+      zIndex: eventZ.value,
+      visible: visible.value,
+      focusable: props.focusable,
+      handlers: {
+        click: onClick,
+        focus: () => {
+          focused.value = true;
+          emit("focus");
+          scheduler.invalidate();
+        },
+        blur: () => {
+          focused.value = false;
+          emit("blur");
+          scheduler.invalidate();
+        },
+        keydown: onKeydown,
+      },
+    }));
+
+    useRenderNode(() => ({
+      zIndex: props.zIndex,
+      rect: visible.value ? rect.value : EMPTY_RECT,
+      deps: [
+        visible.value,
+        rect.value,
+        fullRect.value,
+        props.links,
+        props.activeIndex,
+        props.style,
+        props.activeStyle,
+        props.currentStyle,
+        props.hrefStyle,
+        props.disabledStyle,
+        props.showLineNumbers,
+        props.showHref,
+        props.focusable,
+        internalActiveIndex.value,
+        focused.value,
+        lineNumberDigits.value,
+        defaultStyle.value,
+      ],
+      paint: () => {
+        if (!visible.value) return;
+        const r = rect.value;
+        if (r.w <= 0 || r.h <= 0) return;
+
+        const full = fullRect.value;
+        const base = props.style ?? defaultStyle.value;
+        const disabled = mergeStyle(base, props.disabledStyle);
+
+        const writeSegments = (
+          y: number,
+          rowStyle: Style,
+          segments: readonly Readonly<{
+            text: string;
+            style: Style;
+          }>[],
+        ): void => {
+          let x = r.x;
+          let used = 0;
+          for (const segment of segments) {
+            if (used >= r.w || !segment.text) continue;
+            const text = sliceByCellsRange(segment.text, 0, r.w - used);
+            const cells = textCellWidth(text);
+            if (!text || cells <= 0) continue;
+            terminal.write(text, { x, y, style: segment.style });
+            x += cells;
+            used += cells;
+          }
+          if (used < r.w) terminal.write(spaces(r.w - used), { x, y, style: rowStyle });
+        };
+
+        for (let y = r.y; y < r.y + r.h; y++) {
+          const localY = y - full.y;
+          const item = props.links[localY];
+          if (!item) {
+            if (!props.links.length && localY === 0) {
+              writeSegments(y, disabled, [{ text: EMPTY_LABEL, style: disabled }]);
+            } else {
+              terminal.write(spaces(r.w), { x: r.x, y, style: base });
+            }
+            continue;
+          }
+
+          let rowStyle = base;
+          if (localY === internalActiveIndex.value)
+            rowStyle = mergeStyle(rowStyle, props.activeStyle);
+          if (item.current) rowStyle = mergeStyle(rowStyle, props.currentStyle);
+          const hrefRowStyle = mergeStyle(rowStyle, props.hrefStyle);
+
+          const segments: Array<{ text: string; style: Style }> = [];
+          if (props.showLineNumbers) {
+            segments.push({
+              text: `${String(item.absoluteLineIndex).padStart(lineNumberDigits.value)} `,
+              style: rowStyle,
+            });
+          }
+          if (item.text) segments.push({ text: item.text, style: rowStyle });
+          if (props.showHref && item.href) {
+            if (item.text) segments.push({ text: " ", style: rowStyle });
+            segments.push({ text: item.href, style: hrefRowStyle });
+          }
+          if (!segments.length) segments.push({ text: "", style: rowStyle });
+
+          writeSegments(y, rowStyle, segments);
+        }
+      },
+    }));
+
+    return () => h("span", rootProps);
+  },
+});

--- a/src/vue/components/TLogView.ts
+++ b/src/vue/components/TLogView.ts
@@ -211,6 +211,7 @@ export type TLogViewVisibleLink = Readonly<{
   startX: number;
   endX: number;
   y: number;
+  focused?: boolean;
 }>;
 export type TLogViewLinkFocusPayload = Readonly<{
   link: TLogViewVisibleLink | null;
@@ -2429,6 +2430,7 @@ export const TLogView = defineComponent({
           .slice()
           .sort((a, b) => a.startX - b.startX);
         for (const link of rowLinks) {
+          const focused = focusedLinkMatches(link);
           out.push({
             visibleIndex: out.length,
             href: link.href,
@@ -2440,6 +2442,7 @@ export const TLogView = defineComponent({
             startX: link.startX,
             endX: link.endX,
             y,
+            ...(focused ? { focused: true } : {}),
           });
         }
       }
@@ -2447,10 +2450,14 @@ export const TLogView = defineComponent({
     }
 
     function focusedLinkMatches(
-      link: Pick<TLogViewVisibleLink, "href" | "index" | "startCell" | "endCell">,
+      link: Pick<
+        TLogViewVisibleLink,
+        "href" | "absoluteLineIndex" | "index" | "startCell" | "endCell"
+      >,
     ): boolean {
       return (
         focusedLinkTarget?.href === link.href &&
+        focusedLinkTarget.absoluteLineIndex === link.absoluteLineIndex &&
         focusedLinkTarget.index === link.index &&
         focusedLinkTarget.startCell === link.startCell &&
         focusedLinkTarget.endCell === link.endCell
@@ -2657,7 +2664,9 @@ export const TLogView = defineComponent({
       visibleStartCell: number,
     ): readonly TLogVisualSegment[] {
       const target = focusedLinkTarget;
-      if (!target || target.index !== lineIndex) return segments;
+      if (!target) return segments;
+      if (target.absoluteLineIndex !== firstLineIndex() + lineIndex) return segments;
+      if (target.index !== lineIndex) return segments;
       if (target.endCell <= visibleStartCell) return segments;
 
       const visibleEndCell = visibleStartCell + segments.reduce((sum, seg) => sum + seg.cells, 0);
@@ -2670,7 +2679,10 @@ export const TLogView = defineComponent({
         while (localStart < seg.cells) {
           const absoluteCell = cursor + localStart;
           let nextLocalEnd = seg.cells;
-          const withinFocus = absoluteCell >= target.startCell && absoluteCell < target.endCell;
+          const withinFocus =
+            seg.style.href === target.href &&
+            absoluteCell >= target.startCell &&
+            absoluteCell < target.endCell;
           if (!withinFocus && target.startCell > absoluteCell) {
             nextLocalEnd = Math.min(nextLocalEnd, target.startCell - cursor);
           } else if (withinFocus) {
@@ -3350,7 +3362,7 @@ export const TLogView = defineComponent({
       () => [props.ansi, props.links],
       ([ansi, links]) => {
         if (ansi && links) return;
-        clearLinkFocus(false);
+        clearLinkFocus();
       },
     );
 

--- a/src/vue/log/use-tlog-link-controller.ts
+++ b/src/vue/log/use-tlog-link-controller.ts
@@ -1,0 +1,217 @@
+import type { Ref } from "vue";
+import type {
+  TLogViewHandle,
+  TLogViewLinkActivatePayload,
+  TLogViewLinkClickPayload,
+  TLogViewVisibleLink,
+} from "../components/TLogView.js";
+import type { TLogLinkPanelItem } from "../components/TLogLinksPanel.js";
+import { ref, watch } from "vue";
+
+export type TLogLinkActionSource = "click" | "keyboard" | "programmatic" | "panel";
+
+export type TLogLinkAction = Readonly<{
+  href: string;
+  text: string;
+  source: TLogLinkActionSource;
+  absoluteLineIndex: number;
+  index: number;
+  startCell: number;
+  endCell: number;
+}>;
+
+export type UseTLogLinkControllerOptions = Readonly<{
+  onAction?: (action: TLogLinkAction) => void;
+}>;
+
+function toPanelItem(link: TLogViewVisibleLink): TLogLinkPanelItem {
+  return {
+    visibleIndex: link.visibleIndex,
+    href: link.href,
+    text: link.text,
+    absoluteLineIndex: link.absoluteLineIndex,
+    index: link.index,
+    startCell: link.startCell,
+    endCell: link.endCell,
+    current: link.focused === true || undefined,
+  };
+}
+
+function toActionFromLink(
+  link: Pick<
+    TLogViewVisibleLink,
+    "href" | "text" | "absoluteLineIndex" | "index" | "startCell" | "endCell"
+  >,
+  source: TLogLinkActionSource,
+): TLogLinkAction {
+  return {
+    href: link.href,
+    text: link.text,
+    source,
+    absoluteLineIndex: link.absoluteLineIndex,
+    index: link.index,
+    startCell: link.startCell,
+    endCell: link.endCell,
+  };
+}
+
+function actionKey(
+  value: Pick<
+    TLogLinkAction,
+    "href" | "absoluteLineIndex" | "index" | "startCell" | "endCell" | "source"
+  >,
+): string {
+  return JSON.stringify([
+    value.href,
+    value.absoluteLineIndex,
+    value.index,
+    value.startCell,
+    value.endCell,
+    value.source,
+  ]);
+}
+
+export function useTLogLinkController(
+  logView: Ref<TLogViewHandle | null>,
+  options: UseTLogLinkControllerOptions = {},
+): {
+  visibleLinks: Ref<readonly TLogLinkPanelItem[]>;
+  activeIndex: Ref<number>;
+  refresh: () => void;
+  focusVisibleLink: (visibleIndex: number) => boolean;
+  focusNextLink: () => boolean;
+  focusPreviousLink: () => boolean;
+  clearFocus: () => void;
+  activateVisibleLink: (visibleIndex: number) => boolean;
+  activateFocusedLink: () => boolean;
+  handleLinkClick: (payload: TLogViewLinkClickPayload) => void;
+  handleLinkActivate: (payload: TLogViewLinkActivatePayload) => void;
+} {
+  const visibleLinks = ref<readonly TLogLinkPanelItem[]>([]);
+  const activeIndex = ref(-1);
+  let suppressedActivateKey: string | null = null;
+
+  function emitAction(action: TLogLinkAction): void {
+    options.onAction?.(action);
+  }
+
+  function suppressProgrammaticActivation(link: TLogLinkPanelItem): void {
+    suppressedActivateKey = actionKey({
+      href: link.href,
+      absoluteLineIndex: link.absoluteLineIndex,
+      index: link.index,
+      startCell: link.startCell,
+      endCell: link.endCell,
+      source: "programmatic",
+    });
+  }
+
+  function refresh(): void {
+    const next = logView.value?.getVisibleLinks().map(toPanelItem) ?? [];
+    visibleLinks.value = next;
+    activeIndex.value = next.findIndex((link) => link.current === true);
+  }
+
+  function focusVisibleLink(visibleIndex: number): boolean {
+    const focused = logView.value?.focusVisibleLink(visibleIndex) === true;
+    refresh();
+    return focused;
+  }
+
+  function focusNextLink(): boolean {
+    const focused = logView.value?.focusNextLink() === true;
+    refresh();
+    return focused;
+  }
+
+  function focusPreviousLink(): boolean {
+    const focused = logView.value?.focusPreviousLink() === true;
+    refresh();
+    return focused;
+  }
+
+  function clearFocus(): void {
+    logView.value?.clearLinkFocus();
+    refresh();
+  }
+
+  function activateVisibleLink(visibleIndex: number): boolean {
+    if (!focusVisibleLink(visibleIndex)) return false;
+    const link = visibleLinks.value[activeIndex.value];
+    const handle = logView.value;
+    if (!link || !handle) return false;
+    suppressProgrammaticActivation(link);
+    const activated = handle.activateFocusedLink();
+    if (!activated) {
+      suppressedActivateKey = null;
+      refresh();
+      return false;
+    }
+    emitAction(toActionFromLink(link, "panel"));
+    refresh();
+    return true;
+  }
+
+  function activateFocusedLink(): boolean {
+    const link = visibleLinks.value[activeIndex.value];
+    const handle = logView.value;
+    if (!link || !handle) return false;
+    suppressProgrammaticActivation(link);
+    const activated = handle.activateFocusedLink();
+    if (!activated) {
+      suppressedActivateKey = null;
+      refresh();
+      return false;
+    }
+    emitAction(toActionFromLink(link, "programmatic"));
+    refresh();
+    return true;
+  }
+
+  function handleLinkClick(payload: TLogViewLinkClickPayload): void {
+    emitAction({
+      href: payload.href,
+      text: payload.text,
+      source: "click",
+      absoluteLineIndex: payload.absoluteLineIndex,
+      index: payload.index,
+      startCell: payload.startCell,
+      endCell: payload.endCell,
+    });
+    refresh();
+  }
+
+  function handleLinkActivate(payload: TLogViewLinkActivatePayload): void {
+    const action = toActionFromLink(payload.link, payload.source);
+    const key = actionKey(action);
+    if (suppressedActivateKey === key) {
+      suppressedActivateKey = null;
+      refresh();
+      return;
+    }
+    emitAction(action);
+    refresh();
+  }
+
+  watch(
+    () => logView.value,
+    () => {
+      refresh();
+    },
+    { immediate: true },
+  );
+
+  return {
+    visibleLinks,
+    activeIndex,
+    refresh,
+    focusVisibleLink,
+    focusNextLink,
+    focusPreviousLink,
+    clearFocus,
+    activateVisibleLink,
+    activateFocusedLink,
+    handleLinkClick,
+    handleLinkActivate,
+  };
+}

--- a/test/package-exports.test.ts
+++ b/test/package-exports.test.ts
@@ -22,8 +22,10 @@ describe("package exports", () => {
     expect("TLogSearchBar" in root).toBe(false);
     expect("TLogSearchResults" in root).toBe(false);
     expect("TLogSearchPager" in root).toBe(false);
+    expect("TLogLinksPanel" in root).toBe(false);
     expect("useTLogSearchController" in root).toBe(false);
     expect("useTLogSearchResultsPage" in root).toBe(false);
+    expect("useTLogLinkController" in root).toBe(false);
     expect("createAppendOnlyLogStore" in root).toBe(false);
     expect(root.createFramePerfStore).toBeTruthy();
     expect(root.framePerfNow).toBeTruthy();
@@ -34,8 +36,10 @@ describe("package exports", () => {
     expect(experimental.TLogSearchBar).toBeTruthy();
     expect(experimental.TLogSearchResults).toBeTruthy();
     expect(experimental.TLogSearchPager).toBeTruthy();
+    expect(experimental.TLogLinksPanel).toBeTruthy();
     expect(experimental.useTLogSearchController).toBeTruthy();
     expect(experimental.useTLogSearchResultsPage).toBeTruthy();
+    expect(experimental.useTLogLinkController).toBeTruthy();
     expect(experimental.createAppendOnlyLogStore).toBeTruthy();
   });
 
@@ -46,6 +50,10 @@ describe("package exports", () => {
     expect(experimentalSource).toContain("TLogViewLinkActivatePayload");
     expect(experimentalSource).toContain("TLogViewSearchMode");
     expect(experimentalSource).toContain("TLogViewSearchError");
+    expect(experimentalSource).toContain("TLogLinksPanel");
+    expect(experimentalSource).toContain("TLogLinkPanelItem");
+    expect(experimentalSource).toContain("TLogLinkAction");
+    expect(experimentalSource).toContain("useTLogLinkController");
     expect(experimentalSource).toContain("TLogSearchBarState");
     expect(experimentalSource).toContain("TLogSearchBarMode");
     expect(experimentalSource).toContain("TLogSavedSearch");
@@ -78,8 +86,10 @@ describe("package exports", () => {
     expect(experimental.TLogSearchBar).toBeTruthy();
     expect(experimental.TLogSearchResults).toBeTruthy();
     expect(experimental.TLogSearchPager).toBeTruthy();
+    expect(experimental.TLogLinksPanel).toBeTruthy();
     expect(experimental.useTLogSearchController).toBeTruthy();
     expect(experimental.useTLogSearchResultsPage).toBeTruthy();
+    expect(experimental.useTLogLinkController).toBeTruthy();
     expect(experimental.createAppendOnlyLogStore).toBeTruthy();
     expect(experimentalCjs.TVirtualList).toBeTruthy();
     expect(experimentalCjs.TLogView).toBeTruthy();
@@ -88,8 +98,10 @@ describe("package exports", () => {
     expect(experimentalCjs.TLogSearchBar).toBeTruthy();
     expect(experimentalCjs.TLogSearchResults).toBeTruthy();
     expect(experimentalCjs.TLogSearchPager).toBeTruthy();
+    expect(experimentalCjs.TLogLinksPanel).toBeTruthy();
     expect(experimentalCjs.useTLogSearchController).toBeTruthy();
     expect(experimentalCjs.useTLogSearchResultsPage).toBeTruthy();
+    expect(experimentalCjs.useTLogLinkController).toBeTruthy();
     expect(experimentalCjs.createAppendOnlyLogStore).toBeTruthy();
   });
 });

--- a/test/tlog-link-controller.test.ts
+++ b/test/tlog-link-controller.test.ts
@@ -1,0 +1,280 @@
+import type {
+  TLogLinkAction,
+  TLogViewHandle,
+  TLogViewScrollMetrics,
+  TLogViewVisibleLink,
+} from "../src/experimental.js";
+import { describe, expect, it, vi } from "vitest";
+import { createApp, defineComponent, nextTick, ref } from "./ui-regressions-support.js";
+import { useTLogLinkController } from "../src/experimental.js";
+
+async function mountHarness(
+  logView: ReturnType<typeof ref<TLogViewHandle | null>>,
+  options?: Parameters<typeof useTLogLinkController>[1],
+): Promise<{
+  api: ReturnType<typeof useTLogLinkController>;
+  unmount: () => void;
+}> {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  let api!: ReturnType<typeof useTLogLinkController>;
+
+  const App = defineComponent({
+    name: "UseTLogLinkControllerHarness",
+    setup() {
+      api = useTLogLinkController(logView, options);
+      return () => null;
+    },
+  });
+
+  const app = createApp(App);
+  app.mount(root);
+  await nextTick();
+
+  return {
+    api,
+    unmount: () => {
+      app.unmount();
+      root.remove();
+    },
+  };
+}
+
+function createMetrics(): TLogViewScrollMetrics {
+  return {
+    scrollTop: 10,
+    maxScrollTop: 100,
+    viewportRows: 20,
+    lineCount: 200,
+    firstLineIndex: 10,
+    estimatedVisualRowCount: 200,
+    visualRowCount: 200,
+    measuredVisualRowCount: 200,
+    measuredLineCount: 200,
+    visualIndexStatus: "exact",
+    atTop: false,
+    atBottom: false,
+  };
+}
+
+function createVisibleLinks(): readonly TLogViewVisibleLink[] {
+  return [
+    {
+      visibleIndex: 0,
+      href: "https://example.com/1",
+      text: "one",
+      absoluteLineIndex: 10,
+      index: 10,
+      startCell: 0,
+      endCell: 3,
+      startX: 0,
+      endX: 3,
+      y: 0,
+    },
+    {
+      visibleIndex: 1,
+      href: "https://example.com/2",
+      text: "two",
+      absoluteLineIndex: 11,
+      index: 11,
+      startCell: 1,
+      endCell: 4,
+      startX: 1,
+      endX: 4,
+      y: 1,
+      focused: true,
+    },
+  ];
+}
+
+describe("useTLogLinkController", () => {
+  it("refreshes panel items and active index from visible links", async () => {
+    const visibleLinks = createVisibleLinks();
+    const logView = ref<TLogViewHandle | null>({
+      getVisibleLinks: () => visibleLinks,
+      getScrollMetrics: () => createMetrics(),
+    } as Partial<TLogViewHandle> as TLogViewHandle);
+    const harness = await mountHarness(logView);
+
+    try {
+      harness.api.refresh();
+
+      expect(harness.api.visibleLinks.value).toEqual([
+        {
+          visibleIndex: 0,
+          href: "https://example.com/1",
+          text: "one",
+          absoluteLineIndex: 10,
+          index: 10,
+          startCell: 0,
+          endCell: 3,
+        },
+        {
+          visibleIndex: 1,
+          href: "https://example.com/2",
+          text: "two",
+          absoluteLineIndex: 11,
+          index: 11,
+          startCell: 1,
+          endCell: 4,
+          current: true,
+        },
+      ]);
+      expect(harness.api.activeIndex.value).toBe(1);
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("focuses visible links through the handle and refreshes active index", async () => {
+    const focused = ref(0);
+    const focusVisibleLink = vi.fn((index: number) => {
+      focused.value = index;
+      return true;
+    });
+    const logView = ref<TLogViewHandle | null>({
+      focusVisibleLink,
+      getVisibleLinks: () =>
+        createVisibleLinks().map((link, index) => ({
+          ...link,
+          focused: index === focused.value || undefined,
+        })),
+      getScrollMetrics: () => createMetrics(),
+    } as Partial<TLogViewHandle> as TLogViewHandle);
+    const harness = await mountHarness(logView);
+
+    try {
+      expect(harness.api.focusVisibleLink(1)).toBe(true);
+      expect(focusVisibleLink).toHaveBeenCalledWith(1);
+      expect(harness.api.activeIndex.value).toBe(1);
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("activates a visible link by focusing then activating it", async () => {
+    const actions: TLogLinkAction[] = [];
+    const focused = ref(0);
+    const focusVisibleLink = vi.fn((index: number) => {
+      focused.value = index;
+      return true;
+    });
+    const activateFocusedLink = vi.fn(() => true);
+    const logView = ref<TLogViewHandle | null>({
+      focusVisibleLink,
+      activateFocusedLink,
+      getVisibleLinks: () =>
+        createVisibleLinks().map((link, index) => ({
+          ...link,
+          focused: index === focused.value || undefined,
+        })),
+      getScrollMetrics: () => createMetrics(),
+    } as Partial<TLogViewHandle> as TLogViewHandle);
+    const harness = await mountHarness(logView, {
+      onAction(action) {
+        actions.push(action);
+      },
+    });
+
+    try {
+      expect(harness.api.activateVisibleLink(1)).toBe(true);
+      expect(focusVisibleLink).toHaveBeenCalledWith(1);
+      expect(activateFocusedLink).toHaveBeenCalledTimes(1);
+      expect(actions).toEqual([
+        {
+          href: "https://example.com/2",
+          text: "two",
+          source: "panel",
+          absoluteLineIndex: 11,
+          index: 11,
+          startCell: 1,
+          endCell: 4,
+        },
+      ]);
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("normalizes link click payloads into actions", async () => {
+    const onAction = vi.fn();
+    const logView = ref<TLogViewHandle | null>(null);
+    const harness = await mountHarness(logView, { onAction });
+
+    try {
+      harness.api.handleLinkClick({
+        href: "https://example.com",
+        text: "docs",
+        absoluteLineIndex: 42,
+        index: 2,
+        startCell: 3,
+        endCell: 7,
+        cellX: 4,
+        cellY: 1,
+      });
+
+      expect(onAction).toHaveBeenCalledWith({
+        href: "https://example.com",
+        text: "docs",
+        source: "click",
+        absoluteLineIndex: 42,
+        index: 2,
+        startCell: 3,
+        endCell: 7,
+      });
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("normalizes link activate payloads and suppresses duplicates from programmatic activation", async () => {
+    const actions: TLogLinkAction[] = [];
+    const activateFocusedLink = vi.fn(() => true);
+    const logView = ref<TLogViewHandle | null>({
+      activateFocusedLink,
+      getVisibleLinks: () => createVisibleLinks(),
+      getScrollMetrics: () => createMetrics(),
+    } as Partial<TLogViewHandle> as TLogViewHandle);
+    const harness = await mountHarness(logView, {
+      onAction(action) {
+        actions.push(action);
+      },
+    });
+
+    try {
+      harness.api.refresh();
+      expect(harness.api.activateFocusedLink()).toBe(true);
+      harness.api.handleLinkActivate({
+        link: createVisibleLinks()[1]!,
+        source: "programmatic",
+      });
+      harness.api.handleLinkActivate({
+        link: createVisibleLinks()[1]!,
+        source: "keyboard",
+      });
+
+      expect(actions).toEqual([
+        {
+          href: "https://example.com/2",
+          text: "two",
+          source: "programmatic",
+          absoluteLineIndex: 11,
+          index: 11,
+          startCell: 1,
+          endCell: 4,
+        },
+        {
+          href: "https://example.com/2",
+          text: "two",
+          source: "keyboard",
+          absoluteLineIndex: 11,
+          index: 11,
+          startCell: 1,
+          endCell: 4,
+        },
+      ]);
+    } finally {
+      harness.unmount();
+    }
+  });
+});

--- a/test/tlog-links-panel.test.ts
+++ b/test/tlog-links-panel.test.ts
@@ -392,7 +392,7 @@ describe("TLogLinksPanel integration", () => {
         }
 
         function onActiveChange(payload: TLogLinksPanelActiveChangePayload): void {
-          if (payload.activeIndex >= 0) links.focusVisibleLink(payload.activeIndex);
+          if (payload.item) links.focusVisibleLink(payload.item.visibleIndex);
           else links.clearFocus();
         }
 

--- a/test/tlog-links-panel.test.ts
+++ b/test/tlog-links-panel.test.ts
@@ -1,0 +1,476 @@
+import type {
+  TLogDataSource,
+  TLogLinkPanelItem,
+  TLogLinksPanelActiveChangePayload,
+  TLogLinksPanelActivatePayload,
+  TLogLinksPanelSelectPayload,
+  TLogLinkAction,
+  TLogViewHandle,
+} from "../src/experimental.js";
+import { describe, expect, it, vi } from "vitest";
+import { createTerminalApp } from "../src/index.js";
+import { TLogLinksPanel, TLogView, useTLogLinkController } from "../src/experimental.js";
+import {
+  createApp,
+  defineComponent,
+  h,
+  mountTerminal,
+  nextTick,
+  onMounted,
+  ref,
+} from "./ui-regressions-support.js";
+
+function rowText(
+  mounted: { terminal: ReturnType<typeof createTerminalApp>["terminal"] },
+  y: number,
+): string {
+  return mounted.terminal
+    .getRow(y)
+    .map((cell) => cell.ch)
+    .join("")
+    .trimEnd();
+}
+
+function rowStyles(
+  mounted: { terminal: ReturnType<typeof createTerminalApp>["terminal"] },
+  y: number,
+) {
+  return mounted.terminal.getRow(y).map((cell) => cell.style);
+}
+
+describe("TLogLinksPanel", () => {
+  it("renders visible link items with line number text and href", async () => {
+    const mounted = await mountTerminal(
+      () =>
+        h(TLogLinksPanel, {
+          x: 0,
+          y: 0,
+          w: 30,
+          h: 2,
+          links: [
+            {
+              visibleIndex: 0,
+              href: "https://example.com/1",
+              text: "alpha",
+              absoluteLineIndex: 12,
+              index: 12,
+              startCell: 0,
+              endCell: 5,
+            },
+            {
+              visibleIndex: 1,
+              href: "https://example.com/2",
+              text: "beta",
+              absoluteLineIndex: 1042,
+              index: 42,
+              startCell: 1,
+              endCell: 5,
+            },
+          ] satisfies readonly TLogLinkPanelItem[],
+        }),
+      30,
+      2,
+    );
+
+    try {
+      expect(rowText(mounted, 0)).toBe("  12 alpha https://example.com");
+      expect(rowText(mounted, 1)).toBe("1042 beta https://example.com/");
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("composes active current and href styles", async () => {
+    const mounted = await mountTerminal(
+      () =>
+        h(TLogLinksPanel, {
+          x: 0,
+          y: 0,
+          w: 24,
+          h: 1,
+          activeIndex: 0,
+          activeStyle: { inverse: true },
+          currentStyle: { bold: true },
+          hrefStyle: { underline: true, fg: "yellow" },
+          links: [
+            {
+              visibleIndex: 0,
+              href: "https://e.dev",
+              text: "alpha",
+              absoluteLineIndex: 12,
+              index: 12,
+              startCell: 0,
+              endCell: 5,
+              current: true,
+            },
+          ] satisfies readonly TLogLinkPanelItem[],
+        }),
+      24,
+      1,
+    );
+
+    try {
+      const styles = rowStyles(mounted, 0);
+      expect(styles[0]).toMatchObject({ inverse: true, bold: true });
+      expect(styles[9]).toMatchObject({
+        inverse: true,
+        bold: true,
+      });
+      expect(styles[10]).toMatchObject({
+        inverse: true,
+        bold: true,
+        underline: true,
+        fg: "yellow",
+      });
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("emits select when clicking a row", async () => {
+    const onSelect = vi.fn();
+    const App = defineComponent({
+      name: "TLogLinksPanelClickApp",
+      setup() {
+        return () =>
+          h(TLogLinksPanel, {
+            x: 0,
+            y: 0,
+            w: 24,
+            h: 2,
+            links: [
+              {
+                visibleIndex: 0,
+                href: "https://example.com/1",
+                text: "alpha",
+                absoluteLineIndex: 10,
+                index: 10,
+                startCell: 0,
+                endCell: 5,
+              },
+              {
+                visibleIndex: 1,
+                href: "https://example.com/2",
+                text: "bravo",
+                absoluteLineIndex: 20,
+                index: 20,
+                startCell: 0,
+                endCell: 5,
+              },
+            ] satisfies readonly TLogLinkPanelItem[],
+            onSelect,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 24, rows: 2, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "click", cellX: 0, cellY: 1, time: Date.now() } as any);
+      await nextTick();
+
+      expect(onSelect).toHaveBeenCalledWith({
+        visibleIndex: 1,
+        item: expect.objectContaining({
+          href: "https://example.com/2",
+          absoluteLineIndex: 20,
+        }),
+      } satisfies TLogLinksPanelSelectPayload);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("supports keyboard active-row navigation and escape clearing", async () => {
+    const onActiveChange = vi.fn();
+    const App = defineComponent({
+      name: "TLogLinksPanelKeyboardApp",
+      setup() {
+        return () =>
+          h(TLogLinksPanel, {
+            x: 0,
+            y: 0,
+            w: 24,
+            h: 3,
+            links: [
+              {
+                visibleIndex: 0,
+                href: "https://example.com/1",
+                text: "alpha",
+                absoluteLineIndex: 10,
+                index: 10,
+                startCell: 0,
+                endCell: 5,
+              },
+              {
+                visibleIndex: 1,
+                href: "https://example.com/2",
+                text: "bravo",
+                absoluteLineIndex: 11,
+                index: 11,
+                startCell: 0,
+                endCell: 5,
+              },
+              {
+                visibleIndex: 2,
+                href: "https://example.com/3",
+                text: "charlie",
+                absoluteLineIndex: 12,
+                index: 12,
+                startCell: 0,
+                endCell: 7,
+              },
+            ] satisfies readonly TLogLinkPanelItem[],
+            onActiveChange,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 24, rows: 3, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "click", cellX: 0, cellY: 0, time: Date.now() } as any);
+      app.events.dispatch({
+        type: "keydown",
+        key: "ArrowDown",
+        code: "ArrowDown",
+        time: Date.now(),
+      } as any);
+      app.events.dispatch({ type: "keydown", key: "End", code: "End", time: Date.now() } as any);
+      app.events.dispatch({ type: "keydown", key: "Home", code: "Home", time: Date.now() } as any);
+      app.events.dispatch({
+        type: "keydown",
+        key: "ArrowUp",
+        code: "ArrowUp",
+        time: Date.now(),
+      } as any);
+      app.events.dispatch({
+        type: "keydown",
+        key: "Escape",
+        code: "Escape",
+        time: Date.now(),
+      } as any);
+      await nextTick();
+
+      expect(onActiveChange.mock.calls.map((call) => call[0])).toEqual([
+        {
+          activeIndex: 0,
+          item: expect.objectContaining({ visibleIndex: 0, text: "alpha" }),
+        },
+        {
+          activeIndex: 1,
+          item: expect.objectContaining({ visibleIndex: 1, text: "bravo" }),
+        },
+        {
+          activeIndex: 2,
+          item: expect.objectContaining({ visibleIndex: 2, text: "charlie" }),
+        },
+        {
+          activeIndex: 0,
+          item: expect.objectContaining({ visibleIndex: 0, text: "alpha" }),
+        },
+        {
+          activeIndex: -1,
+          item: null,
+        },
+      ] satisfies readonly TLogLinksPanelActiveChangePayload[]);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("emits activate on enter", async () => {
+    const onActivate = vi.fn();
+    const App = defineComponent({
+      name: "TLogLinksPanelActivateApp",
+      setup() {
+        return () =>
+          h(TLogLinksPanel, {
+            x: 0,
+            y: 0,
+            w: 24,
+            h: 1,
+            activeIndex: 0,
+            links: [
+              {
+                visibleIndex: 0,
+                href: "https://example.com/1",
+                text: "alpha",
+                absoluteLineIndex: 10,
+                index: 10,
+                startCell: 0,
+                endCell: 5,
+              },
+            ] satisfies readonly TLogLinkPanelItem[],
+            onActivate,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 24, rows: 1, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "click", cellX: 0, cellY: 0, time: Date.now() } as any);
+      app.events.dispatch({
+        type: "keydown",
+        key: "Enter",
+        code: "Enter",
+        time: Date.now(),
+      } as any);
+      await nextTick();
+
+      expect(onActivate).toHaveBeenCalledWith({
+        visibleIndex: 0,
+        item: expect.objectContaining({
+          href: "https://example.com/1",
+          text: "alpha",
+        }),
+      } satisfies TLogLinksPanelActivatePayload);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("renders a safe empty state", async () => {
+    const mounted = await mountTerminal(
+      () =>
+        h(TLogLinksPanel, {
+          x: 0,
+          y: 0,
+          w: 20,
+          h: 2,
+          links: [],
+        }),
+      20,
+      2,
+    );
+
+    try {
+      expect(rowText(mounted, 0)).toBe("No visible links");
+      expect(rowStyles(mounted, 0)[0]).toMatchObject({ dim: true });
+    } finally {
+      mounted.unmount();
+    }
+  });
+});
+
+describe("TLogLinksPanel integration", () => {
+  it("focuses and activates visible links through the controller", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const controller = ref<ReturnType<typeof useTLogLinkController> | null>(null);
+    const actions = ref<readonly TLogLinkAction[]>([]);
+    const source: TLogDataSource = {
+      lineCount: () => 2,
+      getLine: (index) =>
+        index === 0
+          ? "\x1b]8;;https://example.com/1\x07one\x1b]8;;\x07"
+          : "\x1b]8;;https://example.com/2\x07two\x1b]8;;\x07",
+      getLineKey: (index) => `line-${index}`,
+    };
+
+    const App = defineComponent({
+      name: "TLogLinksPanelIntegrationApp",
+      setup() {
+        const links = useTLogLinkController(logView, {
+          onAction(action) {
+            actions.value = [...actions.value, action];
+          },
+        });
+        controller.value = links;
+
+        function refreshLinks(): void {
+          links.refresh();
+        }
+
+        function onActiveChange(payload: TLogLinksPanelActiveChangePayload): void {
+          if (payload.activeIndex >= 0) links.focusVisibleLink(payload.activeIndex);
+          else links.clearFocus();
+        }
+
+        onMounted(() => {
+          links.refresh();
+        });
+
+        return () =>
+          h("span", [
+            h(TLogView, {
+              ref: logView,
+              x: 0,
+              y: 0,
+              w: 8,
+              h: 2,
+              source,
+              version: 1,
+              ansi: true,
+              links: true,
+              onScroll: refreshLinks,
+              onLinkFocus: refreshLinks,
+              onLinkClick: links.handleLinkClick,
+              onLinkActivate: links.handleLinkActivate,
+            }),
+            h(TLogLinksPanel, {
+              x: 9,
+              y: 0,
+              w: 22,
+              h: 2,
+              links: links.visibleLinks.value,
+              activeIndex: links.activeIndex.value,
+              onSelect: ({ visibleIndex }: TLogLinksPanelSelectPayload) =>
+                links.focusVisibleLink(visibleIndex),
+              onActiveChange,
+              onActivate: ({ visibleIndex }: TLogLinksPanelActivatePayload) =>
+                links.activateVisibleLink(visibleIndex),
+            }),
+          ]);
+      },
+    });
+
+    const app = createTerminalApp({ cols: 31, rows: 2, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "click", cellX: 9, cellY: 1, time: Date.now() } as any);
+      await nextTick();
+      app.scheduler.flushNow();
+      expect(controller.value?.focusVisibleLink(1)).toBe(true);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(rowStyles(app, 1)[0]).toMatchObject({
+        href: "https://example.com/2",
+        inverse: true,
+      });
+
+      expect(controller.value?.activateVisibleLink(1)).toBe(true);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(actions.value.at(-1)).toEqual({
+        href: "https://example.com/2",
+        text: "two",
+        source: "panel",
+        absoluteLineIndex: 1,
+        index: 1,
+        startCell: 0,
+        endCell: 3,
+      });
+      expect(rowStyles(app, 1)[0]).toMatchObject({
+        href: "https://example.com/2",
+        inverse: true,
+      });
+    } finally {
+      app.dispose();
+    }
+  });
+});

--- a/test/tlog-view.test.ts
+++ b/test/tlog-view.test.ts
@@ -4182,6 +4182,7 @@ describe("TLogView", () => {
             startX: 4,
             endX: 7,
             y: 0,
+            focused: true,
           },
           source: "keyboard",
         },
@@ -4242,6 +4243,7 @@ describe("TLogView", () => {
         startX: 0,
         endX: 5,
         y: 0,
+        focused: true,
       },
       source: "programmatic",
     });
@@ -4258,6 +4260,238 @@ describe("TLogView", () => {
       focusedLinkIndex: -1,
     });
     mounted.unmount();
+  });
+
+  it("clears link focus when absolute line identity changes across retained head reuse", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const version = ref(1);
+    const firstLine = ref(10);
+    const focusPayloads: TLogViewLinkFocusPayload[] = [];
+    const App = defineComponent({
+      name: "TLogViewLinkAbsoluteIdentityApp",
+      setup() {
+        const source: TLogDataSource = {
+          lineCount: () => 1,
+          getLine: () => "\x1b]8;;https://example.com\x07one\x1b]8;;\x07",
+          getLineKey: () => "line",
+          firstLineIndex: () => firstLine.value,
+        };
+        return () =>
+          h(TLogView, {
+            ref: logView,
+            x: 0,
+            y: 0,
+            w: 8,
+            h: 1,
+            source,
+            version: version.value,
+            ansi: true,
+            links: true,
+            onLinkFocus: (payload: TLogViewLinkFocusPayload) => focusPayloads.push(payload),
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 8, rows: 2, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(logView.value?.focusNextLink()).toBe(true);
+      await nextTick();
+      app.scheduler.flushNow();
+      expect(logView.value?.getVisibleLinks()[0]).toMatchObject({
+        absoluteLineIndex: 10,
+        focused: true,
+      });
+
+      firstLine.value = 11;
+      version.value++;
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(logView.value?.getVisibleLinks()[0]).toMatchObject({
+        absoluteLineIndex: 11,
+      });
+      expect(logView.value?.getVisibleLinks()[0]?.focused).toBeUndefined();
+      expect(rowStyles(app, 0)[0]).toMatchObject({
+        href: "https://example.com",
+        underline: true,
+      });
+      expect(rowStyles(app, 0)[0]?.inverse).toBeUndefined();
+      expect(focusPayloads.at(-1)).toEqual({
+        link: null,
+        focusedLinkIndex: -1,
+      });
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("emits linkFocus(null) when links are disabled after a link is focused", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const links = ref(true);
+    const focusPayloads: TLogViewLinkFocusPayload[] = [];
+    const App = defineComponent({
+      name: "TLogViewDisableLinksFocusApp",
+      setup() {
+        const source: TLogDataSource = {
+          lineCount: () => 1,
+          getLine: () => "\x1b]8;;https://example.com\x07one\x1b]8;;\x07",
+          getLineKey: () => "line",
+        };
+        return () =>
+          h(TLogView, {
+            ref: logView,
+            x: 0,
+            y: 0,
+            w: 8,
+            h: 1,
+            source,
+            version: 1,
+            ansi: true,
+            links: links.value,
+            onLinkFocus: (payload: TLogViewLinkFocusPayload) => focusPayloads.push(payload),
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 8, rows: 2, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(logView.value?.focusNextLink()).toBe(true);
+      await nextTick();
+      app.scheduler.flushNow();
+      expect(rowStyles(app, 0)[0]?.inverse).toBe(true);
+
+      links.value = false;
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(rowStyles(app, 0)[0]).toEqual({});
+      expect(rowStyles(app, 0)[0]?.inverse).toBeUndefined();
+      expect(focusPayloads.at(-1)).toEqual({
+        link: null,
+        focusedLinkIndex: -1,
+      });
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("clears custom link focus style without removing href styling", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const source: TLogDataSource = {
+      lineCount: () => 1,
+      getLine: () => "\x1b]8;;https://example.com\x07one\x1b]8;;\x07",
+      getLineKey: () => "line",
+    };
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TLogView, {
+          ref: logView,
+          x: 0,
+          y: 0,
+          w: 8,
+          h: 1,
+          source,
+          version: 1,
+          ansi: true,
+          links: true,
+          linkFocusStyle: { bg: "blue" },
+        }),
+      8,
+      2,
+    );
+
+    try {
+      expect(logView.value?.focusNextLink()).toBe(true);
+      await nextTick();
+      expect(rowStyles(mounted, 0)[0]).toMatchObject({
+        href: "https://example.com",
+        underline: true,
+        bg: "blue",
+      });
+
+      logView.value?.clearLinkFocus();
+      await nextTick();
+      expect(rowStyles(mounted, 0)[0]).toMatchObject({
+        href: "https://example.com",
+        underline: true,
+      });
+      expect(rowStyles(mounted, 0)[0]?.bg).toBeUndefined();
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("applies focused-link overlay only to segments with the matching href", async () => {
+    const logView = ref<TLogViewHandle | null>(null);
+    const version = ref(1);
+    const href = ref("https://example.com/1");
+    const focusPayloads: TLogViewLinkFocusPayload[] = [];
+    const App = defineComponent({
+      name: "TLogViewLinkHrefOverlayApp",
+      setup() {
+        const source: TLogDataSource = {
+          lineCount: () => 1,
+          getLine: () => `\x1b]8;;${href.value}\x07one\x1b]8;;\x07`,
+          getLineKey: () => href.value,
+        };
+        return () =>
+          h(TLogView, {
+            ref: logView,
+            x: 0,
+            y: 0,
+            w: 8,
+            h: 1,
+            source,
+            version: version.value,
+            ansi: true,
+            links: true,
+            onLinkFocus: (payload: TLogViewLinkFocusPayload) => focusPayloads.push(payload),
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 8, rows: 2, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(logView.value?.focusNextLink()).toBe(true);
+      await nextTick();
+      app.scheduler.flushNow();
+      expect(rowStyles(app, 0)[0]).toMatchObject({
+        href: "https://example.com/1",
+        inverse: true,
+      });
+
+      href.value = "https://example.com/2";
+      version.value++;
+      await nextTick();
+      app.scheduler.flushNow();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(rowStyles(app, 0)[0]).toMatchObject({
+        href: "https://example.com/2",
+        underline: true,
+      });
+      expect(rowStyles(app, 0)[0]?.inverse).toBeUndefined();
+      expect(focusPayloads.at(-1)).toEqual({
+        link: null,
+        focusedLinkIndex: -1,
+      });
+    } finally {
+      app.dispose();
+    }
   });
 
   it("does not intercept Tab when keyboardLinks is disabled", async () => {


### PR DESCRIPTION
## Summary

Add `TLogLinksPanel` component and `useTLogLinkController` composable for managing and interacting with OSC8 hyperlinks in TLogView.

### New components
- **TLogLinksPanel** – panel component that displays visible OSC8 links with keyboard/mouse navigation, selection, and activation support
- **useTLogLinkController** – composable that bridges TLogView link events (click/activate/visible links) into a unified link action handler with source tracking (click, keyboard, programmatic, panel)

### Changes
- Export `TLogLinksPanel`, `useTLogLinkController`, and associated types from `src/experimental.ts`
- Update `TLogView` to support link panel integration
- Add unit tests for `TLogLinksPanel` and `useTLogLinkController`
- Update existing TLogView tests for link panel support
- Update package export tests
- Update docs (components.md, components-api.md)