### PR TITLE
perf(tlog-view): add frame mailbox for wheel scroll and data updates

### DIFF
--- a/src/vue/components/TLogView.ts
+++ b/src/vue/components/TLogView.ts
@@ -2958,7 +2958,7 @@ export const TLogView = defineComponent({
     function applyDataUpdate(payload: TLogDataUpdatePayload, ctx: TerminalFrameContext): void {
       if (!alive) return;
       const invalidated = handleSourceVersionChanged(payload);
-      if (!invalidated) return;
+      if (!invalidated || !hasPaintableViewport()) return;
       const nextShouldStick = shouldStickForAppend();
       ctx.invalidate({
         priority: nextShouldStick ? "high" : "normal",
@@ -2988,14 +2988,14 @@ export const TLogView = defineComponent({
       const payload = { version: props.version, lineCount: lineCount() };
       if (shouldStickForAppend()) {
         dataNormalMailbox.cancel();
-        dataHighMailbox.queue(payload);
+        if (!dataHighMailbox.queue(payload)) return;
         return;
       }
       if (dataHighMailbox.hasPending()) {
-        dataHighMailbox.queue(payload);
+        if (!dataHighMailbox.queue(payload)) return;
         return;
       }
-      dataNormalMailbox.queue(payload);
+      if (!dataNormalMailbox.queue(payload)) return;
     }
 
     function requestWheelScroll(nextTop: number): boolean {
@@ -3453,7 +3453,7 @@ export const TLogView = defineComponent({
     watch(
       () => props.scrollTop,
       () => {
-        resetWheelScrollState(wheelState);
+        cancelWheelScrollFrame();
         syncStickFromCurrentScrollTop();
         markViewportDirty();
         invalidateSelf("high", "scroll");

--- a/src/vue/components/TLogView.ts
+++ b/src/vue/components/TLogView.ts
@@ -2955,26 +2955,47 @@ export const TLogView = defineComponent({
       return false;
     }
 
-    const dataMailbox = createFrameMailbox<TLogDataUpdatePayload>({
+    function applyDataUpdate(payload: TLogDataUpdatePayload, ctx: TerminalFrameContext): void {
+      if (!alive) return;
+      const invalidated = handleSourceVersionChanged(payload);
+      if (!invalidated) return;
+      const nextShouldStick = shouldStickForAppend();
+      ctx.invalidate({
+        priority: nextShouldStick ? "high" : "normal",
+        plane: plane.value,
+        reason: "data",
+      });
+    }
+
+    const dataHighMailbox = createFrameMailbox<TLogDataUpdatePayload>({
       scheduler,
-      id: `${frameTaskId}:data`,
+      id: `${frameTaskId}:data-high`,
       reason: "data",
-      priority: "low",
-      apply(payload, ctx) {
-        if (!alive) return;
-        const invalidated = handleSourceVersionChanged(payload);
-        if (!invalidated) return;
-        const nextShouldStick = shouldStickForAppend();
-        ctx.invalidate({
-          priority: nextShouldStick ? "high" : "normal",
-          plane: plane.value,
-          reason: "data",
-        });
-      },
+      priority: "high",
+      sync: true,
+      apply: applyDataUpdate,
+    });
+
+    const dataNormalMailbox = createFrameMailbox<TLogDataUpdatePayload>({
+      scheduler,
+      id: `${frameTaskId}:data-normal`,
+      reason: "data",
+      priority: "normal",
+      apply: applyDataUpdate,
     });
 
     function requestDataFrame(): void {
-      dataMailbox.queue({ version: props.version, lineCount: lineCount() });
+      const payload = { version: props.version, lineCount: lineCount() };
+      if (shouldStickForAppend()) {
+        dataNormalMailbox.cancel();
+        dataHighMailbox.queue(payload);
+        return;
+      }
+      if (dataHighMailbox.hasPending()) {
+        dataHighMailbox.queue(payload);
+        return;
+      }
+      dataNormalMailbox.queue(payload);
     }
 
     function requestWheelScroll(nextTop: number): boolean {
@@ -3452,7 +3473,8 @@ export const TLogView = defineComponent({
         () => fullRect.value.w,
       ],
       () => {
-        dataMailbox.cancel();
+        dataHighMailbox.cancel();
+        dataNormalMailbox.cancel();
         clearLineCaches();
         resetVisualIndex(lineCount(), currentWrapWidth());
         if (props.wrap && props.visualIndexMode === "exact") {
@@ -3542,7 +3564,8 @@ export const TLogView = defineComponent({
       visualMeasureGeneration++;
       cancelWheelScrollFrame();
       wheelMailbox.dispose();
-      dataMailbox.dispose();
+      dataHighMailbox.dispose();
+      dataNormalMailbox.dispose();
     });
 
     const renderNode = useRenderNode(() => ({

--- a/src/vue/components/TLogView.ts
+++ b/src/vue/components/TLogView.ts
@@ -2607,7 +2607,7 @@ export const TLogView = defineComponent({
           resetWheelScrollState(wheelState);
           return;
         }
-        const changed = applyScrollTop(nextTop, "viewport-repaint", { emitScroll: true });
+        const changed = applyScrollTop(nextTop, "auto", { emitScroll: true });
         if (!changed) {
           resetWheelScrollState(wheelState);
           return;

--- a/src/vue/components/TLogView.ts
+++ b/src/vue/components/TLogView.ts
@@ -27,6 +27,7 @@ import { useTerminalNode } from "../composables/use-terminal-node.js";
 import { useTerminal } from "../composables/use-terminal.js";
 import { useVisibility } from "../composables/use-visibility.js";
 import { EventZIndexContextKey, RenderPlaneContextKey } from "../context.js";
+import { createFrameMailbox } from "../scheduler/frame-mailbox.js";
 import { intersectRect, normalizeCellRect, translateRect } from "../utils/rect.js";
 import {
   forEachTextCellSegment,
@@ -108,6 +109,10 @@ type LocatedVisualRow = {
   lineIndex: number;
   partIndex: number;
 };
+type TLogDataUpdatePayload = Readonly<{
+  version: number;
+  lineCount: number;
+}>;
 export type TLogViewSearchMode = "text" | "regex";
 export type TLogViewSearchError = Readonly<{
   kind: "invalid-regex";
@@ -878,6 +883,12 @@ export const TLogView = defineComponent({
       const full = normalizedFullRect();
       const clip = normalizedRect();
       return full.x !== clip.x || full.y !== clip.y || full.w !== clip.w || full.h !== clip.h;
+    }
+
+    function hasPaintableViewport(): boolean {
+      if (!visible.value) return false;
+      const r = normalizedRect();
+      return r.w > 0 && r.h > 0;
     }
 
     function lineCount(): number {
@@ -2584,8 +2595,30 @@ export const TLogView = defineComponent({
       scheduler.invalidate({ priority, plane: plane.value, reason });
     }
 
+    const wheelMailbox = createFrameMailbox<number>({
+      scheduler,
+      id: `${frameTaskId}:wheel`,
+      reason: "scroll",
+      priority: "high",
+      sync: true,
+      apply(nextTop, ctx) {
+        pendingWheelTop = null;
+        if (!alive || !hasPaintableViewport()) {
+          resetWheelScrollState(wheelState);
+          return;
+        }
+        const changed = applyScrollTop(nextTop, "viewport-repaint", { emitScroll: true });
+        if (!changed) {
+          resetWheelScrollState(wheelState);
+          return;
+        }
+        ctx.invalidate({ priority: "high", plane: plane.value, reason: "scroll" });
+      },
+    });
+
     function cancelWheelScrollFrame(): void {
       pendingWheelTop = null;
+      wheelMailbox.cancel();
       resetWheelScrollState(wheelState);
     }
 
@@ -2645,13 +2678,17 @@ export const TLogView = defineComponent({
       return Array.from(rows).sort((a, b) => a - b);
     }
 
-    function markRowsDirty(nextRows: readonly number[]): void {
+    function markRowsDirty(nextRows: readonly number[]): boolean {
+      if (!hasPaintableViewport()) return false;
       dirtyRowsHint = unionDirtyRows(nextRows);
-      if (renderNodeId) render.update(renderNodeId, { dirtyRowsHint });
+      if (!renderNodeId) return false;
+      if (render.markDirtyRows(renderNodeId, dirtyRowsHint)) return true;
+      dirtyRowsHint = undefined;
+      return false;
     }
 
-    function markViewportDirty(): void {
-      markRowsDirty(viewportRows());
+    function markViewportDirty(): boolean {
+      return markRowsDirty(viewportRows());
     }
 
     function applyLinkFocusToSegments(
@@ -2805,9 +2842,9 @@ export const TLogView = defineComponent({
       return startIndex < visible.end && endIndex > visible.start;
     }
 
-    function handleSourceVersionChanged(): boolean {
+    function handleSourceVersionChanged(payload?: TLogDataUpdatePayload): boolean {
       const prevCount = lastLineCount;
-      const nextCount = lineCount();
+      const nextCount = payload?.lineCount ?? lineCount();
       const prevFirst = lastFirstLineIndex;
       const nextFirst = firstLineIndex();
       const droppedHeadLines = Math.max(0, nextFirst - prevFirst);
@@ -2918,57 +2955,48 @@ export const TLogView = defineComponent({
       return false;
     }
 
-    function requestStreamFrame(): void {
-      const shouldStick = shouldStickForAppend();
-      scheduler.queueFrameTask({
-        id: `${frameTaskId}:stream`,
-        reason: "stream",
-        priority: shouldStick ? "high" : "normal",
-        sync: shouldStick,
-        run(ctx) {
-          if (!alive) return;
-          const invalidated = handleSourceVersionChanged();
-          if (!invalidated) return;
-          const nextShouldStick = shouldStickForAppend();
-          ctx.invalidate({
-            priority: nextShouldStick ? "high" : "normal",
-            plane: plane.value,
-            reason: "stream",
-          });
-        },
-      });
+    const dataMailbox = createFrameMailbox<TLogDataUpdatePayload>({
+      scheduler,
+      id: `${frameTaskId}:data`,
+      reason: "data",
+      priority: "low",
+      apply(payload, ctx) {
+        if (!alive) return;
+        const invalidated = handleSourceVersionChanged(payload);
+        if (!invalidated) return;
+        const nextShouldStick = shouldStickForAppend();
+        ctx.invalidate({
+          priority: nextShouldStick ? "high" : "normal",
+          plane: plane.value,
+          reason: "data",
+        });
+      },
+    });
+
+    function requestDataFrame(): void {
+      dataMailbox.queue({ version: props.version, lineCount: lineCount() });
     }
 
     function requestWheelScroll(nextTop: number): boolean {
       pendingWheelTop = nextTop;
-      let accepted: boolean | void;
       try {
-        accepted = scheduler.queueFrameTask({
-          id: `${frameTaskId}:wheel`,
-          reason: "scroll",
-          priority: "high",
-          sync: true,
-          run(ctx) {
-            if (!alive) return;
-            const top = pendingWheelTop;
-            pendingWheelTop = null;
-            if (top == null) return;
-            const changed = applyScrollTop(top, "viewport-repaint", { emitScroll: true });
-            if (!changed) return;
-            ctx.invalidate({ priority: "high", plane: plane.value, reason: "scroll" });
-          },
-        });
+        if (wheelMailbox.queue(nextTop)) return true;
       } catch (error) {
         pendingWheelTop = null;
         resetWheelScrollState(wheelState);
         throw error;
       }
-      if (accepted === false) {
-        pendingWheelTop = null;
-        resetWheelScrollState(wheelState);
-        return false;
-      }
-      return true;
+      pendingWheelTop = null;
+      resetWheelScrollState(wheelState);
+      return false;
+    }
+
+    function replacePendingWheelTop(nextTop: number): boolean {
+      pendingWheelTop = nextTop;
+      if (wheelMailbox.replacePending(nextTop)) return true;
+      pendingWheelTop = null;
+      resetWheelScrollState(wheelState);
+      return false;
     }
 
     function keyboardScroll(nextTop: number, nextStick?: boolean): void {
@@ -3360,10 +3388,35 @@ export const TLogView = defineComponent({
     });
 
     watch(
+      [
+        () => visible.value,
+        () => absRect.value.x,
+        () => absRect.value.y,
+        () => absRect.value.w,
+        () => absRect.value.h,
+        () => fullRect.value.w,
+        () => fullRect.value.h,
+      ],
+      () => {
+        if (pendingWheelTop === null) return;
+        if (!hasPaintableViewport()) {
+          cancelWheelScrollFrame();
+          return;
+        }
+        const nextPendingTop = normalizeScrollTop(pendingWheelTop);
+        if (nextPendingTop === currentScrollTop()) {
+          cancelWheelScrollFrame();
+        } else if (nextPendingTop !== pendingWheelTop) {
+          replacePendingWheelTop(nextPendingTop);
+        }
+      },
+    );
+
+    watch(
       () => props.version,
       () => {
         resetWheelScrollState(wheelState);
-        requestStreamFrame();
+        requestDataFrame();
         requestSearchScan();
       },
     );
@@ -3399,6 +3452,7 @@ export const TLogView = defineComponent({
         () => fullRect.value.w,
       ],
       () => {
+        dataMailbox.cancel();
         clearLineCaches();
         resetVisualIndex(lineCount(), currentWrapWidth());
         if (props.wrap && props.visualIndexMode === "exact") {
@@ -3487,6 +3541,8 @@ export const TLogView = defineComponent({
       searchGeneration++;
       visualMeasureGeneration++;
       cancelWheelScrollFrame();
+      wheelMailbox.dispose();
+      dataMailbox.dispose();
     });
 
     const renderNode = useRenderNode(() => ({

--- a/test/tlog-view.test.ts
+++ b/test/tlog-view.test.ts
@@ -6499,6 +6499,58 @@ describe("TLogView", () => {
     }
   });
 
+  it("keeps bottom append high priority under frame task pressure", async () => {
+    const raf = installManualRaf();
+    const log = createAppendOnlyLogStore();
+    log.appendLines(Array.from({ length: 20 }, (_, index) => `line-${index}`));
+    let pressureRuns = 0;
+
+    const App = defineComponent({
+      name: "TLogViewBottomAppendPriorityApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 4,
+            source: log.source,
+            version: log.version.value,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 8, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      app.scheduler.configure({ frameBudgetMs: 0 });
+
+      app.scheduler.queueFrameTask({
+        id: "test:high-pressure",
+        reason: "input",
+        priority: "high",
+        sync: true,
+        run() {
+          pressureRuns++;
+        },
+      });
+      log.appendLine("line-20");
+      await nextTick();
+
+      expect(raf.pending()).toBe(1);
+      raf.flush();
+      await nextTick();
+
+      expect(pressureRuns).toBe(1);
+      expect(rowText(app, 3)).toBe("line-20");
+    } finally {
+      app.dispose();
+      raf.restore();
+    }
+  });
+
   it("keeps data dirty repaint scoped away from same-plane siblings", async () => {
     const raf = installManualRaf();
     const log = createAppendOnlyLogStore();

--- a/test/tlog-view.test.ts
+++ b/test/tlog-view.test.ts
@@ -20,7 +20,10 @@ import {
   onMounted,
   ref,
   TText,
+  TView,
   useTerminal,
+  vShow,
+  withDirectives,
 } from "./ui-regressions-support.js";
 
 function rowText(
@@ -342,6 +345,255 @@ describe("TLogView", () => {
       expect(rowText(app, 0)).toBe("line-95");
     } finally {
       app.dispose();
+    }
+  });
+
+  it("coalesces consecutive wheel events into one frame scroll update", async () => {
+    const raf = installManualRaf();
+    const source: TLogDataSource = {
+      lineCount: () => 1_000_000,
+      getLine: (index) => `line-${index}`,
+    };
+    const onScroll = vi.fn();
+    let framePerf: ReturnType<typeof useTerminal>["observability"]["framePerf"] | null = null;
+
+    const Probe = defineComponent({
+      name: "TLogViewWheelMailboxProbe",
+      setup() {
+        framePerf = useTerminal().observability.framePerf;
+        framePerf.enabled.value = true;
+        return () => null;
+      },
+    });
+    const App = defineComponent({
+      name: "TLogViewWheelMailboxApp",
+      setup() {
+        return () => [
+          h(Probe),
+          h(TLogView, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 4,
+            source,
+            version: 1,
+            autoFocus: true,
+            onScroll,
+          }),
+          ...Array.from({ length: 50 }, (_, index) =>
+            h(TText, { x: 0, y: 10 + index, w: 20, value: `sibling-${index}` }),
+          ),
+        ];
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 80, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      framePerf!.clear();
+      const commits: unknown[] = [];
+      const off = app.terminal.on("commit", (commit) => commits.push(commit));
+
+      for (let i = 0; i < 1_000; i++) {
+        app.events.dispatch({
+          type: "wheel",
+          cellX: 0,
+          cellY: 0,
+          deltaY: -1,
+          time: 1_000 + i * 10,
+        });
+      }
+
+      expect(onScroll).not.toHaveBeenCalled();
+      expect(commits).toEqual([]);
+      expect(raf.pending()).toBe(1);
+
+      raf.flush();
+      await nextTick();
+
+      expect(onScroll).toHaveBeenCalledTimes(1);
+      const top = onScroll.mock.calls[0]![0].scrollTop;
+      expect(rowText(app, 0)).toBe(`line-${top}`);
+      expect(commits).toHaveLength(1);
+      expect(framePerf!.latest()).toMatchObject({
+        reason: "scroll",
+        frameTaskCount: 1,
+        coalescedFrameTasks: 0,
+        droppedUpdates: 999,
+        remainingFrameTasks: 0,
+      });
+      expect(framePerf!.latest()?.dirtyRows).toBeLessThanOrEqual(4);
+      expect(framePerf!.latest()?.paintedNodes).toBe(1);
+      expect(framePerf!.latest()?.scannedNodes).toBeLessThan(20);
+      off();
+    } finally {
+      app.dispose();
+      raf.restore();
+    }
+  });
+
+  it("drops a pending wheel frame when unmounted before RAF", async () => {
+    const raf = installManualRaf();
+    const onScroll = vi.fn();
+    let hide!: () => void;
+    const source: TLogDataSource = {
+      lineCount: () => 200,
+      getLine: (index) => `line-${index}`,
+    };
+
+    const App = defineComponent({
+      name: "TLogViewPendingWheelUnmountApp",
+      setup() {
+        const shown = ref(true);
+        hide = () => {
+          shown.value = false;
+        };
+        return () =>
+          shown.value
+            ? h(TLogView, {
+                x: 0,
+                y: 0,
+                w: 20,
+                h: 4,
+                source,
+                version: 1,
+                autoFocus: true,
+                onScroll,
+              })
+            : null;
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 8, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "wheel", cellX: 0, cellY: 0, deltaY: -100, time: 1_000 });
+      expect(raf.pending()).toBe(1);
+
+      hide();
+      await nextTick();
+      app.scheduler.flushNow();
+      raf.flush();
+      await nextTick();
+
+      expect(onScroll).not.toHaveBeenCalled();
+    } finally {
+      app.dispose();
+      raf.restore();
+    }
+  });
+
+  it("cancels pending wheel scroll when hidden before RAF", async () => {
+    const raf = installManualRaf();
+    const visible = ref(true);
+    const onScroll = vi.fn();
+    const source: TLogDataSource = {
+      lineCount: () => 200,
+      getLine: (index) => `line-${index}`,
+    };
+
+    const App = defineComponent({
+      name: "TLogViewPendingWheelHiddenApp",
+      setup() {
+        return () => [
+          h(TText, { x: 0, y: 0, w: 20, value: "hidden-placeholder" }),
+          withDirectives(
+            h(TLogView, {
+              x: 0,
+              y: 0,
+              w: 20,
+              h: 4,
+              source,
+              version: 1,
+              autoFocus: true,
+              onScroll,
+            }),
+            [[vShow, visible.value]],
+          ),
+        ];
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 8, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "wheel", cellX: 0, cellY: 0, deltaY: -100, time: 1_000 });
+      expect(raf.pending()).toBe(1);
+
+      visible.value = false;
+      await nextTick();
+      app.scheduler.flushNow();
+      raf.flush();
+      await nextTick();
+
+      expect(onScroll).not.toHaveBeenCalled();
+      expect(rowText(app, 0)).toBe("hidden-placeholder");
+    } finally {
+      app.dispose();
+      raf.restore();
+    }
+  });
+
+  it("cancels pending wheel scroll when clipped before RAF", async () => {
+    const raf = installManualRaf();
+    const clipHeight = ref(4);
+    const onScroll = vi.fn();
+    const source: TLogDataSource = {
+      lineCount: () => 200,
+      getLine: (index) => `line-${index}`,
+    };
+
+    const App = defineComponent({
+      name: "TLogViewPendingWheelClippedApp",
+      setup() {
+        return () =>
+          h(
+            TView,
+            { x: 0, y: 0, w: 20, h: clipHeight.value },
+            {
+              default: () =>
+                h(TLogView, {
+                  x: 0,
+                  y: 0,
+                  w: 20,
+                  h: 4,
+                  source,
+                  version: 1,
+                  autoFocus: true,
+                  onScroll,
+                }),
+            },
+          );
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 8, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "wheel", cellX: 0, cellY: 0, deltaY: -100, time: 1_000 });
+      expect(raf.pending()).toBe(1);
+
+      clipHeight.value = 0;
+      await nextTick();
+      app.scheduler.flushNow();
+      raf.flush();
+      await nextTick();
+
+      expect(onScroll).not.toHaveBeenCalled();
+    } finally {
+      app.dispose();
+      raf.restore();
     }
   });
 
@@ -908,7 +1160,7 @@ describe("TLogView", () => {
         "line-20",
       ]);
       expect(framePerf!.latest()).toMatchObject({
-        reason: "stream",
+        reason: "data",
         dirtyRows: 1,
         frameTaskCount: 1,
       });
@@ -1527,14 +1779,14 @@ describe("TLogView", () => {
     }
   });
 
-  it("does not coalesce stream tasks across multiple TLogView instances", async () => {
+  it("does not coalesce data tasks across multiple TLogView instances", async () => {
     const raf = installManualRaf();
     const logA = createAppendOnlyLogStore();
     const logB = createAppendOnlyLogStore();
     let framePerf: ReturnType<typeof useTerminal>["observability"]["framePerf"] | null = null;
 
     const App = defineComponent({
-      name: "TLogViewMultipleStreamTasksApp",
+      name: "TLogViewMultipleDataTasksApp",
       setup() {
         framePerf = useTerminal().observability.framePerf;
         framePerf.enabled.value = true;
@@ -1577,7 +1829,7 @@ describe("TLogView", () => {
       expect(rowText(app, 0)).toBe("a");
       expect(rowText(app, 2)).toBe("b");
       expect(framePerf!.latest()).toMatchObject({
-        reason: "stream",
+        reason: "data",
         frameTaskCount: 2,
         remainingFrameTasks: 0,
       });
@@ -6192,7 +6444,7 @@ describe("TLogView", () => {
     mounted.unmount();
   });
 
-  it("coalesces burst append through one stream frame task", async () => {
+  it("coalesces burst append through one data mailbox frame task", async () => {
     const raf = installManualRaf();
     const log = createAppendOnlyLogStore();
     log.appendLines(Array.from({ length: 20 }, (_, index) => `line-${index}`));
@@ -6222,19 +6474,86 @@ describe("TLogView", () => {
       app.scheduler.flushNow();
       framePerf!.clear();
 
-      for (let i = 20; i < 120; i++) log.appendLine(`line-${i}`);
-      await nextTick();
+      for (let i = 20; i < 1_020; i++) {
+        log.appendLine(`line-${i}`);
+        await nextTick();
+      }
 
       expect(raf.pending()).toBe(1);
       raf.flush();
       await nextTick();
 
-      expect(rowText(app, 3)).toBe("line-119");
+      expect(rowText(app, 3)).toBe("line-1019");
       expect(framePerf!.latest()).toMatchObject({
-        reason: "stream",
+        reason: "data",
         frameTaskCount: 1,
+        coalescedFrameTasks: 0,
+        droppedUpdates: 999,
         remainingFrameTasks: 0,
       });
+      expect(framePerf!.latest()?.dirtyRows).toBeLessThanOrEqual(4);
+      expect(framePerf!.latest()?.paintedNodes).toBe(1);
+    } finally {
+      app.dispose();
+      raf.restore();
+    }
+  });
+
+  it("keeps data dirty repaint scoped away from same-plane siblings", async () => {
+    const raf = installManualRaf();
+    const log = createAppendOnlyLogStore();
+    log.appendLines(Array.from({ length: 20 }, (_, index) => `line-${index}`));
+    let framePerf: ReturnType<typeof useTerminal>["observability"]["framePerf"] | null = null;
+
+    const Probe = defineComponent({
+      name: "TLogViewDataDirtyRowsProbe",
+      setup() {
+        framePerf = useTerminal().observability.framePerf;
+        framePerf.enabled.value = true;
+        return () => null;
+      },
+    });
+    const App = defineComponent({
+      name: "TLogViewDataDirtyRowsApp",
+      setup() {
+        return () => [
+          h(Probe),
+          h(TLogView, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 4,
+            source: log.source,
+            version: log.version.value,
+          }),
+          ...Array.from({ length: 60 }, (_, index) =>
+            h(TText, { x: 0, y: 10 + index, w: 20, value: `sibling-${index}` }),
+          ),
+        ];
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 80, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      framePerf!.clear();
+
+      log.appendLine("line-20");
+      await nextTick();
+      raf.flush();
+      await nextTick();
+
+      expect(rowText(app, 3)).toBe("line-20");
+      expect(rowText(app, 10)).toBe("sibling-0");
+      expect(framePerf!.latest()).toMatchObject({
+        reason: "data",
+        frameTaskCount: 1,
+        dirtyRows: 4,
+        paintedNodes: 1,
+      });
+      expect(framePerf!.latest()?.scannedNodes).toBeLessThan(20);
     } finally {
       app.dispose();
       raf.restore();

--- a/test/tlog-view.test.ts
+++ b/test/tlog-view.test.ts
@@ -656,6 +656,64 @@ describe("TLogView", () => {
     }
   });
 
+  it("cancels pending wheel scroll when controlled scrollTop changes before RAF", async () => {
+    const raf = installManualRaf();
+    const controlledTop = ref(96);
+    const source: TLogDataSource = {
+      lineCount: () => 100,
+      getLine: (index) => `line-${index}`,
+    };
+    const onScroll = vi.fn();
+    const onUpdateScrollTop = vi.fn((nextTop: number) => {
+      controlledTop.value = nextTop;
+    });
+
+    const App = defineComponent({
+      name: "TLogViewPendingWheelControlledScrollApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 4,
+            source,
+            version: 1,
+            scrollTop: controlledTop.value,
+            autoFocus: true,
+            onScroll,
+            "onUpdate:scrollTop": onUpdateScrollTop,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 8, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      expect(rowText(app, 0)).toBe("line-96");
+
+      app.events.dispatch({ type: "wheel", cellX: 0, cellY: 0, deltaY: -100, time: 1_000 });
+      expect(raf.pending()).toBe(1);
+      expect(onUpdateScrollTop).not.toHaveBeenCalled();
+
+      controlledTop.value = 80;
+      await nextTick();
+      raf.flush();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(controlledTop.value).toBe(80);
+      expect(onUpdateScrollTop).not.toHaveBeenCalled();
+      expect(onScroll).not.toHaveBeenCalled();
+      expect(rowText(app, 0)).toBe("line-80");
+    } finally {
+      app.dispose();
+      raf.restore();
+    }
+  });
+
   it("waits for controlled scrollTop prop updates before changing rendered rows", async () => {
     const controlledTop = ref(96);
     const source: TLogDataSource = {
@@ -6552,6 +6610,78 @@ describe("TLogView", () => {
       });
       expect(framePerf!.latest()?.dirtyRows).toBeLessThanOrEqual(4);
       expect(framePerf!.latest()?.paintedNodes).toBe(1);
+    } finally {
+      app.dispose();
+      raf.restore();
+    }
+  });
+
+  it("does not repaint visible rows for hidden data bursts", async () => {
+    const raf = installManualRaf();
+    const log = createAppendOnlyLogStore();
+    log.appendLines(Array.from({ length: 20 }, (_, index) => `line-${index}`));
+    const logView = ref<TLogViewHandle | null>(null);
+    let framePerf: ReturnType<typeof useTerminal>["observability"]["framePerf"] | null = null;
+
+    const Probe = defineComponent({
+      name: "TLogViewHiddenDataBurstProbe",
+      setup() {
+        framePerf = useTerminal().observability.framePerf;
+        framePerf.enabled.value = true;
+        return () => null;
+      },
+    });
+    const App = defineComponent({
+      name: "TLogViewHiddenDataBurstApp",
+      setup() {
+        const visible = ref(false);
+        return () => [
+          h(Probe),
+          h(TText, { x: 0, y: 0, w: 20, value: "hidden-placeholder" }),
+          withDirectives(
+            h(TLogView, {
+              ref: logView,
+              x: 0,
+              y: 0,
+              w: 20,
+              h: 4,
+              source: log.source,
+              version: log.version.value,
+            }),
+            [[vShow, visible.value]],
+          ),
+          h(TText, { x: 0, y: 6, w: 20, value: "same-plane-sibling" }),
+        ];
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 10, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      framePerf!.clear();
+      const commits: unknown[] = [];
+      const off = app.terminal.on("commit", (commit) => commits.push(commit));
+
+      for (let i = 20; i < 1_020; i++) {
+        log.appendLine(`line-${i}`);
+        await nextTick();
+      }
+
+      expect(raf.pending()).toBe(1);
+      raf.flush();
+      await nextTick();
+
+      expect(logView.value!.getScrollMetrics()).toMatchObject({
+        scrollTop: 1016,
+        lineCount: 1020,
+      });
+      expect(rowText(app, 0)).toBe("hidden-placeholder");
+      expect(rowText(app, 6)).toBe("same-plane-sibling");
+      expect(commits).toEqual([]);
+      expect(framePerf!.latest()).toBeNull();
+      off();
     } finally {
       app.dispose();
       raf.restore();

--- a/test/tlog-view.test.ts
+++ b/test/tlog-view.test.ts
@@ -434,6 +434,65 @@ describe("TLogView", () => {
     }
   });
 
+  it("uses exposed dirty row for full-row unsafe wheel scroll", async () => {
+    const source: TLogDataSource = {
+      lineCount: () => 100,
+      getLine: (index) => `line-${index}`,
+    };
+
+    const App = defineComponent({
+      name: "TLogViewWheelScrollFastPathApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 4,
+            source,
+            version: 1,
+            autoFocus: true,
+            rowScrollMode: "unsafe-full-row",
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 8, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      const commits: Array<{
+        dirtyRows: readonly number[] | null;
+        scrollOperations: unknown;
+      }> = [];
+      const off = app.terminal.on("commit", ({ dirtyRows, scrollOperations }) => {
+        commits.push({ dirtyRows, scrollOperations: scrollOperations ?? null });
+      });
+
+      app.events.dispatch({ type: "wheel", cellX: 0, cellY: 0, deltaY: -100, time: 1_000 });
+      await nextTick();
+      app.scheduler.flushNow();
+
+      off();
+      expect(commits).toEqual([
+        {
+          dirtyRows: [0],
+          scrollOperations: [{ startY: 0, endY: 4, delta: -1 }],
+        },
+      ]);
+      expect([0, 1, 2, 3].map((y) => rowText(app, y))).toEqual([
+        "line-95",
+        "line-96",
+        "line-97",
+        "line-98",
+      ]);
+    } finally {
+      app.dispose();
+    }
+  });
+
   it("drops a pending wheel frame when unmounted before RAF", async () => {
     const raf = installManualRaf();
     const onScroll = vi.fn();


### PR DESCRIPTION
Replace direct `scheduler.queueFrameTask` calls with `createFrameMailbox` for wheel scrolling and data streaming. This coalesces consecutive updates into a single frame task, cancels pending work on unmount/visibility changes, and scopes dirty-row repaints away from same-plane siblings.

## Changes

- Add `wheelMailbox` for coalescing wheel scroll events
- Add `dataMailbox` for coalescing data/version updates
- Add `hasPaintableViewport` guard before scheduling
- `markRowsDirty` returns boolean via `render.markDirtyRows`
- Cancel pending wheel scroll on visibility/rect changes
- Dispose mailboxes on unmount
- Add tests for wheel coalescing, unmount/hidden/clipped cancellation
- Add test for dirty-row repaint scoping with siblings