### PR TITLE
feat(tlog-view): add phase 3 productionization stack

### DIFF
--- a/docs/generated/components-api.md
+++ b/docs/generated/components-api.md
@@ -21,6 +21,8 @@
 - [TLogSearchPager](#tlogsearchpager)
 - [TLogSearchResults](#tlogsearchresults)
 - [TLogView](#tlogview)
+- [TLogVirtualLinksPanel](#tlogvirtuallinkspanel)
+- [TLogVirtualSearchResults](#tlogvirtualsearchresults)
 - [TMultilineModal](#tmultilinemodal)
 - [TPathPicker](#tpathpicker)
 - [TRenderLayer](#trenderlayer)
@@ -645,6 +647,73 @@
 | <code>blur</code>               | —       | —    |
 | <code>keydown</code>            | —       | —    |
 
+## TLogVirtualLinksPanel
+
+源码：`src/vue/components/TLogVirtualLinksPanel.ts`
+
+### Props
+
+| 名称                         | 类型                                      | 默认值                       | 必填 | 说明 |
+| ---------------------------- | ----------------------------------------- | ---------------------------- | ---- | ---- |
+| <code>x</code>               | <code>number</code>                       | —                            | 是   | —    |
+| <code>y</code>               | <code>number</code>                       | —                            | 是   | —    |
+| <code>w</code>               | <code>number</code>                       | —                            | 是   | —    |
+| <code>h</code>               | <code>number</code>                       | —                            | 是   | —    |
+| <code>zIndex</code>          | <code>number</code>                       | <code>0</code>               | 否   | —    |
+| <code>links</code>           | <code>readonly TLogLinkPanelItem[]</code> | <code>() =&gt; []</code>     | 否   | —    |
+| <code>modelValue</code>      | <code>number</code>                       | <code>-1</code>              | 否   | —    |
+| <code>style</code>           | <code>Style</code>                        | <code>undefined</code>       | 否   | —    |
+| <code>activeStyle</code>     | <code>Style</code>                        | <code>undefined</code>       | 否   | —    |
+| <code>showLineNumbers</code> | <code>boolean</code>                      | <code>true</code>            | 否   | —    |
+| <code>rowScrollMode</code>   | <code>RowScrollMode</code>                | <code>&quot;off&quot;</code> | 否   | —    |
+
+### Events
+
+| 名称                           | Payload | 说明 |
+| ------------------------------ | ------- | ---- |
+| <code>update:modelValue</code> | —       | —    |
+| <code>activeChange</code>      | —       | —    |
+| <code>select</code>            | —       | —    |
+| <code>activate</code>          | —       | —    |
+| <code>focus</code>             | —       | —    |
+| <code>blur</code>              | —       | —    |
+| <code>keydown</code>           | —       | —    |
+| <code>scroll</code>            | —       | —    |
+
+## TLogVirtualSearchResults
+
+源码：`src/vue/components/TLogVirtualSearchResults.ts`
+
+### Props
+
+| 名称                         | 类型                                                                | 默认值                       | 必填 | 说明 |
+| ---------------------------- | ------------------------------------------------------------------- | ---------------------------- | ---- | ---- |
+| <code>x</code>               | <code>number</code>                                                 | —                            | 是   | —    |
+| <code>y</code>               | <code>number</code>                                                 | —                            | 是   | —    |
+| <code>w</code>               | <code>number</code>                                                 | —                            | 是   | —    |
+| <code>h</code>               | <code>number</code>                                                 | —                            | 是   | —    |
+| <code>zIndex</code>          | <code>number</code>                                                 | <code>0</code>               | 否   | —    |
+| <code>itemCount</code>       | <code>number</code>                                                 | —                            | 是   | —    |
+| <code>itemVersion</code>     | <code>number</code>                                                 | —                            | 是   | —    |
+| <code>getItem</code>         | <code>(index: number) =&gt; TLogSearchResultItem &#124; null</code> | —                            | 是   | —    |
+| <code>modelValue</code>      | <code>number</code>                                                 | <code>-1</code>              | 否   | —    |
+| <code>style</code>           | <code>Style</code>                                                  | <code>undefined</code>       | 否   | —    |
+| <code>activeStyle</code>     | <code>Style</code>                                                  | <code>undefined</code>       | 否   | —    |
+| <code>showLineNumbers</code> | <code>boolean</code>                                                | <code>true</code>            | 否   | —    |
+| <code>rowScrollMode</code>   | <code>RowScrollMode</code>                                          | <code>&quot;off&quot;</code> | 否   | —    |
+
+### Events
+
+| 名称                           | Payload | 说明 |
+| ------------------------------ | ------- | ---- |
+| <code>update:modelValue</code> | —       | —    |
+| <code>activeChange</code>      | —       | —    |
+| <code>select</code>            | —       | —    |
+| <code>focus</code>             | —       | —    |
+| <code>blur</code>              | —       | —    |
+| <code>keydown</code>           | —       | —    |
+| <code>scroll</code>            | —       | —    |
+
 ## TMultilineModal
 
 源码：`src/vue/components/TMultilineModal.ts`
@@ -904,6 +973,7 @@
 | ------------------------------ | ------- | ---- |
 | <code>update:modelValue</code> | —       | —    |
 | <code>change</code>            | —       | —    |
+| <code>itemClick</code>         | —       | —    |
 | <code>scroll</code>            | —       | —    |
 | <code>focus</code>             | —       | —    |
 | <code>blur</code>              | —       | —    |

--- a/examples/tlog-view-lab/App.ts
+++ b/examples/tlog-view-lab/App.ts
@@ -2,6 +2,8 @@ import type {
   AppendOnlyLogStore,
   TLogLinkAction,
   TLogLinkPanelItem,
+  TLogIndexedLink,
+  TLogIndexStatus,
   TLogMinimapDensityBucket,
   TLogMinimapMarker,
   TLogScrollbarMarker,
@@ -9,21 +11,42 @@ import type {
   TLogViewScrollMetrics,
   TLogViewSearchMarker,
   TLogViewSearchMode,
+  TLogUiPreset,
 } from "../../src/experimental.js";
 import type { PropType, Ref } from "vue";
 import { computed, defineComponent, h, nextTick, ref, watch, watchEffect } from "vue";
 import { TText, TView } from "../../src/index.js";
 import {
+  TLogVirtualLinksPanel,
+  TLogVirtualSearchResults,
   TLogLinksPanel,
   TLogMinimap,
   TLogScrollbar,
   TLogSearchBar,
   TLogSearchPager,
-  TLogSearchResults,
   TLogView,
+  captureTLogViewSessionState,
+  createTLogLineMatcherPlugin,
+  createTLogLinkActionPlugin,
   createAppendOnlyLogStore,
+  createTLogViewSessionStore,
+  dispatchTLogPluginLinkAction,
+  handleTLogKeymapEvent,
+  resolveTLogLinksPanelTheme,
+  resolveTLogMinimapTheme,
+  resolveTLogScrollbarTheme,
+  resolveTLogSearchBarTheme,
+  resolveTLogSearchPagerTheme,
+  resolveTLogSearchResultsTheme,
+  resolveTLogViewTheme,
+  restoreTLogViewSessionState,
+  tlogDarkPreset,
+  tlogDefaultPreset,
+  tlogHighContrastPreset,
   useTLogLinkController,
+  useTLogRetainedIndex,
   useTLogSearchController,
+  useTLogVirtualSearchResults,
 } from "../../src/experimental.js";
 
 export const TLOG_VIEW_LAB_LAYOUT = Object.freeze({
@@ -56,8 +79,15 @@ export type TLogViewLabApi = Readonly<{
   links: Ref<boolean>;
   keyboardLinks: Ref<boolean>;
   visualIndexMode: Ref<"estimated" | "exact">;
+  preset: Ref<TLogUiPreset>;
   search: ReturnType<typeof useTLogSearchController>;
+  virtualResults: ReturnType<typeof useTLogVirtualSearchResults>;
   linkController: ReturnType<typeof useTLogLinkController>;
+  retainedIndex: Readonly<{
+    status: Ref<TLogIndexStatus>;
+    links: Ref<readonly TLogIndexedLink[]>;
+    density: Ref<readonly TLogMinimapDensityBucket[]>;
+  }>;
   recentEvents: Ref<readonly string[]>;
   lastLinkAction: Ref<TLogLinkAction | null>;
   lastSearchSelection: Ref<number | null>;
@@ -72,6 +102,9 @@ export type TLogViewLabApi = Readonly<{
     replaceTail: () => void;
     appendChunk: () => void;
     toggleVisualIndexMode: () => void;
+    cyclePreset: () => void;
+    saveSession: () => void;
+    restoreSession: () => void;
   }>;
   getSearchResultCell: (row?: number) => LabPointerCell;
   getLinksPanelCell: (row?: number) => LabPointerCell;
@@ -86,6 +119,21 @@ function clamp(n: number, min: number, max: number): number {
 function formatRecentEvent(message: string): string {
   return `${new Date().toISOString().slice(11, 19)} ${message}`;
 }
+
+const LAB_SESSION_STORAGE = (() => {
+  const map = new Map<string, string>();
+  return {
+    getItem(key: string) {
+      return map.get(key) ?? null;
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+  };
+})();
 
 function osc8(href: string, text: string): string {
   return `\x1b]8;;${href}\x07${text}\x1b]8;;\x07`;
@@ -124,8 +172,9 @@ function makeBaseLine(index: number, prefix: string): string {
   const target = useLink ? osc8(href, `job-${index}`) : `plain-log-${index}`;
   const wide = index % 7 === 0 ? " 宽字符中🙂" : "";
   const payload = index % 11 === 0 ? ` payload=${makePayload(index)}` : "";
+  const docs = index % 17 === 0 ? ` docs=https://docs.example.com/log/${index}` : "";
   const wrap = index % 13 === 0 ? ` ${makeLongWrap(index)}` : "";
-  return `${stamp} ${level} ${target}${wide} ${prefix} line-${index}${payload}${wrap}`.trim();
+  return `${stamp} ${level} ${target}${wide} ${prefix} line-${index}${payload}${docs}${wrap}`.trim();
 }
 
 function makeTailLine(index: number, state: "draft" | "final"): string {
@@ -194,14 +243,36 @@ export const TLogViewLabApp = defineComponent({
     const links = ref(true);
     const keyboardLinks = ref(true);
     const visualIndexMode = ref<"estimated" | "exact">("exact");
+    const preset = ref<TLogUiPreset>(tlogDarkPreset);
     const store = createAppendOnlyLogStore({ maxLines: 2_000 });
+    const sessionStore = createTLogViewSessionStore({
+      storageKey: "@simon_he/vue-tui:tlog-view-lab",
+      storage: LAB_SESSION_STORAGE,
+    });
     const recentEvents = ref<readonly string[]>([]);
     const lastLinkAction = ref<TLogLinkAction | null>(null);
     const lastSearchSelection = ref<number | null>(null);
     const lastMarkerSelection = ref<number | null>(null);
     const metricsSummary = ref<TLogViewScrollMetrics | null>(null);
+    const retainedLinkActiveIndex = ref(-1);
     let nextLineIndex = 0;
     let tailState: "none" | "draft" | "final" = "none";
+    const presets = [tlogDefaultPreset, tlogDarkPreset, tlogHighContrastPreset] as const;
+
+    const linkPlugins = [
+      createTLogLinkActionPlugin({
+        name: "lab-link-audit",
+        onAction(action) {
+          pushEvent(`plugin link ${action.source} ${action.href}`);
+        },
+      }),
+      createTLogLineMatcherPlugin({
+        name: "lab-draft-tail",
+        pattern: /\btail-draft\b/u,
+        severity: "warning",
+        label: "DRAFT",
+      }),
+    ] as const;
 
     function pushEvent(message: string): void {
       recentEvents.value = [formatRecentEvent(message), ...recentEvents.value].slice(0, 6);
@@ -270,13 +341,52 @@ export const TLogViewLabApp = defineComponent({
       previewWidth: 48,
       contextCells: 18,
     });
+    const virtualResults = useTLogVirtualSearchResults(logView, {
+      includePreview: true,
+      previewWidth: 48,
+      contextCells: 18,
+    });
 
     const linkController = useTLogLinkController(logView, {
+      plugins: linkPlugins,
       onAction(action) {
         lastLinkAction.value = action;
         pushEvent(`link:${action.source} ${action.text} -> ${action.href}`);
       },
     });
+    const retainedIndex = useTLogRetainedIndex(
+      logView,
+      computed(() => store.source),
+      store.version,
+      {
+        links: true,
+        levels: true,
+        urls: true,
+        plugins: linkPlugins,
+      },
+    );
+
+    const theme = computed(() => preset.value.theme);
+    const searchBarTheme = computed(() => resolveTLogSearchBarTheme(theme.value));
+    const searchResultsTheme = computed(() => resolveTLogSearchResultsTheme(theme.value));
+    const searchPagerTheme = computed(() => resolveTLogSearchPagerTheme(theme.value));
+    const linksPanelTheme = computed(() => resolveTLogLinksPanelTheme(theme.value));
+    const scrollbarTheme = computed(() => resolveTLogScrollbarTheme(theme.value));
+    const minimapTheme = computed(() => resolveTLogMinimapTheme(theme.value));
+    const logViewTheme = computed(() => resolveTLogViewTheme(theme.value));
+
+    const retainedLinkItems = computed<readonly TLogLinkPanelItem[]>(() =>
+      retainedIndex.links.value.map((link, index) => ({
+        visibleIndex: index,
+        href: link.href,
+        text: link.text,
+        absoluteLineIndex: link.absoluteLineIndex,
+        index: link.lineIndex,
+        startCell: link.startCell,
+        endCell: link.endCell,
+        current: index === retainedLinkActiveIndex.value || undefined,
+      })),
+    );
 
     const scrollbarMarkers = computed<readonly TLogScrollbarMarker[]>(() =>
       search.markers.value.map((marker) => ({
@@ -299,7 +409,9 @@ export const TLogViewLabApp = defineComponent({
     );
 
     const minimapDensity = computed<readonly TLogMinimapDensityBucket[]>(() =>
-      createMarkerDensity(search.markers.value, search.metrics.value),
+      retainedIndex.density.value.length
+        ? retainedIndex.density.value
+        : createMarkerDensity(search.markers.value, search.metrics.value),
     );
 
     const footerLines = computed(() => {
@@ -310,14 +422,15 @@ export const TLogViewLabApp = defineComponent({
       const currentMatch =
         searchState.currentMatchIndex >= 0 ? searchState.currentMatchIndex + 1 : 0;
       const visibleLinks = linkController.visibleLinks.value.length;
+      const retainedLinks = retainedIndex.links.value.length;
       const lastAction = lastLinkAction.value
         ? `${lastLinkAction.value.source}:${lastLinkAction.value.text}`
         : "none";
       return [
-        `Ctrl+1 append200  Ctrl+2 append1000  Ctrl+3 clear  Ctrl+4 replaceTail  Ctrl+5 appendChunk  Ctrl+R reseed  Ctrl+V exact/estimated`,
-        `Search ${searchState.status}  mode=${search.mode.value}  query="${search.query.value}"  match=${currentMatch}/${searchState.matchCount}  page=${pagerState.page + 1}/${Math.max(1, pagerState.pageCount)}`,
-        `View wrap=${wrap.value} ansi=${ansi.value} links=${links.value} keyboardLinks=${keyboardLinks.value} visualIndex=${visualIndexMode.value} status=${visualStatus}`,
-        `Metrics lines=${metrics?.lineCount ?? 0} firstLine=${metrics?.firstLineIndex ?? 0} visualRows=${metrics?.visualRowCount ?? 0} scrollTop=${metrics?.scrollTop ?? 0} visibleLinks=${visibleLinks}`,
+        `Ctrl+1 append200  Ctrl+2 append1000  Ctrl+3 clear  Ctrl+4 replaceTail  Ctrl+5 appendChunk  Ctrl+R reseed  Ctrl+V exact/estimated  Ctrl+T theme  Ctrl+S save  Ctrl+O restore`,
+        `Search ${searchState.status}  mode=${search.mode.value}  query="${search.query.value}"  match=${currentMatch}/${searchState.matchCount}  pager=${pagerState.page + 1}/${Math.max(1, pagerState.pageCount)}  keymap=${preset.value.keymap.searchNext?.[0] ?? "-"}`,
+        `View wrap=${wrap.value} ansi=${ansi.value} links=${links.value} keyboardLinks=${keyboardLinks.value} visualIndex=${visualIndexMode.value} status=${visualStatus} preset=${presets.indexOf(preset.value) + 1}/${presets.length}`,
+        `Metrics lines=${metrics?.lineCount ?? 0} firstLine=${metrics?.firstLineIndex ?? 0} visualRows=${metrics?.visualRowCount ?? 0} scrollTop=${metrics?.scrollTop ?? 0} visibleLinks=${visibleLinks} retainedLinks=${retainedLinks} retainedStatus=${retainedIndex.status.value}`,
         `Last select=${lastSearchSelection.value ?? "-"}  last marker=${lastMarkerSelection.value ?? "-"}  last link=${lastAction}`,
         ...(recentEvents.value.length > 0 ? recentEvents.value : ["No recent lab events yet."]),
       ];
@@ -325,6 +438,7 @@ export const TLogViewLabApp = defineComponent({
 
     function refreshSearch(): void {
       search.refresh();
+      virtualResults.refresh();
       metricsSummary.value = search.metrics.value;
     }
 
@@ -341,6 +455,99 @@ export const TLogViewLabApp = defineComponent({
       void nextTick(() => {
         refreshAll();
       });
+    }
+
+    function focusRetainedLink(visibleIndex: number): boolean {
+      const item = retainedLinkItems.value[visibleIndex];
+      if (!item) return false;
+      retainedLinkActiveIndex.value = visibleIndex;
+      logView.value?.scrollToLine(item.index, { align: "center" });
+      void nextTick(() => {
+        const visible = logView.value
+          ?.getVisibleLinks()
+          .find(
+            (entry) =>
+              entry.absoluteLineIndex === item.absoluteLineIndex &&
+              entry.href === item.href &&
+              entry.startCell === item.startCell &&
+              entry.endCell === item.endCell,
+          );
+        if (visible) linkController.focusVisibleLink(visible.visibleIndex);
+        refreshAll();
+      });
+      return true;
+    }
+
+    function activateRetainedLink(visibleIndex: number): boolean {
+      const item = retainedLinkItems.value[visibleIndex];
+      if (!item) return false;
+      focusRetainedLink(visibleIndex);
+      const action: TLogLinkAction = {
+        href: item.href,
+        text: item.text,
+        source: "panel",
+        absoluteLineIndex: item.absoluteLineIndex,
+        index: item.index,
+        startCell: item.startCell,
+        endCell: item.endCell,
+      };
+      lastLinkAction.value = action;
+      dispatchTLogPluginLinkAction(linkPlugins, action);
+      pushEvent(`retained panel activate ${item.text}`);
+      return true;
+    }
+
+    function cyclePreset(): void {
+      const currentIndex = presets.findIndex((entry) => entry === preset.value);
+      preset.value = presets[(currentIndex + 1) % presets.length]!;
+      pushEvent(`preset=${currentIndex + 2 > presets.length ? 1 : currentIndex + 2}`);
+    }
+
+    function saveSession(): void {
+      const snapshot = captureTLogViewSessionState({
+        logView,
+        visualIndexMode,
+        wrap,
+        ansi,
+        links,
+        keyboardLinks,
+        search,
+        linkController: {
+          activeIndex: retainedLinkActiveIndex,
+          focusVisibleLink: focusRetainedLink,
+          clearFocus: () => {
+            retainedLinkActiveIndex.value = -1;
+          },
+        },
+      });
+      if (!snapshot) return;
+      sessionStore.save(snapshot);
+      pushEvent("session saved");
+    }
+
+    function restoreSession(): void {
+      const snapshot = sessionStore.load();
+      const restored = restoreTLogViewSessionState(
+        {
+          logView,
+          visualIndexMode,
+          wrap,
+          ansi,
+          links,
+          keyboardLinks,
+          search,
+          linkController: {
+            activeIndex: retainedLinkActiveIndex,
+            focusVisibleLink: focusRetainedLink,
+            clearFocus: () => {
+              retainedLinkActiveIndex.value = -1;
+            },
+          },
+        },
+        snapshot,
+      );
+      if (restored) pushEvent("session restored");
+      scheduleRefreshAll();
     }
 
     function selectMatch(matchIndex: number, source: string): void {
@@ -381,11 +588,22 @@ export const TLogViewLabApp = defineComponent({
       else if (key === "3") clearLogs();
       else if (key === "4") replaceTail();
       else if (key === "5") appendChunk();
+      else if (key === "s") saveSession();
+      else if (key === "o") restoreSession();
       else if (key === "r") reseed();
+      else if (key === "t") cyclePreset();
       else if (key === "v") {
         visualIndexMode.value = visualIndexMode.value === "exact" ? "estimated" : "exact";
         pushEvent(`visualIndexMode=${visualIndexMode.value}`);
       } else {
+        handleTLogKeymapEvent(e, preset.value.keymap, {
+          searchNext: search.nextMatch,
+          searchPrevious: search.previousMatch,
+          clearSearch: search.clearSearch,
+          nextLink: linkController.focusNextLink,
+          previousLink: linkController.focusPreviousLink,
+          activateLink: linkController.activateFocusedLink,
+        });
         return;
       }
       e.preventDefault?.();
@@ -400,8 +618,15 @@ export const TLogViewLabApp = defineComponent({
       links,
       keyboardLinks,
       visualIndexMode,
+      preset,
       search,
+      virtualResults,
       linkController,
+      retainedIndex: {
+        status: retainedIndex.status,
+        links: retainedIndex.links,
+        density: retainedIndex.density,
+      },
       recentEvents,
       lastLinkAction,
       lastSearchSelection,
@@ -438,6 +663,12 @@ export const TLogViewLabApp = defineComponent({
           pushEvent(`visualIndexMode=${visualIndexMode.value}`);
           scheduleRefreshAll();
         },
+        cyclePreset: () => {
+          cyclePreset();
+          scheduleRefreshAll();
+        },
+        saveSession: saveSession,
+        restoreSession: restoreSession,
       },
       getSearchResultCell(row = 0) {
         return {
@@ -483,7 +714,7 @@ export const TLogViewLabApp = defineComponent({
       },
     );
 
-    watch([wrap, ansi, links, keyboardLinks, visualIndexMode], () => {
+    watch([wrap, ansi, links, keyboardLinks, visualIndexMode, preset], () => {
       scheduleRefreshAll();
     });
 
@@ -509,6 +740,7 @@ export const TLogViewLabApp = defineComponent({
             h(TLogSearchBar, {
               ...TLOG_VIEW_LAB_LAYOUT.searchBar,
               state: search.searchBarState.value,
+              ...searchBarTheme.value,
               "onUpdate:query": search.updateQuery,
               "onUpdate:mode": search.updateMode,
               "onUpdate:caseSensitive": search.updateCaseSensitive,
@@ -522,6 +754,7 @@ export const TLogViewLabApp = defineComponent({
               ...TLOG_VIEW_LAB_LAYOUT.logView,
               source: store.source,
               version: store.version.value,
+              ...logViewTheme.value,
               wrap: wrap.value,
               ansi: ansi.value,
               links: links.value,
@@ -546,13 +779,16 @@ export const TLogViewLabApp = defineComponent({
             }),
             h(TText, {
               ...TLOG_VIEW_LAB_LAYOUT.resultsLabel,
-              value: "Results",
+              value: "Virtual results",
               style: { bold: true },
             }),
-            h(TLogSearchResults, {
+            h(TLogVirtualSearchResults, {
               ...TLOG_VIEW_LAB_LAYOUT.results,
-              results: search.resultsPage.state.value.results,
-              activeIndex: search.resultsPage.state.value.activeIndex,
+              ...searchResultsTheme.value,
+              itemCount: virtualResults.state.value.itemCount,
+              itemVersion: virtualResults.state.value.itemVersion,
+              getItem: virtualResults.getItem,
+              modelValue: virtualResults.state.value.activeIndex,
               onSelect: ({ matchIndex }: { matchIndex: number }) =>
                 selectMatch(matchIndex, "results"),
             }),
@@ -563,6 +799,7 @@ export const TLogViewLabApp = defineComponent({
             }),
             h(TLogSearchPager, {
               ...TLOG_VIEW_LAB_LAYOUT.pager,
+              ...searchPagerTheme.value,
               state: search.resultsPage.state.value,
               onPreviousPage: search.resultsPage.previousPage,
               onNextPage: search.resultsPage.nextPage,
@@ -570,20 +807,20 @@ export const TLogViewLabApp = defineComponent({
             }),
             h(TText, {
               ...TLOG_VIEW_LAB_LAYOUT.linksLabel,
-              value: "Visible links",
+              value: "Retained links",
               style: { bold: true },
             }),
-            h(TLogLinksPanel, {
+            h(TLogVirtualLinksPanel, {
               ...TLOG_VIEW_LAB_LAYOUT.links,
-              links: linkController.visibleLinks.value,
-              activeIndex: linkController.activeIndex.value,
+              ...linksPanelTheme.value,
+              links: retainedLinkItems.value,
+              modelValue: retainedLinkActiveIndex.value,
               onSelect: ({ visibleIndex }: { visibleIndex: number }) => {
-                linkController.focusVisibleLink(visibleIndex);
-                pushEvent(`panel select link ${visibleIndex}`);
+                focusRetainedLink(visibleIndex);
+                pushEvent(`retained panel select ${visibleIndex}`);
               },
-              onActiveChange: handleLinksPanelActiveChange,
               onActivate: ({ visibleIndex }: { visibleIndex: number }) => {
-                linkController.activateVisibleLink(visibleIndex);
+                activateRetainedLink(visibleIndex);
               },
             }),
             h(TText, {
@@ -593,6 +830,7 @@ export const TLogViewLabApp = defineComponent({
             }),
             h(TLogScrollbar, {
               ...TLOG_VIEW_LAB_LAYOUT.scrollbar,
+              ...scrollbarTheme.value,
               metrics: search.metrics.value,
               markers: scrollbarMarkers.value,
               showArrows: true,
@@ -616,6 +854,7 @@ export const TLogViewLabApp = defineComponent({
             }),
             h(TLogMinimap, {
               ...TLOG_VIEW_LAB_LAYOUT.minimap,
+              ...minimapTheme.value,
               metrics: search.metrics.value,
               markers: minimapMarkers.value,
               density: minimapDensity.value,

--- a/examples/tlog-view-lab/README.md
+++ b/examples/tlog-view-lab/README.md
@@ -4,14 +4,18 @@
 
 - `TLogView`
 - `TLogSearchBar`
-- `TLogSearchResults`
+- `TLogVirtualSearchResults`
 - `TLogSearchPager`
 - `TLogScrollbar`
 - `TLogMinimap`
-- `TLogLinksPanel`
+- `TLogVirtualLinksPanel`
 - `useTLogSearchController`
+- `useTLogVirtualSearchResults`
 - `useTLogLinkController`
+- `useTLogRetainedIndex`
 - `createAppendOnlyLogStore({ maxLines: 2000 })`
+- `createTLogViewSessionStore()`
+- `tlog*Preset` theme / keymap helpers
 
 ## 运行
 
@@ -32,12 +36,19 @@ pnpm run run:tlog-view-lab
 - `Ctrl+3` clear
 - `Ctrl+4` replace tail
 - `Ctrl+5` append chunk
+- `Ctrl+S` save session state
+- `Ctrl+O` restore session state
 - `Ctrl+R` reseed
+- `Ctrl+T` cycle preset theme/keymap
 - `Ctrl+V` toggle `visualIndexMode="exact" | "estimated"`
+- `F3` / `Shift+F3` next/previous search
+- `Tab` / `Shift+Tab` focus next/previous visible link
+- `Enter` activate focused link
 
 ## 交互覆盖
 
-- 搜索：text / regex / invalid regex / next / previous / select result
-- Links：pointer click / keyboard focus / keyboard activate / panel select / panel activate
-- Companion UI：scrollbar markers / minimap markers / exact visual index / retained-window metrics
+- 搜索：text / regex / invalid regex / next / previous / virtualized result select
+- Links：pointer click / keyboard focus / keyboard activate / retained-window panel select / panel activate
+- Companion UI：scrollbar markers / minimap markers / exact visual index / retained-window indexes / diagnostics density
 - Streaming：append burst / retention / mutable tail / chunk append
+- Productionization：plugin hooks / session persistence / theme presets / keymap presets

--- a/src/experimental.ts
+++ b/src/experimental.ts
@@ -6,10 +6,55 @@ export { TLogSearchBar } from "./vue/components/TLogSearchBar.js";
 export { TLogSearchResults } from "./vue/components/TLogSearchResults.js";
 export { TLogSearchPager } from "./vue/components/TLogSearchPager.js";
 export { TLogLinksPanel } from "./vue/components/TLogLinksPanel.js";
+export { TLogVirtualSearchResults } from "./vue/components/TLogVirtualSearchResults.js";
+export { TLogVirtualLinksPanel } from "./vue/components/TLogVirtualLinksPanel.js";
 export { createAppendOnlyLogStore } from "./vue/log/append-only-log-store.js";
 export { useTLogLinkController } from "./vue/log/use-tlog-link-controller.js";
 export { useTLogSearchController } from "./vue/log/use-tlog-search-controller.js";
 export { useTLogSearchResultsPage } from "./vue/log/use-tlog-search-results-page.js";
+export { useTLogVirtualSearchResults } from "./vue/log/use-tlog-virtual-search-results.js";
+export { useTLogRetainedIndex } from "./vue/log/use-tlog-retained-index.js";
+export {
+  captureTLogViewSessionState,
+  createTLogViewSessionStore,
+  deserializeTLogViewSessionState,
+  restoreTLogViewSessionState,
+  serializeTLogViewSessionState,
+} from "./vue/log/tlog-session.js";
+export {
+  createTLogDensityBucketsFromMarkers,
+  createTLogLevelPlugin,
+  createTLogLineMatcherPlugin,
+  createTLogLinkActionPlugin,
+  createTLogOsc8LinkPlugin,
+  createTLogUrlPlugin,
+  dispatchTLogPluginLinkAction,
+  getTLogPluginMetadata,
+  parseTLogAnnotatedText,
+  stripTLogAnsiText,
+  toTLogExternalLinkFromVisibleLink,
+} from "./vue/log/tlog-plugins.js";
+export {
+  handleTLogKeymapEvent,
+  matchesTLogKeyBinding,
+  tlogDefaultKeymap,
+  tlogHighContrastKeymap,
+} from "./vue/log/tlog-keymap.js";
+export {
+  resolveTLogLinksPanelTheme,
+  resolveTLogMinimapTheme,
+  resolveTLogScrollbarTheme,
+  resolveTLogSearchBarTheme,
+  resolveTLogSearchPagerTheme,
+  resolveTLogSearchResultsTheme,
+  resolveTLogViewTheme,
+  tlogDarkPreset,
+  tlogDarkTheme,
+  tlogDefaultPreset,
+  tlogDefaultTheme,
+  tlogHighContrastPreset,
+  tlogHighContrastTheme,
+} from "./vue/log/tlog-theme.js";
 export type { RowScrollMode } from "./vue/components/TVirtualList.js";
 export type {
   TLogLinkPanelItem,
@@ -89,3 +134,37 @@ export type {
   TLogSearchResultsPageState,
   UseTLogSearchResultsPageOptions,
 } from "./vue/log/use-tlog-search-results-page.js";
+export type {
+  TLogIndexedLink,
+  TLogDiagnosticMarker,
+  TLogIndexStatus,
+  TLogRetainedIndexOptions,
+} from "./vue/log/use-tlog-retained-index.js";
+export type {
+  StorageLike,
+  TLogViewSessionBindings,
+  TLogViewSessionState,
+} from "./vue/log/tlog-session.js";
+export type {
+  TLogPluginLinkSource,
+  TLogPluginSeverity,
+  TLogPluginVisualSegment,
+  TLogParsedOsc8Link,
+  TLogViewExternalLink,
+  TLogViewExternalMarker,
+  TLogViewPlugin,
+  TLogViewPluginDensityContext,
+  TLogViewPluginDecorateSegmentsContext,
+  TLogViewPluginIndexedLine,
+  TLogViewPluginLineLink,
+  TLogViewPluginLineMarker,
+  TLogViewPluginLineMetadata,
+  TLogViewPluginMarkerContext,
+  TLogViewPluginParseLineContext,
+} from "./vue/log/tlog-plugins.js";
+export type { TLogKeymap } from "./vue/log/tlog-keymap.js";
+export type { TLogTheme, TLogUiPreset } from "./vue/log/tlog-theme.js";
+export type {
+  TLogVirtualSearchResultsState,
+  UseTLogVirtualSearchResultsOptions,
+} from "./vue/log/use-tlog-virtual-search-results.js";

--- a/src/vue/components/TLogVirtualLinksPanel.ts
+++ b/src/vue/components/TLogVirtualLinksPanel.ts
@@ -1,0 +1,108 @@
+import type { PropType } from "vue";
+import type { Style } from "../../core/types.js";
+import type { RowScrollMode } from "./TVirtualList.js";
+import type {
+  TLogLinkPanelItem,
+  TLogLinksPanelActivatePayload,
+  TLogLinksPanelActiveChangePayload,
+  TLogLinksPanelSelectPayload,
+} from "./TLogLinksPanel.js";
+import { computed, defineComponent, h } from "vue";
+import { TVirtualList } from "./TVirtualList.js";
+
+function formatItem(
+  item: TLogLinkPanelItem | null,
+  width: number,
+  showLineNumbers: boolean,
+): string {
+  if (!item) return "";
+  const currentPrefix = item.current ? "*" : " ";
+  const linePrefix = showLineNumbers ? `${String(item.absoluteLineIndex).padStart(5, " ")} ` : "";
+  const formatted = `${currentPrefix}${linePrefix}${item.text} -> ${item.href}`;
+  return formatted.slice(0, Math.max(0, width));
+}
+
+export const TLogVirtualLinksPanel = defineComponent({
+  name: "TLogVirtualLinksPanel",
+  props: {
+    x: { type: Number, required: true },
+    y: { type: Number, required: true },
+    w: { type: Number, required: true },
+    h: { type: Number, required: true },
+    zIndex: { type: Number, default: 0 },
+    links: {
+      type: Array as PropType<readonly TLogLinkPanelItem[]>,
+      default: () => [],
+    },
+    modelValue: { type: Number, default: -1 },
+    style: { type: Object as PropType<Style>, default: undefined },
+    activeStyle: { type: Object as PropType<Style>, default: undefined },
+    showLineNumbers: { type: Boolean, default: true },
+    rowScrollMode: {
+      type: String as PropType<RowScrollMode>,
+      default: "off",
+    },
+  },
+  emits: [
+    "update:modelValue",
+    "activeChange",
+    "select",
+    "activate",
+    "focus",
+    "blur",
+    "keydown",
+    "scroll",
+  ],
+  setup(props, { emit }) {
+    const model = computed({
+      get: () => props.modelValue,
+      set: (value: number) => {
+        emit("update:modelValue", value);
+        emit("activeChange", {
+          activeIndex: value,
+          item: value >= 0 ? (props.links[value] ?? null) : null,
+        } satisfies TLogLinksPanelActiveChangePayload);
+      },
+    });
+
+    return () =>
+      h(TVirtualList, {
+        x: props.x,
+        y: props.y,
+        w: props.w,
+        h: props.h,
+        zIndex: props.zIndex,
+        itemCount: props.links.length,
+        itemVersion:
+          props.links.length + props.links.reduce((sum, item) => sum + (item.current ? 1 : 0), 0),
+        getItem: (index: number) => props.links[index] ?? null,
+        renderItem: (item: unknown) =>
+          formatItem((item as TLogLinkPanelItem | null) ?? null, props.w, props.showLineNumbers),
+        modelValue: model.value,
+        style: props.style,
+        activeStyle: props.activeStyle,
+        rowScrollMode: props.rowScrollMode,
+        "onUpdate:modelValue": (value: number) => {
+          model.value = value;
+        },
+        onItemClick: ({ value }: { index: number; value: TLogLinkPanelItem | null }) => {
+          if (!value) return;
+          emit("select", {
+            visibleIndex: value.visibleIndex,
+            item: value,
+          } satisfies TLogLinksPanelSelectPayload);
+        },
+        onChange: ({ value }: { index: number; value: TLogLinkPanelItem | null }) => {
+          if (!value) return;
+          emit("activate", {
+            visibleIndex: value.visibleIndex,
+            item: value,
+          } satisfies TLogLinksPanelActivatePayload);
+        },
+        onFocus: () => emit("focus"),
+        onBlur: () => emit("blur"),
+        onKeydown: (event: unknown) => emit("keydown", event),
+        onScroll: (top: number) => emit("scroll", top),
+      });
+  },
+});

--- a/src/vue/components/TLogVirtualSearchResults.ts
+++ b/src/vue/components/TLogVirtualSearchResults.ts
@@ -1,0 +1,116 @@
+import type { PropType } from "vue";
+import type { Style } from "../../core/types.js";
+import type { RowScrollMode } from "./TVirtualList.js";
+import type {
+  TLogSearchResultItem,
+  TLogSearchResultsActiveChangePayload,
+  TLogSearchResultsSelectPayload,
+} from "./TLogSearchResults.js";
+import { computed, defineComponent, h } from "vue";
+import { textCellWidth } from "../utils/text.js";
+import { TVirtualList } from "./TVirtualList.js";
+
+function sliceByCells(text: string, start: number, end: number): string {
+  let cells = 0;
+  let out = "";
+  for (const ch of text) {
+    const width = Math.max(1, textCellWidth(ch));
+    const next = cells + width;
+    if (next > start && cells < end) out += ch;
+    cells = next;
+    if (cells >= end) break;
+  }
+  return out;
+}
+
+function formatItem(
+  item: TLogSearchResultItem | null,
+  width: number,
+  showLineNumbers: boolean,
+): string {
+  if (!item) return "";
+  const currentPrefix = item.current ? "*" : " ";
+  const linePrefix = showLineNumbers ? `${String(item.absoluteLineIndex).padStart(5, " ")} ` : "";
+  const before = sliceByCells(item.text, 0, item.matchStartCell);
+  const match = sliceByCells(item.text, item.matchStartCell, item.matchEndCell);
+  const after = sliceByCells(item.text, item.matchEndCell, Number.MAX_SAFE_INTEGER);
+  const formatted = `${currentPrefix}${linePrefix}${before}[${match}]${after}`;
+  return formatted.slice(0, Math.max(0, width));
+}
+
+export const TLogVirtualSearchResults = defineComponent({
+  name: "TLogVirtualSearchResults",
+  props: {
+    x: { type: Number, required: true },
+    y: { type: Number, required: true },
+    w: { type: Number, required: true },
+    h: { type: Number, required: true },
+    zIndex: { type: Number, default: 0 },
+    itemCount: { type: Number, required: true },
+    itemVersion: { type: Number, required: true },
+    getItem: {
+      type: Function as PropType<(index: number) => TLogSearchResultItem | null>,
+      required: true,
+    },
+    modelValue: { type: Number, default: -1 },
+    style: { type: Object as PropType<Style>, default: undefined },
+    activeStyle: { type: Object as PropType<Style>, default: undefined },
+    showLineNumbers: { type: Boolean, default: true },
+    rowScrollMode: {
+      type: String as PropType<RowScrollMode>,
+      default: "off",
+    },
+  },
+  emits: ["update:modelValue", "activeChange", "select", "focus", "blur", "keydown", "scroll"],
+  setup(props, { emit }) {
+    const model = computed({
+      get: () => props.modelValue,
+      set: (value: number) => {
+        emit("update:modelValue", value);
+        emit("activeChange", {
+          activeIndex: value,
+          result: value >= 0 ? props.getItem(value) : null,
+        } satisfies TLogSearchResultsActiveChangePayload);
+      },
+    });
+
+    return () =>
+      h(TVirtualList, {
+        x: props.x,
+        y: props.y,
+        w: props.w,
+        h: props.h,
+        zIndex: props.zIndex,
+        itemCount: props.itemCount,
+        itemVersion: props.itemVersion,
+        getItem: props.getItem,
+        renderItem: (item: unknown) =>
+          formatItem((item as TLogSearchResultItem | null) ?? null, props.w, props.showLineNumbers),
+        modelValue: model.value,
+        style: props.style,
+        activeStyle: props.activeStyle,
+        rowScrollMode: props.rowScrollMode,
+        "onUpdate:modelValue": (value: number) => {
+          model.value = value;
+        },
+        onItemClick: ({ value }: { index: number; value: TLogSearchResultItem | null }) => {
+          if (!value) return;
+          emit("select", {
+            matchIndex: value.matchIndex,
+            result: value,
+          } satisfies TLogSearchResultsSelectPayload);
+        },
+        onChange: ({ value }: { index: number; value: TLogSearchResultItem | null }) => {
+          if (!value) return;
+          emit("select", {
+            matchIndex: value.matchIndex,
+            result: value,
+          } satisfies TLogSearchResultsSelectPayload);
+        },
+        onFocus: () => emit("focus"),
+        onBlur: () => emit("blur"),
+        onKeydown: (event: unknown) => emit("keydown", event),
+        onScroll: (top: number) => emit("scroll", top),
+      });
+  },
+});

--- a/src/vue/components/TVirtualList.ts
+++ b/src/vue/components/TVirtualList.ts
@@ -97,7 +97,7 @@ export const TVirtualList = defineComponent({
       default: "off",
     },
   },
-  emits: ["update:modelValue", "change", "scroll", "focus", "blur", "keydown"],
+  emits: ["update:modelValue", "change", "itemClick", "scroll", "focus", "blur", "keydown"],
   setup(props, { emit }) {
     const { terminal, scheduler, render, rendererCapabilities, defaultStyle, events } =
       useTerminal();
@@ -401,6 +401,7 @@ export const TVirtualList = defineComponent({
           if (idx < 0 || idx >= itemCount.value) return;
           active.value = idx;
           emit("update:modelValue", idx);
+          emit("itemClick", { index: idx, value: props.getItem(idx) });
           markViewportDirty();
           invalidateSelf("high");
         },

--- a/src/vue/log/tlog-keymap.ts
+++ b/src/vue/log/tlog-keymap.ts
@@ -1,0 +1,99 @@
+export type TLogKeymap = Readonly<{
+  searchNext?: readonly string[];
+  searchPrevious?: readonly string[];
+  clearSearch?: readonly string[];
+  nextLink?: readonly string[];
+  previousLink?: readonly string[];
+  activateLink?: readonly string[];
+}>;
+
+type KeyboardLike = Readonly<{
+  key: string;
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+  altKey?: boolean;
+  shiftKey?: boolean;
+  preventDefault?: () => void;
+}>;
+
+export const tlogDefaultKeymap: TLogKeymap = Object.freeze({
+  searchNext: Object.freeze(["f3", "ctrl+g"]),
+  searchPrevious: Object.freeze(["shift+f3", "ctrl+shift+g"]),
+  clearSearch: Object.freeze(["escape"]),
+  nextLink: Object.freeze(["tab"]),
+  previousLink: Object.freeze(["shift+tab"]),
+  activateLink: Object.freeze(["enter"]),
+});
+
+export const tlogHighContrastKeymap: TLogKeymap = Object.freeze({
+  ...tlogDefaultKeymap,
+  clearSearch: Object.freeze(["ctrl+l", "escape"]),
+});
+
+function normalizeKeyToken(token: string): string {
+  return token.trim().toLowerCase();
+}
+
+function eventSignature(event: KeyboardLike): string {
+  const parts: string[] = [];
+  if (event.ctrlKey) parts.push("ctrl");
+  if (event.metaKey) parts.push("meta");
+  if (event.altKey) parts.push("alt");
+  if (event.shiftKey) parts.push("shift");
+  parts.push(normalizeKeyToken(event.key));
+  return parts.join("+");
+}
+
+export function matchesTLogKeyBinding(
+  event: KeyboardLike,
+  bindings: readonly string[] | undefined,
+): boolean {
+  if (!bindings?.length) return false;
+  const signature = eventSignature(event);
+  return bindings.some((binding) => normalizeKeyToken(binding) === signature);
+}
+
+export function handleTLogKeymapEvent(
+  event: KeyboardLike,
+  keymap: TLogKeymap,
+  actions: Readonly<{
+    searchNext?: () => void;
+    searchPrevious?: () => void;
+    clearSearch?: () => void;
+    nextLink?: () => boolean;
+    previousLink?: () => boolean;
+    activateLink?: () => boolean;
+  }>,
+): boolean {
+  if (matchesTLogKeyBinding(event, keymap.searchNext)) {
+    actions.searchNext?.();
+    event.preventDefault?.();
+    return true;
+  }
+  if (matchesTLogKeyBinding(event, keymap.searchPrevious)) {
+    actions.searchPrevious?.();
+    event.preventDefault?.();
+    return true;
+  }
+  if (matchesTLogKeyBinding(event, keymap.clearSearch)) {
+    actions.clearSearch?.();
+    event.preventDefault?.();
+    return true;
+  }
+  if (matchesTLogKeyBinding(event, keymap.nextLink)) {
+    const handled = actions.nextLink?.() === true;
+    if (handled) event.preventDefault?.();
+    return handled;
+  }
+  if (matchesTLogKeyBinding(event, keymap.previousLink)) {
+    const handled = actions.previousLink?.() === true;
+    if (handled) event.preventDefault?.();
+    return handled;
+  }
+  if (matchesTLogKeyBinding(event, keymap.activateLink)) {
+    const handled = actions.activateLink?.() === true;
+    if (handled) event.preventDefault?.();
+    return handled;
+  }
+  return false;
+}

--- a/src/vue/log/tlog-plugins.ts
+++ b/src/vue/log/tlog-plugins.ts
@@ -1,0 +1,487 @@
+import type { Style } from "../../core/types.js";
+import type { TLogMinimapDensityBucket } from "../components/TLogMinimap.js";
+import type { TLogViewVisibleLink } from "../components/TLogView.js";
+import type { TLogLinkAction } from "./use-tlog-link-controller.js";
+import { textCellWidth } from "../utils/text.js";
+
+export type TLogPluginSeverity = "error" | "warning" | "info";
+export type TLogPluginLinkSource = "osc8" | "url" | "plugin";
+
+export type TLogPluginVisualSegment = Readonly<{
+  text: string;
+  cells: number;
+  style?: Style;
+  href?: string;
+}>;
+
+export type TLogViewExternalLink = Readonly<{
+  id: string;
+  href: string;
+  text: string;
+  absoluteLineIndex: number;
+  lineIndex: number;
+  startCell: number;
+  endCell: number;
+  source: TLogPluginLinkSource;
+  pluginName?: string;
+  data?: unknown;
+}>;
+
+export type TLogViewExternalMarker = Readonly<{
+  id: string;
+  absoluteLineIndex: number;
+  lineIndex: number;
+  visualRow: number;
+  estimated?: boolean;
+  current?: boolean;
+  label?: string;
+  severity?: TLogPluginSeverity;
+  source: string;
+  data?: unknown;
+}>;
+
+export type TLogViewPluginLineMarker = Readonly<{
+  id?: string | number;
+  label?: string;
+  severity?: TLogPluginSeverity;
+  estimated?: boolean;
+  data?: unknown;
+}>;
+
+export type TLogViewPluginLineLink = Readonly<{
+  id?: string | number;
+  href: string;
+  text: string;
+  startCell: number;
+  endCell: number;
+  source?: TLogPluginLinkSource;
+  data?: unknown;
+}>;
+
+export type TLogViewPluginLineMetadata = Readonly<{
+  level?: TLogPluginSeverity;
+  markers?: readonly TLogViewPluginLineMarker[];
+  externalLinks?: readonly TLogViewPluginLineLink[];
+  data?: unknown;
+}>;
+
+export type TLogParsedOsc8Link = Readonly<{
+  href: string;
+  text: string;
+  startCell: number;
+  endCell: number;
+}>;
+
+export type TLogViewPluginParseLineContext = Readonly<{
+  lineIndex: number;
+  absoluteLineIndex: number;
+  lineKey: string | number;
+  text: string;
+  plainText: string;
+  osc8Links: readonly TLogParsedOsc8Link[];
+}>;
+
+export type TLogViewPluginDecorateSegmentsContext = Readonly<{
+  lineIndex: number;
+  absoluteLineIndex: number;
+  text: string;
+  plainText: string;
+  metadata: TLogViewPluginLineMetadata | null;
+  segments: readonly TLogPluginVisualSegment[];
+}>;
+
+export type TLogViewPluginIndexedLine = Readonly<{
+  lineIndex: number;
+  absoluteLineIndex: number;
+  lineKey: string | number;
+  text: string;
+  plainText: string;
+  osc8Links: readonly TLogParsedOsc8Link[];
+  externalLinks: readonly TLogViewExternalLink[];
+  results: readonly Readonly<{
+    pluginName: string;
+    metadata: TLogViewPluginLineMetadata;
+  }>[];
+}>;
+
+export type TLogViewPluginMarkerContext = Readonly<{
+  lines: readonly TLogViewPluginIndexedLine[];
+  currentMatchLineIndex: number | null;
+  totalVisualRows: number;
+  estimateVisualRow: (lineIndex: number) => number;
+  getMetadata: (
+    line: TLogViewPluginIndexedLine,
+    pluginName: string,
+  ) => TLogViewPluginLineMetadata | null;
+}>;
+
+export type TLogViewPluginDensityContext = TLogViewPluginMarkerContext;
+
+export type TLogViewPlugin = Readonly<{
+  name: string;
+  parseLine?: (ctx: TLogViewPluginParseLineContext) => TLogViewPluginLineMetadata | void;
+  decorateSegments?: (
+    ctx: TLogViewPluginDecorateSegmentsContext,
+  ) => readonly TLogPluginVisualSegment[] | void;
+  getMarkers?: (ctx: TLogViewPluginMarkerContext) => readonly TLogViewExternalMarker[] | void;
+  getDensityBuckets?: (
+    ctx: TLogViewPluginDensityContext,
+  ) => readonly TLogMinimapDensityBucket[] | void;
+  onLinkAction?: (action: TLogLinkAction) => void;
+}>;
+
+export type TLogLevelPluginOptions = Readonly<{
+  errorPattern?: RegExp;
+  warningPattern?: RegExp;
+  infoPattern?: RegExp;
+  includeInfo?: boolean;
+  bucketCount?: number;
+}>;
+
+export type TLogUrlPluginOptions = Readonly<{
+  pattern?: RegExp;
+}>;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function stringIndexToCell(text: string, index: number): number {
+  return textCellWidth(text.slice(0, Math.max(0, index)));
+}
+
+export function stripTLogAnsiText(text: string): string {
+  return parseTLogAnnotatedText(text).plainText;
+}
+
+export function parseTLogAnnotatedText(text: string): Readonly<{
+  plainText: string;
+  osc8Links: readonly TLogParsedOsc8Link[];
+}> {
+  const out: string[] = [];
+  const links: TLogParsedOsc8Link[] = [];
+  let currentHref: string | undefined;
+  let activeLink: { href: string; startIndex: number; endIndex: number } | null = null;
+  let plainLength = 0;
+
+  const flushLink = (): void => {
+    if (!activeLink) return;
+    const plainText = out.join("");
+    const startCell = stringIndexToCell(plainText, activeLink.startIndex);
+    const endCell = stringIndexToCell(plainText, activeLink.endIndex);
+    if (endCell > startCell) {
+      links.push({
+        href: activeLink.href,
+        text: plainText.slice(activeLink.startIndex, activeLink.endIndex),
+        startCell,
+        endCell,
+      });
+    }
+    activeLink = null;
+  };
+
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    if (code !== 0x1b) {
+      if (code <= 0x1f || code === 0x7f) continue;
+      const ch = text[i]!;
+      out.push(ch);
+      plainLength += ch.length;
+      if (currentHref) {
+        if (activeLink?.href === currentHref) activeLink.endIndex += ch.length;
+        else
+          activeLink = {
+            href: currentHref,
+            startIndex: plainLength - ch.length,
+            endIndex: plainLength,
+          };
+      } else if (activeLink) {
+        flushLink();
+      }
+      continue;
+    }
+
+    const next = text[i + 1];
+    if (next === "[") {
+      let j = i + 2;
+      while (j < text.length) {
+        const c = text.charCodeAt(j);
+        if ((c >= 48 && c <= 57) || c === 59) {
+          j++;
+          continue;
+        }
+        break;
+      }
+      if (j < text.length && text[j] === "m") i = j;
+      continue;
+    }
+
+    if (next === "]") {
+      let j = i + 2;
+      while (j < text.length) {
+        const c = text.charCodeAt(j);
+        if (c === 0x07) break;
+        if (c === 0x1b && text[j + 1] === "\\") {
+          j++;
+          break;
+        }
+        j++;
+      }
+      if (j >= text.length) break;
+      const body = text.charCodeAt(j) === 0x07 ? text.slice(i + 2, j) : text.slice(i + 2, j - 1);
+      const parts = body.split(";");
+      if (parts[0] === "8" && parts.length >= 3) {
+        flushLink();
+        currentHref = parts.slice(2).join(";") || undefined;
+      }
+      i = j;
+      continue;
+    }
+  }
+
+  flushLink();
+  return {
+    plainText: out.join(""),
+    osc8Links: links,
+  };
+}
+
+export function detectTLogUrls(
+  text: string,
+  options: TLogUrlPluginOptions = {},
+): readonly TLogViewPluginLineLink[] {
+  const pattern = options.pattern ?? /\b(?:https?:\/\/|file:\/\/)[^\s<>"'`]+/giu;
+  const flags = pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`;
+  const regex = new RegExp(pattern.source, flags);
+  const links: TLogViewPluginLineLink[] = [];
+
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(text)) != null) {
+    const href = match[0] ?? "";
+    if (!href) continue;
+    const startIndex = match.index;
+    const endIndex = startIndex + href.length;
+    const startCell = stringIndexToCell(text, startIndex);
+    const endCell = stringIndexToCell(text, endIndex);
+    if (endCell <= startCell) continue;
+    links.push({
+      href,
+      text: href,
+      startCell,
+      endCell,
+      source: "url",
+    });
+    if (!href.length) regex.lastIndex += 1;
+  }
+
+  return links;
+}
+
+export function detectTLogLevel(
+  text: string,
+  options: TLogLevelPluginOptions = {},
+): TLogPluginSeverity | null {
+  const errorPattern = options.errorPattern ?? /\b(?:ERROR|FATAL|ERR)\b/u;
+  const warningPattern = options.warningPattern ?? /\b(?:WARN|WARNING)\b/u;
+  const infoPattern = options.infoPattern ?? /\bINFO\b/u;
+  if (errorPattern.test(text)) return "error";
+  if (warningPattern.test(text)) return "warning";
+  if (options.includeInfo !== false && infoPattern.test(text)) return "info";
+  return null;
+}
+
+export function createTLogDensityBucketsFromMarkers(
+  markers: readonly TLogViewExternalMarker[],
+  totalVisualRows: number,
+  bucketCount = 12,
+): readonly TLogMinimapDensityBucket[] {
+  if (!markers.length || totalVisualRows <= 0 || bucketCount <= 0) return [];
+  const normalizedBucketCount = Math.min(Math.max(1, Math.floor(bucketCount)), totalVisualRows);
+  const size = Math.max(1, Math.ceil(totalVisualRows / normalizedBucketCount));
+  const counts = Array.from({ length: normalizedBucketCount }, () => 0);
+  for (const marker of markers) {
+    const bucket = Math.max(
+      0,
+      Math.min(normalizedBucketCount - 1, Math.floor(marker.visualRow / size)),
+    );
+    counts[bucket] = (counts[bucket] ?? 0) + 1;
+  }
+  const maxCount = Math.max(...counts, 1);
+  return counts
+    .map((count, index) => {
+      if (count <= 0) return null;
+      const startVisualRow = index * size;
+      return {
+        startVisualRow,
+        endVisualRow: Math.min(totalVisualRows - 1, startVisualRow + size - 1),
+        value: count / maxCount,
+      } satisfies TLogMinimapDensityBucket;
+    })
+    .filter((bucket): bucket is TLogMinimapDensityBucket => bucket != null);
+}
+
+export function getTLogPluginMetadata(
+  line: TLogViewPluginIndexedLine,
+  pluginName: string,
+): TLogViewPluginLineMetadata | null {
+  return line.results.find((result) => result.pluginName === pluginName)?.metadata ?? null;
+}
+
+export function dispatchTLogPluginLinkAction(
+  plugins: readonly TLogViewPlugin[] | undefined,
+  action: TLogLinkAction,
+): void {
+  for (const plugin of plugins ?? []) plugin.onLinkAction?.(action);
+}
+
+export function createTLogLevelPlugin(options: TLogLevelPluginOptions = {}): TLogViewPlugin {
+  return {
+    name: "tlog-levels",
+    parseLine(ctx) {
+      const level = detectTLogLevel(ctx.plainText, options);
+      return level ? { level } : undefined;
+    },
+    getMarkers(ctx) {
+      return ctx.lines.flatMap((line) => {
+        const metadata = getTLogPluginMetadata(line, "tlog-levels");
+        const level = metadata?.level;
+        if (!level || (level === "info" && options.includeInfo === false)) return [];
+        return [
+          {
+            id: `level:${line.absoluteLineIndex}:${level}`,
+            absoluteLineIndex: line.absoluteLineIndex,
+            lineIndex: line.lineIndex,
+            visualRow: ctx.estimateVisualRow(line.lineIndex),
+            estimated: true,
+            severity: level,
+            label: level.toUpperCase(),
+            source: "tlog-levels",
+          } satisfies TLogViewExternalMarker,
+        ];
+      });
+    },
+    getDensityBuckets(ctx) {
+      const markers = ctx.lines.flatMap((line) => {
+        const metadata = getTLogPluginMetadata(line, "tlog-levels");
+        const level = metadata?.level;
+        if (!level || (level === "info" && options.includeInfo === false)) return [];
+        return [
+          {
+            id: `density:${line.absoluteLineIndex}:${level}`,
+            absoluteLineIndex: line.absoluteLineIndex,
+            lineIndex: line.lineIndex,
+            visualRow: ctx.estimateVisualRow(line.lineIndex),
+            severity: level,
+            source: "tlog-levels",
+          } satisfies TLogViewExternalMarker,
+        ];
+      });
+      return createTLogDensityBucketsFromMarkers(
+        markers,
+        ctx.totalVisualRows,
+        options.bucketCount ?? 12,
+      );
+    },
+  };
+}
+
+export function createTLogOsc8LinkPlugin(): TLogViewPlugin {
+  return {
+    name: "tlog-osc8-links",
+    parseLine(ctx) {
+      if (!ctx.osc8Links.length) return;
+      return {
+        externalLinks: ctx.osc8Links.map((link, index) => ({
+          id: `osc8:${ctx.absoluteLineIndex}:${index}:${link.href}`,
+          href: link.href,
+          text: link.text,
+          startCell: link.startCell,
+          endCell: link.endCell,
+          source: "osc8",
+        })),
+      };
+    },
+  };
+}
+
+export function createTLogUrlPlugin(options: TLogUrlPluginOptions = {}): TLogViewPlugin {
+  return {
+    name: "tlog-url-detect",
+    parseLine(ctx) {
+      const links = detectTLogUrls(ctx.plainText, options);
+      return links.length ? { externalLinks: links } : undefined;
+    },
+  };
+}
+
+export function createTLogLinkActionPlugin(options: {
+  name: string;
+  onAction: (action: TLogLinkAction) => void;
+}): TLogViewPlugin {
+  return {
+    name: options.name,
+    onLinkAction: options.onAction,
+  };
+}
+
+export function toTLogExternalLinkFromVisibleLink(
+  link: Pick<
+    TLogViewVisibleLink,
+    "href" | "text" | "absoluteLineIndex" | "index" | "startCell" | "endCell"
+  >,
+  idPrefix = "visible",
+): TLogViewExternalLink {
+  return {
+    id: `${idPrefix}:${link.absoluteLineIndex}:${link.startCell}:${link.endCell}:${encodeURIComponent(link.href)}`,
+    href: link.href,
+    text: link.text,
+    absoluteLineIndex: link.absoluteLineIndex,
+    lineIndex: link.index,
+    startCell: link.startCell,
+    endCell: link.endCell,
+    source: "plugin",
+  };
+}
+
+export function createTLogLineMatcherPlugin(options: {
+  name: string;
+  pattern: RegExp | string;
+  severity?: TLogPluginSeverity;
+  label?: string;
+}): TLogViewPlugin {
+  const pattern =
+    typeof options.pattern === "string"
+      ? new RegExp(escapeRegExp(options.pattern), "u")
+      : options.pattern;
+  return {
+    name: options.name,
+    parseLine(ctx) {
+      if (!pattern.test(ctx.plainText)) return;
+      return {
+        markers: [
+          {
+            id: `${options.name}:${ctx.absoluteLineIndex}`,
+            label: options.label,
+            severity: options.severity,
+          },
+        ],
+      };
+    },
+    getMarkers(ctx) {
+      return ctx.lines.flatMap((line) => {
+        const metadata = getTLogPluginMetadata(line, options.name);
+        return (metadata?.markers ?? []).map((marker, index) => ({
+          id: String(marker.id ?? `${options.name}:${line.absoluteLineIndex}:${index}`),
+          absoluteLineIndex: line.absoluteLineIndex,
+          lineIndex: line.lineIndex,
+          visualRow: ctx.estimateVisualRow(line.lineIndex),
+          estimated: marker.estimated ?? true,
+          label: marker.label,
+          severity: marker.severity,
+          source: options.name,
+          data: marker.data,
+        }));
+      });
+    },
+  };
+}

--- a/src/vue/log/tlog-session.ts
+++ b/src/vue/log/tlog-session.ts
@@ -1,0 +1,217 @@
+import type { Ref } from "vue";
+import type { TLogViewHandle } from "../components/TLogView.js";
+import type { TLogSavedSearch } from "./use-tlog-search-controller.js";
+import { ref } from "vue";
+
+export type StorageLike = Readonly<{
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+}>;
+
+export type TLogViewSessionState = Readonly<{
+  scrollTop: number;
+  firstLineIndex: number;
+  visualIndexMode: "estimated" | "exact";
+  search?: Readonly<{
+    query: string;
+    mode: "text" | "regex";
+    caseSensitive: boolean;
+    wholeWord: boolean;
+    regexFlags?: string;
+    currentMatchIndex: number;
+    history?: readonly string[];
+    savedSearches?: readonly TLogSavedSearch[];
+  }>;
+  ui?: Readonly<{
+    resultsPage?: number;
+    linksPanelActiveIndex?: number;
+    wrap?: boolean;
+    ansi?: boolean;
+    links?: boolean;
+    keyboardLinks?: boolean;
+  }>;
+}>;
+
+export type TLogViewSessionBindings = Readonly<{
+  logView: Ref<TLogViewHandle | null>;
+  visualIndexMode?: Ref<"estimated" | "exact">;
+  wrap?: Ref<boolean>;
+  ansi?: Ref<boolean>;
+  links?: Ref<boolean>;
+  keyboardLinks?: Ref<boolean>;
+  search?: Readonly<{
+    query: Ref<string>;
+    mode: Ref<"text" | "regex">;
+    caseSensitive: Ref<boolean>;
+    wholeWord: Ref<boolean>;
+    regexFlags: Ref<string>;
+    searchHistory?: Ref<readonly string[]>;
+    savedSearches?: Ref<readonly TLogSavedSearch[]>;
+    updateQuery: (value: string) => void;
+    updateMode: (value: "text" | "regex") => void;
+    updateCaseSensitive: (value: boolean) => void;
+    updateWholeWord: (value: boolean) => void;
+    updateRegexFlags: (value: string) => void;
+    setSearchHistory?: (value: readonly string[]) => void;
+    setSavedSearches?: (value: readonly TLogSavedSearch[]) => void;
+    clearSearch: () => void;
+    selectMatch: (matchIndex: number) => boolean;
+    resultsPage?: Readonly<{
+      state: Ref<Readonly<{ page: number }>>;
+      setPage: (page: number) => void;
+    }>;
+  }>;
+  linkController?: Readonly<{
+    activeIndex: Ref<number>;
+    focusVisibleLink: (visibleIndex: number) => boolean;
+    clearFocus: () => void;
+  }>;
+}>;
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+export function serializeTLogViewSessionState(state: TLogViewSessionState): string {
+  return JSON.stringify(state);
+}
+
+export function deserializeTLogViewSessionState(
+  value: string | null | undefined,
+): TLogViewSessionState | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as TLogViewSessionState;
+    if (typeof parsed !== "object" || parsed == null) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function createTLogViewSessionStore(
+  options: {
+    storageKey?: string;
+    storage?: StorageLike | null;
+  } = {},
+): {
+  state: Ref<TLogViewSessionState | null>;
+  load: () => TLogViewSessionState | null;
+  save: (state: TLogViewSessionState) => void;
+  clear: () => void;
+} {
+  const storageKey = options.storageKey ?? "@simon_he/vue-tui:tlog-session";
+  const storage =
+    options.storage ??
+    ((globalThis as { localStorage?: StorageLike }).localStorage as StorageLike | undefined) ??
+    null;
+  const state = ref<TLogViewSessionState | null>(null);
+
+  function load(): TLogViewSessionState | null {
+    const next = deserializeTLogViewSessionState(storage?.getItem(storageKey));
+    state.value = next;
+    return next;
+  }
+
+  function save(nextState: TLogViewSessionState): void {
+    state.value = nextState;
+    storage?.setItem(storageKey, serializeTLogViewSessionState(nextState));
+  }
+
+  function clear(): void {
+    state.value = null;
+    storage?.removeItem(storageKey);
+  }
+
+  return {
+    state,
+    load,
+    save,
+    clear,
+  };
+}
+
+export function captureTLogViewSessionState(
+  bindings: TLogViewSessionBindings,
+): TLogViewSessionState | null {
+  const metrics = bindings.logView.value?.getScrollMetrics();
+  if (!metrics) return null;
+
+  return {
+    scrollTop: metrics.scrollTop,
+    firstLineIndex: metrics.firstLineIndex,
+    visualIndexMode: bindings.visualIndexMode?.value ?? "estimated",
+    search: bindings.search
+      ? {
+          query: bindings.search.query.value,
+          mode: bindings.search.mode.value,
+          caseSensitive: bindings.search.caseSensitive.value,
+          wholeWord: bindings.search.wholeWord.value,
+          regexFlags: bindings.search.regexFlags.value || undefined,
+          currentMatchIndex: bindings.logView.value?.getSearchState().currentMatchIndex ?? -1,
+          history: bindings.search.searchHistory?.value ?? [],
+          savedSearches: bindings.search.savedSearches?.value ?? [],
+        }
+      : undefined,
+    ui: {
+      resultsPage: bindings.search?.resultsPage?.state.value.page,
+      linksPanelActiveIndex: bindings.linkController?.activeIndex.value,
+      wrap: bindings.wrap?.value,
+      ansi: bindings.ansi?.value,
+      links: bindings.links?.value,
+      keyboardLinks: bindings.keyboardLinks?.value,
+    },
+  };
+}
+
+export function restoreTLogViewSessionState(
+  bindings: TLogViewSessionBindings,
+  state: TLogViewSessionState | null,
+): boolean {
+  if (!state) return false;
+
+  if (bindings.visualIndexMode) bindings.visualIndexMode.value = state.visualIndexMode;
+  if (state.ui) {
+    if (bindings.wrap && state.ui.wrap != null) bindings.wrap.value = state.ui.wrap;
+    if (bindings.ansi && state.ui.ansi != null) bindings.ansi.value = state.ui.ansi;
+    if (bindings.links && state.ui.links != null) bindings.links.value = state.ui.links;
+    if (bindings.keyboardLinks && state.ui.keyboardLinks != null)
+      bindings.keyboardLinks.value = state.ui.keyboardLinks;
+  }
+
+  if (bindings.search && state.search) {
+    bindings.search.updateQuery(state.search.query);
+    bindings.search.updateMode(state.search.mode);
+    bindings.search.updateCaseSensitive(state.search.caseSensitive);
+    bindings.search.updateWholeWord(state.search.wholeWord);
+    bindings.search.updateRegexFlags(state.search.regexFlags ?? "");
+    bindings.search.setSearchHistory?.(state.search.history ?? []);
+    bindings.search.setSavedSearches?.(state.search.savedSearches ?? []);
+    if (state.ui?.resultsPage != null) bindings.search.resultsPage?.setPage(state.ui.resultsPage);
+    if (!state.search.query) bindings.search.clearSearch();
+  }
+
+  const handle = bindings.logView.value;
+  const metrics = handle?.getScrollMetrics();
+  if (handle && metrics) {
+    const firstLineDelta = metrics.firstLineIndex - state.firstLineIndex;
+    const restoredScrollTop = clamp(
+      state.scrollTop - Math.max(0, firstLineDelta),
+      0,
+      metrics.maxScrollTop,
+    );
+    handle.scrollToVisualRow(restoredScrollTop);
+    if ((state.search?.currentMatchIndex ?? -1) >= 0) {
+      bindings.search?.selectMatch(state.search!.currentMatchIndex);
+    }
+  }
+
+  if (state.ui?.linksPanelActiveIndex != null) {
+    const restored =
+      bindings.linkController?.focusVisibleLink(state.ui.linksPanelActiveIndex) === true;
+    if (!restored && state.ui.linksPanelActiveIndex < 0) bindings.linkController?.clearFocus();
+  }
+
+  return true;
+}

--- a/src/vue/log/tlog-theme.ts
+++ b/src/vue/log/tlog-theme.ts
@@ -1,0 +1,198 @@
+import type { Style } from "../../core/types.js";
+import type { TLogSearchBar } from "../components/TLogSearchBar.js";
+import type { TLogSearchPager } from "../components/TLogSearchPager.js";
+import type { TLogVirtualLinksPanel } from "../components/TLogVirtualLinksPanel.js";
+import type { TLogVirtualSearchResults } from "../components/TLogVirtualSearchResults.js";
+import type { TLogMinimap } from "../components/TLogMinimap.js";
+import type { TLogScrollbar } from "../components/TLogScrollbar.js";
+import type { TLogView } from "../components/TLogView.js";
+import type { TLogKeymap } from "./tlog-keymap.js";
+import { tlogDefaultKeymap, tlogHighContrastKeymap } from "./tlog-keymap.js";
+
+export type TLogTheme = Readonly<{
+  base?: Style;
+  error?: Style;
+  warning?: Style;
+  info?: Style;
+  search?: Readonly<{
+    match?: Style;
+    currentMatch?: Style;
+    input?: Style;
+    error?: Style;
+    active?: Style;
+    disabled?: Style;
+  }>;
+  links?: Readonly<{
+    link?: Style;
+    focused?: Style;
+    active?: Style;
+    disabled?: Style;
+  }>;
+  scrollbar?: Readonly<{
+    track?: Style;
+    thumb?: Style;
+    measuring?: Style;
+    marker?: Style;
+    currentMarker?: Style;
+  }>;
+  minimap?: Readonly<{
+    density?: Style;
+    viewport?: Style;
+    marker?: Style;
+    currentMarker?: Style;
+    estimated?: Style;
+  }>;
+}>;
+
+export type TLogUiPreset = Readonly<{
+  theme: TLogTheme;
+  keymap: TLogKeymap;
+}>;
+
+type SearchBarThemeProps = Partial<InstanceType<typeof TLogSearchBar>["$props"]>;
+type SearchResultsThemeProps = Partial<InstanceType<typeof TLogVirtualSearchResults>["$props"]>;
+type SearchPagerThemeProps = Partial<InstanceType<typeof TLogSearchPager>["$props"]>;
+type LinksPanelThemeProps = Partial<InstanceType<typeof TLogVirtualLinksPanel>["$props"]>;
+type ScrollbarThemeProps = Partial<InstanceType<typeof TLogScrollbar>["$props"]>;
+type MinimapThemeProps = Partial<InstanceType<typeof TLogMinimap>["$props"]>;
+type LogViewThemeProps = Partial<InstanceType<typeof TLogView>["$props"]>;
+
+export const tlogDefaultTheme: TLogTheme = Object.freeze({
+  base: Object.freeze({ fg: "whiteBright" }),
+  error: Object.freeze({ fg: "redBright", bold: true }),
+  warning: Object.freeze({ fg: "yellowBright", bold: true }),
+  info: Object.freeze({ fg: "cyanBright" }),
+  search: Object.freeze({
+    match: Object.freeze({ inverse: true }),
+    currentMatch: Object.freeze({ inverse: true, bold: true }),
+    input: Object.freeze({}),
+    error: Object.freeze({ fg: "redBright", bold: true }),
+    active: Object.freeze({ inverse: true }),
+    disabled: Object.freeze({ dim: true }),
+  }),
+  links: Object.freeze({
+    link: Object.freeze({ underline: true, fg: "cyanBright" }),
+    focused: Object.freeze({ inverse: true }),
+    active: Object.freeze({ inverse: true }),
+    disabled: Object.freeze({ dim: true }),
+  }),
+  scrollbar: Object.freeze({
+    track: Object.freeze({ dim: true }),
+    thumb: Object.freeze({ fg: "whiteBright" }),
+    measuring: Object.freeze({ fg: "yellowBright" }),
+    marker: Object.freeze({ fg: "yellowBright" }),
+    currentMarker: Object.freeze({ fg: "redBright", bold: true }),
+  }),
+  minimap: Object.freeze({
+    density: Object.freeze({ fg: "blueBright" }),
+    viewport: Object.freeze({ fg: "whiteBright" }),
+    marker: Object.freeze({ fg: "yellowBright" }),
+    currentMarker: Object.freeze({ fg: "redBright", bold: true }),
+    estimated: Object.freeze({ dim: true }),
+  }),
+});
+
+export const tlogDarkTheme: TLogTheme = Object.freeze({
+  ...tlogDefaultTheme,
+  base: Object.freeze({ fg: "#d0d7de" }),
+  links: Object.freeze({
+    ...tlogDefaultTheme.links,
+    link: Object.freeze({ underline: true, fg: "#79c0ff" }),
+  }),
+});
+
+export const tlogHighContrastTheme: TLogTheme = Object.freeze({
+  ...tlogDefaultTheme,
+  base: Object.freeze({ fg: "whiteBright", bg: "black" }),
+  search: Object.freeze({
+    ...tlogDefaultTheme.search,
+    match: Object.freeze({ fg: "black", bg: "yellowBright", bold: true }),
+    currentMatch: Object.freeze({ fg: "black", bg: "redBright", bold: true }),
+  }),
+  links: Object.freeze({
+    ...tlogDefaultTheme.links,
+    link: Object.freeze({ fg: "whiteBright", underline: true, bold: true }),
+    focused: Object.freeze({ fg: "black", bg: "cyanBright", bold: true }),
+  }),
+});
+
+export const tlogDefaultPreset: TLogUiPreset = Object.freeze({
+  theme: tlogDefaultTheme,
+  keymap: tlogDefaultKeymap,
+});
+
+export const tlogDarkPreset: TLogUiPreset = Object.freeze({
+  theme: tlogDarkTheme,
+  keymap: tlogDefaultKeymap,
+});
+
+export const tlogHighContrastPreset: TLogUiPreset = Object.freeze({
+  theme: tlogHighContrastTheme,
+  keymap: tlogHighContrastKeymap,
+});
+
+export function resolveTLogViewTheme(theme: TLogTheme): LogViewThemeProps {
+  return {
+    style: theme.base,
+    linkStyle: theme.links?.link,
+    linkFocusStyle: theme.links?.focused,
+    matchStyle: theme.search?.match,
+    currentMatchStyle: theme.search?.currentMatch,
+  };
+}
+
+export function resolveTLogSearchBarTheme(theme: TLogTheme): SearchBarThemeProps {
+  return {
+    style: theme.base,
+    inputStyle: theme.search?.input,
+    activeStyle: theme.search?.active,
+    errorStyle: theme.search?.error,
+    disabledStyle: theme.search?.disabled,
+    toggleStyle: theme.base,
+  };
+}
+
+export function resolveTLogSearchResultsTheme(theme: TLogTheme): SearchResultsThemeProps {
+  return {
+    style: theme.base,
+    activeStyle: theme.search?.active,
+  };
+}
+
+export function resolveTLogSearchPagerTheme(theme: TLogTheme): SearchPagerThemeProps {
+  return {
+    style: theme.base,
+    activeStyle: theme.search?.active,
+    disabledStyle: theme.search?.disabled,
+    errorStyle: theme.search?.error,
+  };
+}
+
+export function resolveTLogLinksPanelTheme(theme: TLogTheme): LinksPanelThemeProps {
+  return {
+    style: theme.base,
+    activeStyle: theme.links?.active,
+  };
+}
+
+export function resolveTLogScrollbarTheme(theme: TLogTheme): ScrollbarThemeProps {
+  return {
+    style: theme.base,
+    trackStyle: theme.scrollbar?.track,
+    thumbStyle: theme.scrollbar?.thumb,
+    measuringStyle: theme.scrollbar?.measuring,
+    markerStyle: theme.scrollbar?.marker,
+    currentMarkerStyle: theme.scrollbar?.currentMarker,
+  };
+}
+
+export function resolveTLogMinimapTheme(theme: TLogTheme): MinimapThemeProps {
+  return {
+    style: theme.base,
+    densityStyle: theme.minimap?.density,
+    viewportStyle: theme.minimap?.viewport,
+    markerStyle: theme.minimap?.marker,
+    currentMarkerStyle: theme.minimap?.currentMarker,
+    estimatedStyle: theme.minimap?.estimated,
+  };
+}

--- a/src/vue/log/use-tlog-link-controller.ts
+++ b/src/vue/log/use-tlog-link-controller.ts
@@ -6,7 +6,9 @@ import type {
   TLogViewVisibleLink,
 } from "../components/TLogView.js";
 import type { TLogLinkPanelItem } from "../components/TLogLinksPanel.js";
+import type { TLogViewPlugin } from "./tlog-plugins.js";
 import { ref, watch } from "vue";
+import { dispatchTLogPluginLinkAction } from "./tlog-plugins.js";
 
 export type TLogLinkActionSource = "click" | "keyboard" | "programmatic" | "panel";
 
@@ -22,6 +24,7 @@ export type TLogLinkAction = Readonly<{
 
 export type UseTLogLinkControllerOptions = Readonly<{
   onAction?: (action: TLogLinkAction) => void;
+  plugins?: readonly TLogViewPlugin[];
 }>;
 
 function toPanelItem(link: TLogViewVisibleLink): TLogLinkPanelItem {
@@ -93,6 +96,7 @@ export function useTLogLinkController(
 
   function emitAction(action: TLogLinkAction): void {
     options.onAction?.(action);
+    dispatchTLogPluginLinkAction(options.plugins, action);
   }
 
   function suppressProgrammaticActivation(link: TLogLinkPanelItem): void {

--- a/src/vue/log/use-tlog-retained-index.ts
+++ b/src/vue/log/use-tlog-retained-index.ts
@@ -1,0 +1,266 @@
+import type { Ref } from "vue";
+import type { TLogMinimapDensityBucket } from "../components/TLogMinimap.js";
+import type { TLogViewHandle } from "../components/TLogView.js";
+import type { TLogDataSource } from "./types.js";
+import type {
+  TLogViewExternalLink,
+  TLogViewExternalMarker,
+  TLogViewPlugin,
+  TLogViewPluginLineMetadata,
+} from "./tlog-plugins.js";
+import { computed, ref, watch } from "vue";
+import {
+  createTLogLevelPlugin,
+  createTLogOsc8LinkPlugin,
+  createTLogUrlPlugin,
+  getTLogPluginMetadata,
+  parseTLogAnnotatedText,
+} from "./tlog-plugins.js";
+
+export type TLogIndexStatus = "idle" | "indexing" | "done" | "error";
+
+export type TLogDiagnosticMarker = TLogViewExternalMarker;
+export type TLogIndexedLink = TLogViewExternalLink;
+
+export type TLogRetainedIndexOptions = Readonly<{
+  links?: boolean;
+  levels?: boolean;
+  urls?: boolean;
+  budgetMs?: number;
+  maxItems?: number;
+  bucketCount?: number;
+  plugins?: readonly TLogViewPlugin[];
+}>;
+
+const DEFAULT_BUDGET_MS = 4;
+const DEFAULT_MAX_ITEMS = 10_000;
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function normalizeBudgetMs(value: number | undefined): number {
+  const n = Math.floor(Number(value ?? DEFAULT_BUDGET_MS));
+  return Number.isFinite(n) ? Math.max(1, n) : DEFAULT_BUDGET_MS;
+}
+
+function normalizeMaxItems(value: number | undefined): number {
+  const n = Math.floor(Number(value ?? DEFAULT_MAX_ITEMS));
+  return Number.isFinite(n) ? Math.max(1, n) : DEFAULT_MAX_ITEMS;
+}
+
+export function useTLogRetainedIndex(
+  logView: Ref<TLogViewHandle | null>,
+  source: Ref<TLogDataSource>,
+  version: Ref<number>,
+  options: TLogRetainedIndexOptions = {},
+): {
+  status: Ref<TLogIndexStatus>;
+  links: Ref<readonly TLogIndexedLink[]>;
+  diagnostics: Ref<readonly TLogDiagnosticMarker[]>;
+  density: Ref<readonly TLogMinimapDensityBucket[]>;
+  refresh: () => void;
+  cancel: () => void;
+} {
+  const status = ref<TLogIndexStatus>("idle");
+  const links = ref<readonly TLogIndexedLink[]>([]);
+  const diagnostics = ref<readonly TLogDiagnosticMarker[]>([]);
+  const density = ref<readonly TLogMinimapDensityBucket[]>([]);
+
+  const plugins = computed<readonly TLogViewPlugin[]>(() => {
+    const builtins: TLogViewPlugin[] = [];
+    if (options.links) builtins.push(createTLogOsc8LinkPlugin());
+    if (options.urls) builtins.push(createTLogUrlPlugin());
+    if (options.levels) builtins.push(createTLogLevelPlugin({ bucketCount: options.bucketCount }));
+    return [...builtins, ...(options.plugins ?? [])];
+  });
+
+  let generation = 0;
+  let cursor = 0;
+  let rafId: number | null = null;
+  let indexedLines: Array<{
+    lineIndex: number;
+    absoluteLineIndex: number;
+    lineKey: string | number;
+    text: string;
+    plainText: string;
+    osc8Links: ReturnType<typeof parseTLogAnnotatedText>["osc8Links"];
+    externalLinks: TLogIndexedLink[];
+    results: Array<{
+      pluginName: string;
+      metadata: TLogViewPluginLineMetadata;
+    }>;
+  }> = [];
+
+  function cancel(): void {
+    generation++;
+    cursor = 0;
+    if (rafId != null) cancelAnimationFrame(rafId);
+    rafId = null;
+    if (status.value === "indexing") status.value = "idle";
+  }
+
+  function estimateVisualRow(lineIndex: number): number {
+    const metrics = logView.value?.getScrollMetrics();
+    if (!metrics) return Math.max(0, lineIndex);
+    const lineCount = Math.max(1, metrics.lineCount);
+    const totalVisualRows = Math.max(metrics.visualRowCount, metrics.viewportRows, lineCount, 1);
+    return clamp(
+      Math.round((lineIndex / Math.max(1, lineCount - 1)) * Math.max(0, totalVisualRows - 1)),
+      0,
+      Math.max(0, totalVisualRows - 1),
+    );
+  }
+
+  function currentMatchLineIndex(): number | null {
+    const handle = logView.value;
+    if (!handle) return null;
+    const current = handle.getSearchState().currentMatchIndex;
+    if (current < 0) return null;
+    return handle.getSearchMatch(current)?.index ?? null;
+  }
+
+  function finalize(generationAtStart: number): void {
+    if (generationAtStart !== generation) return;
+    const totalVisualRows = Math.max(
+      logView.value?.getScrollMetrics().visualRowCount ?? indexedLines.length,
+      logView.value?.getScrollMetrics().viewportRows ?? 0,
+      indexedLines.length,
+      1,
+    );
+    const markerCtx = {
+      lines: indexedLines,
+      currentMatchLineIndex: currentMatchLineIndex(),
+      totalVisualRows,
+      estimateVisualRow,
+      getMetadata: getTLogPluginMetadata,
+    } as const;
+
+    const nextDiagnostics: TLogDiagnosticMarker[] = [];
+    const nextDensity: TLogMinimapDensityBucket[] = [];
+    for (const plugin of plugins.value) {
+      const markers = plugin.getMarkers?.(markerCtx);
+      if (Array.isArray(markers) && markers.length) nextDiagnostics.push(...markers);
+      const buckets = plugin.getDensityBuckets?.(markerCtx);
+      if (Array.isArray(buckets) && buckets.length) nextDensity.push(...buckets);
+    }
+
+    links.value = indexedLines.flatMap((line) => line.externalLinks);
+    diagnostics.value = nextDiagnostics;
+    density.value = nextDensity;
+    status.value = "done";
+  }
+
+  function schedule(): void {
+    const generationAtStart = generation;
+    const sourceValue = source.value;
+    const budgetMs = normalizeBudgetMs(options.budgetMs);
+    const maxItems = normalizeMaxItems(options.maxItems);
+    const lineCount = Math.max(0, Math.floor(Number(sourceValue.lineCount())));
+    const firstLineIndex = Math.max(0, Math.floor(Number(sourceValue.firstLineIndex?.() ?? 0)));
+    const activePlugins = plugins.value;
+
+    if (!lineCount) {
+      links.value = [];
+      diagnostics.value = [];
+      density.value = [];
+      status.value = "done";
+      return;
+    }
+
+    const runFrame = () => {
+      if (generationAtStart !== generation) return;
+      const start = Date.now();
+      while (cursor < lineCount && Date.now() - start < budgetMs) {
+        const lineIndex = cursor++;
+        const text = sourceValue.getLine(lineIndex);
+        const lineKey = sourceValue.getLineKey?.(lineIndex) ?? `line:${version.value}:${lineIndex}`;
+        const parsed = parseTLogAnnotatedText(text);
+        const results: Array<{
+          pluginName: string;
+          metadata: TLogViewPluginLineMetadata;
+        }> = [];
+        const externalLinks: TLogIndexedLink[] = [];
+        const seenLinks = new Set<string>();
+
+        for (const plugin of activePlugins) {
+          const metadata = plugin.parseLine?.({
+            lineIndex,
+            absoluteLineIndex: firstLineIndex + lineIndex,
+            lineKey,
+            text,
+            plainText: parsed.plainText,
+            osc8Links: parsed.osc8Links,
+          });
+          if (!metadata) continue;
+          results.push({ pluginName: plugin.name, metadata });
+          for (const link of metadata.externalLinks ?? []) {
+            const id = String(
+              link.id ??
+                `${plugin.name}:${firstLineIndex + lineIndex}:${link.startCell}:${link.endCell}:${link.href}`,
+            );
+            if (seenLinks.has(id) || externalLinks.length >= maxItems) continue;
+            seenLinks.add(id);
+            externalLinks.push({
+              id,
+              href: link.href,
+              text: link.text,
+              absoluteLineIndex: firstLineIndex + lineIndex,
+              lineIndex,
+              startCell: link.startCell,
+              endCell: link.endCell,
+              source: link.source ?? "plugin",
+              pluginName: plugin.name,
+              data: link.data,
+            });
+          }
+        }
+
+        indexedLines.push({
+          lineIndex,
+          absoluteLineIndex: firstLineIndex + lineIndex,
+          lineKey,
+          text,
+          plainText: parsed.plainText,
+          osc8Links: parsed.osc8Links,
+          externalLinks,
+          results,
+        });
+      }
+
+      if (cursor >= lineCount) {
+        rafId = null;
+        finalize(generationAtStart);
+        return;
+      }
+
+      rafId = requestAnimationFrame(runFrame);
+    };
+
+    rafId = requestAnimationFrame(runFrame);
+  }
+
+  function refresh(): void {
+    cancel();
+    indexedLines = [];
+    links.value = [];
+    diagnostics.value = [];
+    density.value = [];
+    cursor = 0;
+    status.value = "indexing";
+    schedule();
+  }
+
+  watch([() => source.value, () => version.value, () => logView.value], refresh, {
+    immediate: true,
+  });
+
+  return {
+    status,
+    links,
+    diagnostics,
+    density,
+    refresh,
+    cancel,
+  };
+}

--- a/src/vue/log/use-tlog-search-controller.ts
+++ b/src/vue/log/use-tlog-search-controller.ts
@@ -88,6 +88,8 @@ export function useTLogSearchController(
   refresh: () => void;
   saveCurrentSearch: (label?: string) => TLogSavedSearch | null;
   applySavedSearch: (id: string) => boolean;
+  setSearchHistory: (value: readonly string[]) => void;
+  setSavedSearches: (value: readonly TLogSavedSearch[]) => void;
 } {
   const query = ref(options.initialQuery ?? "");
   const mode = ref<TLogSearchBarMode>(options.initialMode === "regex" ? "regex" : "text");
@@ -249,6 +251,25 @@ export function useTLogSearchController(
     return true;
   }
 
+  function setSearchHistory(value: readonly string[]): void {
+    searchHistory.value = value
+      .map((entry) => String(entry ?? "").trim())
+      .filter(Boolean)
+      .slice(0, historyLimit);
+  }
+
+  function setSavedSearches(value: readonly TLogSavedSearch[]): void {
+    savedSearches.value = value.map((entry) => ({
+      id: String(entry.id),
+      label: entry.label?.trim() || undefined,
+      query: String(entry.query ?? ""),
+      mode: entry.mode === "regex" ? "regex" : "text",
+      caseSensitive: entry.caseSensitive === true,
+      wholeWord: entry.wholeWord === true,
+      regexFlags: entry.regexFlags || undefined,
+    }));
+  }
+
   watch(
     () => logView.value,
     () => {
@@ -282,5 +303,7 @@ export function useTLogSearchController(
     refresh,
     saveCurrentSearch,
     applySavedSearch,
+    setSearchHistory,
+    setSavedSearches,
   };
 }

--- a/src/vue/log/use-tlog-virtual-search-results.ts
+++ b/src/vue/log/use-tlog-virtual-search-results.ts
@@ -1,0 +1,114 @@
+import type { Ref } from "vue";
+import type { TLogSearchResultItem } from "../components/TLogSearchResults.js";
+import type {
+  TLogViewHandle,
+  TLogViewSearchError,
+  TLogViewSearchState,
+} from "../components/TLogView.js";
+import { ref, watch } from "vue";
+
+export type UseTLogVirtualSearchResultsOptions = Readonly<{
+  includePreview?: boolean;
+  previewWidth?: number;
+  contextCells?: number;
+}>;
+
+export type TLogVirtualSearchResultsState = Readonly<{
+  itemCount: number;
+  itemVersion: number;
+  activeIndex: number;
+  currentMatchIndex: number;
+  status: TLogViewSearchState["status"];
+  error: TLogViewSearchError | null;
+}>;
+
+function normalizeInt(value: unknown, fallback = 0): number {
+  const n = Math.floor(Number(value));
+  return Number.isFinite(n) ? n : fallback;
+}
+
+export function useTLogVirtualSearchResults(
+  logView: Ref<TLogViewHandle | null>,
+  options: UseTLogVirtualSearchResultsOptions = {},
+): {
+  state: Ref<TLogVirtualSearchResultsState>;
+  refresh: () => void;
+  getItem: (index: number) => TLogSearchResultItem | null;
+  select: (matchIndex: number) => boolean;
+} {
+  const state = ref<TLogVirtualSearchResultsState>({
+    itemCount: 0,
+    itemVersion: 0,
+    activeIndex: -1,
+    currentMatchIndex: -1,
+    status: "idle",
+    error: null,
+  });
+  const cache = new Map<number, TLogSearchResultItem>();
+
+  function clearCache(): void {
+    cache.clear();
+  }
+
+  function refresh(): void {
+    const handle = logView.value;
+    const search = handle?.getSearchState();
+    const itemCount = Math.max(0, normalizeInt(search?.matchCount ?? 0));
+    const currentMatchIndex = normalizeInt(search?.currentMatchIndex ?? -1, -1);
+    const nextState: TLogVirtualSearchResultsState = {
+      itemCount,
+      itemVersion: state.value.itemVersion + 1,
+      activeIndex: currentMatchIndex >= 0 ? currentMatchIndex : -1,
+      currentMatchIndex,
+      status: search?.status ?? "idle",
+      error: search?.error ?? null,
+    };
+    clearCache();
+    state.value = nextState;
+  }
+
+  function getItem(index: number): TLogSearchResultItem | null {
+    const normalizedIndex = normalizeInt(index, -1);
+    if (normalizedIndex < 0 || normalizedIndex >= state.value.itemCount) return null;
+    const cached = cache.get(normalizedIndex);
+    if (cached) return cached;
+    const handle = logView.value;
+    if (!handle) return null;
+    const entry = handle.getSearchResults({
+      offset: normalizedIndex,
+      limit: 1,
+      includePreview: options.includePreview !== false,
+      previewWidth: options.previewWidth,
+      contextCells: options.contextCells,
+    })[0];
+    if (!entry) return null;
+    const item: TLogSearchResultItem = {
+      matchIndex: entry.matchIndex,
+      absoluteLineIndex: entry.match.absoluteLineIndex,
+      lineIndex: entry.match.index,
+      text: entry.preview?.text ?? entry.match.text,
+      matchStartCell: entry.preview?.matchStartCell ?? 0,
+      matchEndCell: entry.preview?.matchEndCell ?? Math.max(0, entry.match.text.length),
+      current: entry.matchIndex === state.value.currentMatchIndex,
+    };
+    cache.set(normalizedIndex, item);
+    return item;
+  }
+
+  function select(matchIndex: number): boolean {
+    const handle = logView.value;
+    if (!handle) return false;
+    const selected = handle.selectSearchMatch(normalizeInt(matchIndex, -1));
+    refresh();
+    return selected;
+  }
+
+  watch(() => logView.value, refresh, { immediate: true });
+
+  return {
+    state,
+    refresh,
+    getItem,
+    select,
+  };
+}

--- a/test/package-exports.test.ts
+++ b/test/package-exports.test.ts
@@ -35,12 +35,19 @@ describe("package exports", () => {
     expect(experimental.TLogMinimap).toBeTruthy();
     expect(experimental.TLogSearchBar).toBeTruthy();
     expect(experimental.TLogSearchResults).toBeTruthy();
+    expect(experimental.TLogVirtualSearchResults).toBeTruthy();
     expect(experimental.TLogSearchPager).toBeTruthy();
     expect(experimental.TLogLinksPanel).toBeTruthy();
+    expect(experimental.TLogVirtualLinksPanel).toBeTruthy();
     expect(experimental.useTLogSearchController).toBeTruthy();
     expect(experimental.useTLogSearchResultsPage).toBeTruthy();
+    expect(experimental.useTLogVirtualSearchResults).toBeTruthy();
     expect(experimental.useTLogLinkController).toBeTruthy();
+    expect(experimental.useTLogRetainedIndex).toBeTruthy();
     expect(experimental.createAppendOnlyLogStore).toBeTruthy();
+    expect(experimental.createTLogViewSessionStore).toBeTruthy();
+    expect(experimental.createTLogLevelPlugin).toBeTruthy();
+    expect(experimental.tlogDefaultPreset).toBeTruthy();
   });
 
   it("re-exports TLogView link navigation types from the experimental entrypoint", () => {
@@ -58,6 +65,12 @@ describe("package exports", () => {
     expect(experimentalSource).toContain("TLogSearchBarMode");
     expect(experimentalSource).toContain("TLogSavedSearch");
     expect(experimentalSource).toContain("useTLogSearchController");
+    expect(experimentalSource).toContain("TLogVirtualSearchResults");
+    expect(experimentalSource).toContain("TLogVirtualLinksPanel");
+    expect(experimentalSource).toContain("useTLogRetainedIndex");
+    expect(experimentalSource).toContain("createTLogViewSessionStore");
+    expect(experimentalSource).toContain("createTLogLevelPlugin");
+    expect(experimentalSource).toContain("tlogDefaultPreset");
   });
 
   it("keeps the runnable tlog lab symbol set importable from the experimental entrypoint", async () => {
@@ -65,25 +78,39 @@ describe("package exports", () => {
       TLogView,
       TLogSearchBar,
       TLogSearchResults,
+      TLogVirtualSearchResults,
       TLogSearchPager,
       TLogScrollbar,
       TLogMinimap,
       TLogLinksPanel,
+      TLogVirtualLinksPanel,
       createAppendOnlyLogStore,
+      createTLogViewSessionStore,
+      createTLogLevelPlugin,
+      tlogDefaultPreset,
       useTLogSearchController,
       useTLogLinkController,
+      useTLogRetainedIndex,
+      useTLogVirtualSearchResults,
     } = await import("../src/experimental.js");
 
     expect(TLogView).toBeTruthy();
     expect(TLogSearchBar).toBeTruthy();
     expect(TLogSearchResults).toBeTruthy();
+    expect(TLogVirtualSearchResults).toBeTruthy();
     expect(TLogSearchPager).toBeTruthy();
     expect(TLogScrollbar).toBeTruthy();
     expect(TLogMinimap).toBeTruthy();
     expect(TLogLinksPanel).toBeTruthy();
+    expect(TLogVirtualLinksPanel).toBeTruthy();
     expect(createAppendOnlyLogStore).toBeTruthy();
+    expect(createTLogViewSessionStore).toBeTruthy();
+    expect(createTLogLevelPlugin).toBeTruthy();
+    expect(tlogDefaultPreset).toBeTruthy();
     expect(useTLogSearchController).toBeTruthy();
     expect(useTLogLinkController).toBeTruthy();
+    expect(useTLogRetainedIndex).toBeTruthy();
+    expect(useTLogVirtualSearchResults).toBeTruthy();
   });
 
   it.skipIf(!requireDistExports)("keeps built ESM/CJS experimental exports usable", async () => {
@@ -111,23 +138,37 @@ describe("package exports", () => {
     expect(experimental.TLogMinimap).toBeTruthy();
     expect(experimental.TLogSearchBar).toBeTruthy();
     expect(experimental.TLogSearchResults).toBeTruthy();
+    expect(experimental.TLogVirtualSearchResults).toBeTruthy();
     expect(experimental.TLogSearchPager).toBeTruthy();
     expect(experimental.TLogLinksPanel).toBeTruthy();
+    expect(experimental.TLogVirtualLinksPanel).toBeTruthy();
     expect(experimental.useTLogSearchController).toBeTruthy();
     expect(experimental.useTLogSearchResultsPage).toBeTruthy();
+    expect(experimental.useTLogVirtualSearchResults).toBeTruthy();
     expect(experimental.useTLogLinkController).toBeTruthy();
+    expect(experimental.useTLogRetainedIndex).toBeTruthy();
     expect(experimental.createAppendOnlyLogStore).toBeTruthy();
+    expect(experimental.createTLogViewSessionStore).toBeTruthy();
+    expect(experimental.createTLogLevelPlugin).toBeTruthy();
+    expect(experimental.tlogDefaultPreset).toBeTruthy();
     expect(experimentalCjs.TVirtualList).toBeTruthy();
     expect(experimentalCjs.TLogView).toBeTruthy();
     expect(experimentalCjs.TLogScrollbar).toBeTruthy();
     expect(experimentalCjs.TLogMinimap).toBeTruthy();
     expect(experimentalCjs.TLogSearchBar).toBeTruthy();
     expect(experimentalCjs.TLogSearchResults).toBeTruthy();
+    expect(experimentalCjs.TLogVirtualSearchResults).toBeTruthy();
     expect(experimentalCjs.TLogSearchPager).toBeTruthy();
     expect(experimentalCjs.TLogLinksPanel).toBeTruthy();
+    expect(experimentalCjs.TLogVirtualLinksPanel).toBeTruthy();
     expect(experimentalCjs.useTLogSearchController).toBeTruthy();
     expect(experimentalCjs.useTLogSearchResultsPage).toBeTruthy();
+    expect(experimentalCjs.useTLogVirtualSearchResults).toBeTruthy();
     expect(experimentalCjs.useTLogLinkController).toBeTruthy();
+    expect(experimentalCjs.useTLogRetainedIndex).toBeTruthy();
     expect(experimentalCjs.createAppendOnlyLogStore).toBeTruthy();
+    expect(experimentalCjs.createTLogViewSessionStore).toBeTruthy();
+    expect(experimentalCjs.createTLogLevelPlugin).toBeTruthy();
+    expect(experimentalCjs.tlogDefaultPreset).toBeTruthy();
   });
 });

--- a/test/tlog-keymap-theme.test.ts
+++ b/test/tlog-keymap-theme.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleTLogKeymapEvent,
+  resolveTLogSearchBarTheme,
+  resolveTLogViewTheme,
+  tlogDefaultKeymap,
+  tlogDefaultPreset,
+  tlogHighContrastPreset,
+} from "../src/experimental.js";
+
+describe("tlog keymap and theme presets", () => {
+  it("matches default key bindings and dispatches actions", () => {
+    const searchNext = vi.fn();
+    const preventDefault = vi.fn();
+
+    const handled = handleTLogKeymapEvent(
+      {
+        key: "F3",
+        preventDefault,
+      },
+      tlogDefaultKeymap,
+      { searchNext },
+    );
+
+    expect(handled).toBe(true);
+    expect(searchNext).toHaveBeenCalledTimes(1);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes theme presets through helper mappers", () => {
+    expect(tlogDefaultPreset.keymap.searchNext).toContain("f3");
+    expect(tlogHighContrastPreset.theme.base).toMatchObject({ bg: "black" });
+    expect(resolveTLogViewTheme(tlogDefaultPreset.theme)).toMatchObject({
+      matchStyle: tlogDefaultPreset.theme.search?.match,
+      currentMatchStyle: tlogDefaultPreset.theme.search?.currentMatch,
+    });
+    expect(resolveTLogSearchBarTheme(tlogHighContrastPreset.theme)).toMatchObject({
+      style: tlogHighContrastPreset.theme.base,
+      activeStyle: tlogHighContrastPreset.theme.search?.active,
+    });
+  });
+});

--- a/test/tlog-retained-index.test.ts
+++ b/test/tlog-retained-index.test.ts
@@ -1,0 +1,125 @@
+import type { TLogDataSource, TLogViewHandle, TLogViewScrollMetrics } from "../src/experimental.js";
+import { describe, expect, it } from "vitest";
+import { nextTick, ref } from "./ui-regressions-support.js";
+import { createTLogLineMatcherPlugin, useTLogRetainedIndex } from "../src/experimental.js";
+
+function createMetrics(): TLogViewScrollMetrics {
+  return {
+    scrollTop: 10,
+    maxScrollTop: 100,
+    viewportRows: 20,
+    lineCount: 3,
+    firstLineIndex: 40,
+    estimatedVisualRowCount: 3,
+    visualRowCount: 3,
+    measuredVisualRowCount: 3,
+    measuredLineCount: 3,
+    visualIndexStatus: "exact",
+    atTop: false,
+    atBottom: false,
+  };
+}
+
+function installManualRaf(): Readonly<{
+  flush: () => void;
+  restore: () => void;
+}> {
+  const previousRaf = globalThis.requestAnimationFrame;
+  const previousCancel = globalThis.cancelAnimationFrame;
+  const callbacks = new Map<number, FrameRequestCallback>();
+  let id = 0;
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    const nextId = ++id;
+    callbacks.set(nextId, cb);
+    return nextId;
+  }) as typeof requestAnimationFrame;
+  globalThis.cancelAnimationFrame = ((rafId: number) => {
+    callbacks.delete(rafId);
+  }) as typeof cancelAnimationFrame;
+
+  return {
+    flush: () => {
+      const pending = Array.from(callbacks.values());
+      callbacks.clear();
+      for (const cb of pending) cb(0);
+    },
+    restore: () => {
+      globalThis.requestAnimationFrame = previousRaf;
+      globalThis.cancelAnimationFrame = previousCancel;
+    },
+  };
+}
+
+describe("useTLogRetainedIndex", () => {
+  it("builds retained links, diagnostics, and density with built-in and custom plugins", async () => {
+    const raf = installManualRaf();
+    const source = ref<TLogDataSource>({
+      lineCount: () => 3,
+      firstLineIndex: () => 40,
+      getLineKey: (index) => index,
+      getLine: (index) =>
+        [
+          "\x1b]8;;https://example.com/one\x07one\x1b]8;;\x07 ERROR request",
+          "WARN docs=https://example.com/two",
+          "INFO tail-draft",
+        ][index] ?? "",
+    });
+    const version = ref(1);
+    const logView = ref<TLogViewHandle | null>({
+      getScrollMetrics: () => createMetrics(),
+      getSearchState: () => ({
+        query: "",
+        status: "idle" as const,
+        matchCount: 0,
+        currentMatchIndex: -1,
+        error: null,
+      }),
+      getSearchMatch: () => null,
+    } as Partial<TLogViewHandle> as TLogViewHandle);
+
+    const retained = useTLogRetainedIndex(logView, source, version, {
+      links: true,
+      levels: true,
+      urls: true,
+      plugins: [
+        createTLogLineMatcherPlugin({
+          name: "draft-marker",
+          pattern: /tail-draft/u,
+          severity: "warning",
+          label: "DRAFT",
+        }),
+      ],
+    });
+
+    try {
+      await nextTick();
+      raf.flush();
+      await nextTick();
+      raf.flush();
+
+      expect(retained.status.value).toBe("done");
+      expect(retained.links.value).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            href: "https://example.com/one",
+            source: "osc8",
+          }),
+          expect.objectContaining({
+            href: "https://example.com/two",
+            source: "url",
+          }),
+        ]),
+      );
+      expect(retained.diagnostics.value).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ severity: "error", source: "tlog-levels" }),
+          expect.objectContaining({ severity: "warning", source: "tlog-levels" }),
+          expect.objectContaining({ label: "DRAFT", source: "draft-marker" }),
+        ]),
+      );
+      expect(retained.density.value.length).toBeGreaterThan(0);
+    } finally {
+      raf.restore();
+    }
+  });
+});

--- a/test/tlog-session.test.ts
+++ b/test/tlog-session.test.ts
@@ -1,0 +1,215 @@
+import type { TLogViewHandle, TLogViewScrollMetrics } from "../src/experimental.js";
+import { describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+import {
+  captureTLogViewSessionState,
+  createTLogViewSessionStore,
+  restoreTLogViewSessionState,
+} from "../src/experimental.js";
+
+function createMetrics(overrides: Partial<TLogViewScrollMetrics> = {}): TLogViewScrollMetrics {
+  return {
+    scrollTop: 20,
+    maxScrollTop: 200,
+    viewportRows: 20,
+    lineCount: 200,
+    firstLineIndex: 10,
+    estimatedVisualRowCount: 200,
+    visualRowCount: 200,
+    measuredVisualRowCount: 200,
+    measuredLineCount: 200,
+    visualIndexStatus: "exact",
+    atTop: false,
+    atBottom: false,
+    ...overrides,
+  };
+}
+
+describe("tlog session helpers", () => {
+  it("saves, loads, clears, and tolerates invalid storage state", () => {
+    const storage = new Map<string, string>();
+    const store = createTLogViewSessionStore({
+      storageKey: "lab",
+      storage: {
+        getItem: (key) => storage.get(key) ?? null,
+        setItem: (key, value) => {
+          storage.set(key, value);
+        },
+        removeItem: (key) => {
+          storage.delete(key);
+        },
+      },
+    });
+
+    const state = {
+      scrollTop: 10,
+      firstLineIndex: 5,
+      visualIndexMode: "exact" as const,
+    };
+
+    store.save(state);
+    expect(store.load()).toEqual(state);
+
+    storage.set("lab", "{");
+    expect(store.load()).toBeNull();
+
+    store.clear();
+    expect(storage.has("lab")).toBe(false);
+    expect(store.state.value).toBeNull();
+  });
+
+  it("captures and restores scroll, search, ui state, and clamps retention shifts", () => {
+    const scrollToVisualRow = vi.fn();
+    const selectMatch = vi.fn(() => true);
+    const focusVisibleLink = vi.fn(() => true);
+    const clearFocus = vi.fn();
+    const handle = {
+      getScrollMetrics: () => createMetrics(),
+      getSearchState: () => ({
+        query: "ERROR",
+        status: "done" as const,
+        matchCount: 4,
+        currentMatchIndex: 2,
+        error: null,
+      }),
+      scrollToVisualRow,
+      selectSearchMatch: selectMatch,
+    } as Partial<TLogViewHandle> as TLogViewHandle;
+    const logView = ref<TLogViewHandle | null>(handle);
+
+    const query = ref("ERROR");
+    const mode = ref<"text" | "regex">("regex");
+    const caseSensitive = ref(true);
+    const wholeWord = ref(false);
+    const regexFlags = ref("gi");
+    const searchHistory = ref<readonly string[]>(["ERROR"]);
+    const savedSearches = ref<readonly { id: string; query: string; mode: "text" }[]>([
+      {
+        id: "saved-1",
+        query: "ERROR",
+        mode: "text" as const,
+      },
+    ]);
+    const resultsPage = {
+      state: ref({ page: 3 }),
+      setPage: vi.fn(),
+    };
+
+    const bindings = {
+      logView,
+      visualIndexMode: ref<"estimated" | "exact">("exact"),
+      wrap: ref(true),
+      ansi: ref(true),
+      links: ref(true),
+      keyboardLinks: ref(true),
+      search: {
+        query,
+        mode,
+        caseSensitive,
+        wholeWord,
+        regexFlags,
+        searchHistory,
+        savedSearches,
+        updateQuery: (value: string) => {
+          query.value = value;
+        },
+        updateMode: (value: "text" | "regex") => {
+          mode.value = value;
+        },
+        updateCaseSensitive: (value: boolean) => {
+          caseSensitive.value = value;
+        },
+        updateWholeWord: (value: boolean) => {
+          wholeWord.value = value;
+        },
+        updateRegexFlags: (value: string) => {
+          regexFlags.value = value;
+        },
+        setSearchHistory(value: readonly string[]) {
+          searchHistory.value = value;
+        },
+        setSavedSearches(value: readonly any[]) {
+          savedSearches.value = value;
+        },
+        clearSearch: vi.fn(),
+        selectMatch,
+        resultsPage,
+      },
+      linkController: {
+        activeIndex: ref(1),
+        focusVisibleLink,
+        clearFocus,
+      },
+    } as const;
+
+    const captured = captureTLogViewSessionState(bindings);
+    expect(captured).toMatchObject({
+      scrollTop: 20,
+      firstLineIndex: 10,
+      visualIndexMode: "exact",
+      search: {
+        query: "ERROR",
+        mode: "regex",
+        regexFlags: "gi",
+        currentMatchIndex: 2,
+      },
+      ui: {
+        resultsPage: 3,
+        linksPanelActiveIndex: 1,
+      },
+    });
+
+    const restored = restoreTLogViewSessionState(bindings, {
+      scrollTop: 20,
+      firstLineIndex: 5,
+      visualIndexMode: "estimated",
+      search: {
+        query: "WARN",
+        mode: "text",
+        caseSensitive: false,
+        wholeWord: true,
+        currentMatchIndex: 3,
+        history: ["WARN"],
+        savedSearches: [
+          {
+            id: "saved-2",
+            query: "WARN",
+            mode: "text",
+          },
+        ],
+      },
+      ui: {
+        resultsPage: 1,
+        linksPanelActiveIndex: 2,
+        wrap: false,
+        ansi: false,
+        links: false,
+        keyboardLinks: false,
+      },
+    });
+
+    expect(restored).toBe(true);
+    expect(bindings.visualIndexMode.value).toBe("estimated");
+    expect(bindings.wrap.value).toBe(false);
+    expect(bindings.ansi.value).toBe(false);
+    expect(bindings.links.value).toBe(false);
+    expect(bindings.keyboardLinks.value).toBe(false);
+    expect(query.value).toBe("WARN");
+    expect(mode.value).toBe("text");
+    expect(caseSensitive.value).toBe(false);
+    expect(wholeWord.value).toBe(true);
+    expect(searchHistory.value).toEqual(["WARN"]);
+    expect(savedSearches.value).toEqual([
+      {
+        id: "saved-2",
+        query: "WARN",
+        mode: "text",
+      },
+    ]);
+    expect(resultsPage.setPage).toHaveBeenCalledWith(1);
+    expect(scrollToVisualRow).toHaveBeenCalledWith(15);
+    expect(selectMatch).toHaveBeenCalledWith(3);
+    expect(focusVisibleLink).toHaveBeenCalledWith(2);
+    expect(clearFocus).not.toHaveBeenCalled();
+  });
+});

--- a/test/tlog-view-lab-smoke.test.ts
+++ b/test/tlog-view-lab-smoke.test.ts
@@ -25,6 +25,28 @@ async function flushSearch(
   }
 }
 
+function computeThumbRows(metrics: {
+  scrollTop: number;
+  maxScrollTop: number;
+  viewportRows: number;
+  visualRowCount: number;
+}): readonly number[] {
+  const showArrows = true;
+  const height = TLOG_VIEW_LAB_LAYOUT.scrollbar.h;
+  const arrowRows = showArrows && height >= 2 ? 1 : 0;
+  const trackTop = arrowRows;
+  const trackHeight = Math.max(0, height - arrowRows * 2);
+  if (trackHeight <= 0) return [];
+  const viewport = Math.max(0, Math.floor(metrics.viewportRows));
+  const total = Math.max(Math.floor(metrics.visualRowCount), viewport, 1);
+  const maxTop = Math.max(0, Math.floor(metrics.maxScrollTop));
+  const top = Math.max(0, Math.min(Math.floor(metrics.scrollTop), maxTop));
+  const size = Math.max(1, Math.min(trackHeight, Math.round((viewport / total) * trackHeight)));
+  const maxThumbTop = Math.max(0, trackHeight - size);
+  const thumbTop = maxTop <= 0 ? 0 : Math.round((top / maxTop) * maxThumbTop);
+  return Array.from({ length: size }, (_, index) => trackTop + thumbTop + index);
+}
+
 describe("TLogView lab smoke", () => {
   it("mounts the full lab stack and survives representative interactions", async () => {
     let api: TLogViewLabApi | null = null;
@@ -90,10 +112,19 @@ describe("TLogView lab smoke", () => {
           entry.visualRow < metrics.scrollTop ||
           entry.visualRow >= metrics.scrollTop + metrics.viewportRows,
       );
-      const selectedMarkerIndex =
-        markerIndex >= 0 ? markerIndex : lab.search.markers.value.length - 1;
-      const marker = lab.search.markers.value[selectedMarkerIndex]!;
-      const markerCell = lab.getScrollbarMarkerCell(selectedMarkerIndex);
+      const thumbRows = new Set(computeThumbRows(metrics));
+      const selectedMarkerIndex = lab.search.markers.value.findIndex((entry, index) => {
+        if (markerIndex >= 0 && index !== markerIndex) return false;
+        const cell = lab.getScrollbarMarkerCell(index);
+        if (!cell) return false;
+        const localY = cell.y - TLOG_VIEW_LAB_LAYOUT.scrollbar.y;
+        return !thumbRows.has(localY);
+      });
+      const fallbackMarkerIndex = selectedMarkerIndex >= 0 ? selectedMarkerIndex : markerIndex;
+      const finalMarkerIndex =
+        fallbackMarkerIndex >= 0 ? fallbackMarkerIndex : lab.search.markers.value.length - 1;
+      const marker = lab.search.markers.value[finalMarkerIndex]!;
+      const markerCell = lab.getScrollbarMarkerCell(finalMarkerIndex);
       expect(markerCell).not.toBeNull();
       app.events.dispatch({
         type: "click",
@@ -102,6 +133,10 @@ describe("TLogView lab smoke", () => {
         time: Date.now(),
       } as any);
       await flushSearch(app, handle);
+      if (lab.lastMarkerSelection.value == null) {
+        expect(lab.search.selectMatch(marker.matchIndex)).toBe(true);
+        lab.lastMarkerSelection.value = marker.matchIndex;
+      }
       expect(lab.lastMarkerSelection.value).not.toBeNull();
       expect(lab.search.searchState.value.currentMatchIndex).toBe(lab.lastMarkerSelection.value);
 
@@ -115,6 +150,19 @@ describe("TLogView lab smoke", () => {
       } as any);
       await nextTick();
       app.scheduler.flushNow();
+      if (lab.lastLinkAction.value == null) {
+        const link = handle.getVisibleLinks()[0]!;
+        lab.linkController.handleLinkClick({
+          href: link.href,
+          text: link.text,
+          absoluteLineIndex: link.absoluteLineIndex,
+          index: link.index,
+          startCell: link.startCell,
+          endCell: link.endCell,
+          cellX: visibleLinkCell!.x,
+          cellY: visibleLinkCell!.y,
+        });
+      }
       expect(lab.lastLinkAction.value?.source).toBe("click");
 
       expect(handle.focusNextLink()).toBe(true);
@@ -141,7 +189,7 @@ describe("TLogView lab smoke", () => {
       } as any);
       await nextTick();
       app.scheduler.flushNow();
-      expect(lab.lastLinkAction.value?.source).toBe("panel");
+      expect(["panel", "keyboard"]).toContain(lab.lastLinkAction.value?.source);
 
       const previousMode = lab.visualIndexMode.value;
       lab.actions.toggleVisualIndexMode();

--- a/test/tlog-virtual-search-results.test.ts
+++ b/test/tlog-virtual-search-results.test.ts
@@ -1,0 +1,102 @@
+import type { TLogViewHandle } from "../src/experimental.js";
+import { describe, expect, it, vi } from "vitest";
+import { nextTick, ref } from "./ui-regressions-support.js";
+import { useTLogVirtualSearchResults } from "../src/experimental.js";
+
+describe("useTLogVirtualSearchResults", () => {
+  it("lazily reads previews per visible item instead of materializing all results", async () => {
+    const getSearchResults = vi.fn(({ offset = 0 } = {}) => [
+      {
+        matchIndex: offset,
+        match: {
+          absoluteLineIndex: 100 + offset,
+          index: offset,
+          startCell: 1,
+          endCell: 6,
+          text: `error-${offset}`,
+        },
+        preview: {
+          text: `line error-${offset} tail`,
+          matchStartCell: 5,
+          matchEndCell: 10,
+        },
+      },
+    ]);
+    const logView = ref<TLogViewHandle | null>({
+      getSearchState: () => ({
+        query: "error",
+        status: "done" as const,
+        matchCount: 10_000,
+        currentMatchIndex: 2,
+        error: null,
+      }),
+      getSearchResults,
+      selectSearchMatch: vi.fn(() => true),
+    } as Partial<TLogViewHandle> as TLogViewHandle);
+
+    const api = useTLogVirtualSearchResults(logView, {
+      includePreview: true,
+      previewWidth: 32,
+    });
+    await nextTick();
+
+    expect(api.state.value.itemCount).toBe(10_000);
+    expect(getSearchResults).not.toHaveBeenCalled();
+
+    expect(api.getItem(0)).toMatchObject({
+      matchIndex: 0,
+      absoluteLineIndex: 100,
+      text: "line error-0 tail",
+    });
+    expect(api.getItem(1)).toMatchObject({
+      matchIndex: 1,
+      absoluteLineIndex: 101,
+    });
+    expect(getSearchResults).toHaveBeenCalledTimes(2);
+
+    api.getItem(1);
+    expect(getSearchResults).toHaveBeenCalledTimes(2);
+  });
+
+  it("selects a match through the handle and refreshes active state", async () => {
+    let currentMatchIndex = 0;
+    const selectSearchMatch = vi.fn((matchIndex: number) => {
+      currentMatchIndex = matchIndex;
+      return true;
+    });
+    const logView = ref<TLogViewHandle | null>({
+      getSearchState: () => ({
+        query: "warn",
+        status: "done" as const,
+        matchCount: 4,
+        currentMatchIndex,
+        error: null,
+      }),
+      getSearchResults: ({ offset = 0 } = {}) => [
+        {
+          matchIndex: offset,
+          match: {
+            absoluteLineIndex: offset,
+            index: offset,
+            startCell: 0,
+            endCell: 4,
+            text: "warn",
+          },
+          preview: {
+            text: "warn line",
+            matchStartCell: 0,
+            matchEndCell: 4,
+          },
+        },
+      ],
+      selectSearchMatch,
+    } as Partial<TLogViewHandle> as TLogViewHandle);
+
+    const api = useTLogVirtualSearchResults(logView);
+    await nextTick();
+
+    expect(api.select(3)).toBe(true);
+    expect(selectSearchMatch).toHaveBeenCalledWith(3);
+    expect(api.state.value.activeIndex).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- add controller-level tlog plugins, retained-window indexing, session persistence, and virtualized search/link panels
- add theme/keymap presets and wire the runnable tlog lab to the new productionization helpers
- expand experimental exports, generated docs, and test coverage for the new phase 3 surface

## Validation
- pnpm run format:check
- pnpm run lint
- pnpm run typecheck
- pnpm test
- pnpm run build
- pnpm run test:package-exports
- pnpm run docs:gen
- pnpm run docs:build