### PR TITLE
feat(TVirtualList): add controlled scrollTop prop and migrate wheel to frame mailbox

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -432,7 +432,7 @@ request repaint; repaint only happens when active rows or `scrollTop` change.
 
 大数据选择/浏览列表：使用 `itemCount` / `itemVersion` / `getItem` 从外部数据源读取可见行，避免把大数组本体放进 Vue deep reactivity。它不是日志/streaming 组件；append-only 输出请使用 `TLogView`。
 
-> Phase 1 experimental API：当前从 `@simon_he/vue-tui/experimental` 导出，暂不进入 root 入口。API 仍可能在 scheduler frame task、controlled scrollTop、overscan、TLogView 等后续能力落地前调整。
+> Phase 1 experimental API：当前从 `@simon_he/vue-tui/experimental` 导出，暂不进入 root 入口。API 仍可能在 overscan、TLogView 等后续能力落地前调整。
 
 ### Props
 
@@ -442,9 +442,10 @@ request repaint; repaint only happens when active rows or `scrollTop` change.
 - `getItem` `((index: number) => unknown, required)`
 - `renderItem` `((item, index) => unknown)`
 - `modelValue` `(number)` + `update:modelValue`
+- `scrollTop` `(number?)` + `update:scrollTop`：受控 viewport scrollTop；省略时由组件内部维护
 - `style` / `activeStyle` `(Style?)`
 - `autoFocus` `(boolean)`
-- `rowScrollMode` `("off" | "unsafe-full-row")`：full-row 场景的 opt-in unsafe row-scroll 优化
+- `rowScrollMode` `("off" | "unsafe-full-row")`：保留的实验性开关；当前 wheel path 走 viewport repaint，不使用 exposed-row row-scroll
 
 ### Data source
 
@@ -463,9 +464,9 @@ const renderItem = (item: Row) => item.title;
 <TVirtualList :get-item="(index) => items[index]" />
 ```
 
-### Row scroll
+### Wheel Scroll
 
-`rowScrollMode` 是危险优化开关，不是列表内部局部滚动。它会 shift 当前 render plane 的整行区域，只能用于该 plane 的这些 rows 被 `TVirtualList` 独占且列表没有被裁剪的场景；同 plane 其它内容会被一起移动。DOM renderer 支持通过移动 line nodes 消费 terminal `scrollOperations`，但只有列表占满终端整行、列表 rect 未被裁剪、rows 在 terminal bounds 内且 renderer capability 开启时才会走 exposed-row repaint；其它场景会退回 viewport repaint。debug perf 模式会对这些被忽略的场景发出一次 warning。
+Wheel burst 通过 frame mailbox 合并；同一帧只应用最后的 `scrollTop`。滚动 repaint 只调用 `markDirtyRows(viewportRows)`，dirty rows 不超过可见 viewport 高度，也不会走 exposed-row fast path 或提交 `scrollOperations`。组件 hidden、fully clipped、unmount 或受控 `scrollTop` 在 RAF 前变化时，会取消 pending wheel，不会让旧 wheel 覆盖新的受控位置。
 
 ### Selection model
 
@@ -474,6 +475,7 @@ const renderItem = (item: Row) => item.title;
 ### Events
 
 - `change`: `{ index, value }`
+- `update:scrollTop`: `scrollTop`（number）
 - `scroll`: `scrollTop`（number）
 - `focus` / `blur` / `keydown`
 

--- a/docs/generated/components-api.md
+++ b/docs/generated/components-api.md
@@ -963,6 +963,7 @@
 | <code>getItem</code>       | <code>(index: number) =&gt; unknown</code>                | —                            | 是   | —    |
 | <code>renderItem</code>    | <code>(item: unknown, index: number) =&gt; unknown</code> | <code>undefined</code>       | 否   | —    |
 | <code>modelValue</code>    | <code>number</code>                                       | <code>0</code>               | 否   | —    |
+| <code>scrollTop</code>     | <code>number</code>                                       | <code>undefined</code>       | 否   | —    |
 | <code>style</code>         | <code>Style</code>                                        | <code>undefined</code>       | 否   | —    |
 | <code>activeStyle</code>   | <code>Style</code>                                        | <code>undefined</code>       | 否   | —    |
 | <code>autoFocus</code>     | <code>boolean</code>                                      | <code>false</code>           | 否   | —    |
@@ -973,6 +974,7 @@
 | 名称                           | Payload | 说明 |
 | ------------------------------ | ------- | ---- |
 | <code>update:modelValue</code> | —       | —    |
+| <code>update:scrollTop</code>  | —       | —    |
 | <code>change</code>            | —       | —    |
 | <code>itemClick</code>         | —       | —    |
 | <code>scroll</code>            | —       | —    |

--- a/src/vue/components/TVirtualList.ts
+++ b/src/vue/components/TVirtualList.ts
@@ -6,6 +6,7 @@ import type { FramePerfReason } from "../../observability/frame-perf.js";
 import {
   computed,
   defineComponent,
+  getCurrentInstance,
   h,
   inject,
   onBeforeUnmount,
@@ -19,6 +20,7 @@ import { useTerminalNode } from "../composables/use-terminal-node.js";
 import { useTerminal } from "../composables/use-terminal.js";
 import { useVisibility } from "../composables/use-visibility.js";
 import { EventZIndexContextKey, RenderPlaneContextKey } from "../context.js";
+import { createFrameMailbox } from "../scheduler/frame-mailbox.js";
 import { intersectRect, normalizeCellRect, translateRect } from "../utils/rect.js";
 import { defaultActiveStyle } from "../utils/style-cache.js";
 import { formatInlineCellLine, padEndByCells, sliceByCellsRange } from "../utils/text.js";
@@ -59,7 +61,6 @@ function getWheelScrollInput(e: { deltaY?: number; deltaMode?: number }): {
   return { deltaY, mode: "auto" };
 }
 
-type ScrollStrategy = "auto" | "viewport-repaint";
 export type RowScrollMode = "off" | "unsafe-full-row";
 
 let virtualListInstanceSeq = 0;
@@ -80,6 +81,7 @@ export const TVirtualList = defineComponent({
       default: undefined,
     },
     modelValue: { type: Number, default: 0 },
+    scrollTop: { type: Number, default: undefined },
     style: { type: Object as PropType<Style>, default: undefined },
     activeStyle: { type: Object as PropType<Style>, default: undefined },
     autoFocus: { type: Boolean, default: false },
@@ -88,10 +90,19 @@ export const TVirtualList = defineComponent({
       default: "off",
     },
   },
-  emits: ["update:modelValue", "change", "itemClick", "scroll", "focus", "blur", "keydown"],
+  emits: [
+    "update:modelValue",
+    "update:scrollTop",
+    "change",
+    "itemClick",
+    "scroll",
+    "focus",
+    "blur",
+    "keydown",
+  ],
   setup(props, { emit }) {
-    const { terminal, scheduler, render, rendererCapabilities, defaultStyle, events } =
-      useTerminal();
+    const { terminal, scheduler, render, defaultStyle, events } = useTerminal();
+    const instance = getCurrentInstance();
     const layout = useLayout();
     const { visible, rootProps } = useVisibility();
     const plane = inject(RenderPlaneContextKey, ref<TerminalRenderPlane>("default"));
@@ -107,8 +118,6 @@ export const TVirtualList = defineComponent({
     // Reactive deps and rect changes repaint through useRenderNode normally.
     let dirtyRowsHint: readonly number[] | undefined;
     let renderNodeId: string | null = null;
-    const warnedIgnoredRowScrollReasons = new Set<string>();
-    let warnedEnabledRowScroll = false;
     let warnedGetItemIdentity = false;
     let warnedRenderItemIdentity = false;
     let alive = true;
@@ -148,22 +157,41 @@ export const TVirtualList = defineComponent({
       };
     }
 
-    function isClipped(): boolean {
-      const full = normalizedFullRect();
-      const clip = normalizedRect();
-      return full.x !== clip.x || full.y !== clip.y || full.w !== clip.w || full.h !== clip.h;
-    }
-
     function maxScrollTop(): number {
       const clip = normalizedRect();
       const { y: clipY } = clipOffsets();
       return Math.max(0, itemCount.value - (clipY + clip.h));
     }
 
+    function maxScrollTopForClamp(): number | null {
+      const full = normalizedFullRect();
+      const clip = normalizedRect();
+      if (full.h <= 0) return 0;
+      if (clip.h <= 0) return null;
+      return maxScrollTop();
+    }
+
+    function clampScrollTop(value: unknown): number {
+      const n = Math.floor(Number(value));
+      if (!Number.isFinite(n)) return 0;
+      const maxTop = maxScrollTopForClamp();
+      if (maxTop == null) return Math.max(0, n);
+      return clamp(n, 0, maxTop);
+    }
+
+    function hasPaintableViewport(): boolean {
+      const r = normalizedRect();
+      return visible.value && r.w > 0 && r.h > 0;
+    }
+
+    function isScrollControlled(): boolean {
+      return Object.prototype.hasOwnProperty.call(instance?.vnode.props ?? {}, "scrollTop");
+    }
+
     const visibleWindow = computed(() => {
       const clip = normalizedRect();
       const { y: clipY } = clipOffsets();
-      const top = clamp(scrollTop.value, 0, maxScrollTop());
+      const top = clampScrollTop(scrollTop.value);
       return {
         top,
         end: Math.min(itemCount.value, top + clipY + clip.h),
@@ -176,7 +204,6 @@ export const TVirtualList = defineComponent({
     }
 
     function ensureActiveVisible(
-      strategy: ScrollStrategy = "viewport-repaint",
       options?: Readonly<{
         emitScroll?: boolean;
         priority?: "low" | "normal" | "high";
@@ -194,15 +221,68 @@ export const TVirtualList = defineComponent({
       if (active.value < visibleStart) nextTop = clamp(active.value - clipY, 0, maxTop);
       else if (active.value > visibleEnd)
         nextTop = clamp(active.value - (clipY + clip.h - 1), 0, maxTop);
-      return applyScrollTop(nextTop, strategy, options);
+      return applyScrollTop(nextTop, options);
     }
 
     function normalizedModelValue(): number {
       return normalizeIndex(props.modelValue, itemCount.value);
     }
 
+    const wheelMailbox = createFrameMailbox<number>({
+      scheduler,
+      id: wheelTaskId,
+      reason: "scroll",
+      priority: "high",
+      sync: true,
+      apply(nextTop, ctx) {
+        pendingWheelTop = null;
+        if (!alive || !hasPaintableViewport()) {
+          resetWheelScrollState(wheelState);
+          return;
+        }
+        const changed = applyScrollTop(nextTop, {
+          emitScroll: true,
+          emitUpdate: true,
+        });
+        if (!changed) {
+          resetWheelScrollState(wheelState);
+          return;
+        }
+        ctx.invalidate({ priority: "high", plane: plane.value, reason: "scroll" });
+      },
+    });
+
+    function cancelWheelScrollFrame(): void {
+      pendingWheelTop = null;
+      wheelMailbox.cancel();
+      resetWheelScrollState(wheelState);
+    }
+
+    function requestWheelScroll(nextTop: number): boolean {
+      pendingWheelTop = nextTop;
+      try {
+        if (wheelMailbox.queue(nextTop)) return true;
+      } catch (error) {
+        pendingWheelTop = null;
+        resetWheelScrollState(wheelState);
+        throw error;
+      }
+      pendingWheelTop = null;
+      resetWheelScrollState(wheelState);
+      return false;
+    }
+
+    function replacePendingWheelTop(nextTop: number): boolean {
+      pendingWheelTop = nextTop;
+      if (wheelMailbox.replacePending(nextTop)) return true;
+      pendingWheelTop = null;
+      resetWheelScrollState(wheelState);
+      return false;
+    }
+
     let initializedModel = false;
     let initializedGeometry = false;
+    let initializedScrollTop = false;
 
     watch(
       () => props.modelValue,
@@ -211,7 +291,11 @@ export const TVirtualList = defineComponent({
         initializedModel = true;
         resetWheelScrollState(wheelState);
         active.value = normalizedModelValue();
-        ensureActiveVisible("viewport-repaint", { emitScroll });
+        if (isScrollControlled()) {
+          if (emitScroll) markViewportDirty();
+          return;
+        }
+        ensureActiveVisible({ emitScroll });
       },
       { immediate: true },
     );
@@ -229,10 +313,37 @@ export const TVirtualList = defineComponent({
         initializedGeometry = true;
         resetWheelScrollState(wheelState);
         active.value = normalizedModelValue();
-        const nextTop = clamp(scrollTop.value, 0, maxScrollTop());
-        const changed = applyScrollTop(nextTop, "viewport-repaint", { emitScroll });
+        const nextTop = clampScrollTop(scrollTop.value);
+        const changed = applyScrollTop(nextTop, { emitScroll });
         if (!changed) markViewportDirty();
+        if (pendingWheelTop !== null && !hasPaintableViewport()) {
+          cancelWheelScrollFrame();
+        } else if (pendingWheelTop !== null) {
+          const nextPendingTop = clampScrollTop(pendingWheelTop);
+          if (nextPendingTop === scrollTop.value) {
+            cancelWheelScrollFrame();
+          } else if (nextPendingTop !== pendingWheelTop) {
+            replacePendingWheelTop(nextPendingTop);
+          }
+        }
         invalidateSelf();
+      },
+      { immediate: true },
+    );
+
+    watch(
+      () => props.scrollTop,
+      () => {
+        if (!isScrollControlled()) return;
+        const wasInitialized = initializedScrollTop;
+        initializedScrollTop = true;
+        cancelWheelScrollFrame();
+        const nextTop = clampScrollTop(props.scrollTop);
+        const changed = scrollTop.value !== nextTop;
+        scrollTop.value = nextTop;
+        if (!wasInitialized || !changed) return;
+        markViewportDirty();
+        invalidateSelf("high", "scroll");
       },
       { immediate: true },
     );
@@ -275,67 +386,11 @@ export const TVirtualList = defineComponent({
       emit("change", { index: next, value: props.getItem(next) });
     }
 
-    function cancelWheelScrollFrame(): void {
-      pendingWheelTop = null;
-      scheduler.cancelFrameTask?.(wheelTaskId);
-      resetWheelScrollState(wheelState);
-    }
-
-    function requestWheelScroll(nextTop: number): boolean {
-      pendingWheelTop = nextTop;
-      // TODO(perf): Convert TVirtualList wheel scheduling to createFrameMailbox
-      // so wheel burst metrics match TList: producer-level droppedUpdates instead
-      // of scheduler-level coalescedFrameTasks.
-      let accepted: boolean | void;
-      try {
-        accepted = scheduler.queueFrameTask({
-          id: wheelTaskId,
-          reason: "scroll",
-          priority: "high",
-          sync: true,
-          run(ctx) {
-            if (!alive) return;
-            const top = pendingWheelTop;
-            pendingWheelTop = null;
-            if (top == null) return;
-            const changed = applyScrollTop(top, "auto", { emitScroll: true });
-            if (!changed) return;
-            ctx.invalidate({ priority: "high", plane: plane.value, reason: "scroll" });
-          },
-        });
-      } catch (error) {
-        pendingWheelTop = null;
-        resetWheelScrollState(wheelState);
-        throw error;
-      }
-      if (accepted === false) {
-        pendingWheelTop = null;
-        resetWheelScrollState(wheelState);
-        return false;
-      }
-      return true;
-    }
-
     function invalidateSelf(
       priority: "low" | "normal" | "high" = "normal",
       reason?: FramePerfReason,
     ): void {
       scheduler.invalidate({ priority, plane: plane.value, reason });
-    }
-
-    function warnIgnoredRowScroll(reason: string): void {
-      if (warnedIgnoredRowScrollReasons.has(reason) || !(globalThis as any).__VT_DEBUG_PERF__)
-        return;
-      warnedIgnoredRowScrollReasons.add(reason);
-      console.warn(`[vue-tui] TVirtualList.rowScrollMode="unsafe-full-row" ignored: ${reason}`);
-    }
-
-    function warnEnabledRowScroll(): void {
-      if (warnedEnabledRowScroll || !(globalThis as any).__VT_DEBUG_PERF__) return;
-      warnedEnabledRowScroll = true;
-      console.warn(
-        '[vue-tui] TVirtualList.rowScrollMode="unsafe-full-row" shifts whole plane rows. Use only when these rows are exclusively owned by this component.',
-      );
     }
 
     function moveActive(index: number): void {
@@ -344,7 +399,7 @@ export const TVirtualList = defineComponent({
       const prevTop = scrollTop.value;
       active.value = clamp(index, 0, Math.max(0, itemCount.value - 1));
       emit("update:modelValue", active.value);
-      const scrolled = ensureActiveVisible("viewport-repaint");
+      const scrolled = ensureActiveVisible();
       if (scrolled) emit("scroll", scrollTop.value);
       if (!scrolled || scrollTop.value === prevTop) markViewportDirty();
       invalidateSelf("high", "input");
@@ -464,20 +519,19 @@ export const TVirtualList = defineComponent({
       manager.focus(nodeId);
     });
 
+    watch(
+      () => visible.value,
+      (nextVisible) => {
+        if (!nextVisible) cancelWheelScrollFrame();
+      },
+    );
+
     onBeforeUnmount(() => {
       alive = false;
-      cancelWheelScrollFrame();
+      pendingWheelTop = null;
+      resetWheelScrollState(wheelState);
+      wheelMailbox.dispose();
     });
-
-    function exposedRowsForDelta(y0: number, h: number, delta: number): number[] {
-      const rows: number[] = [];
-      if (delta > 0) {
-        for (let i = h - delta; i < h; i++) rows.push(y0 + i);
-      } else {
-        for (let i = 0; i < -delta; i++) rows.push(y0 + i);
-      }
-      return rows;
-    }
 
     function viewportRows(): number[] {
       const r = normalizedRect();
@@ -493,21 +547,24 @@ export const TVirtualList = defineComponent({
       return Array.from(rows).sort((a, b) => a - b);
     }
 
-    function markRowsDirty(nextRows: readonly number[]): void {
-      if (!visible.value) return;
+    function markRowsDirty(nextRows: readonly number[]): boolean {
+      if (!hasPaintableViewport()) return false;
       dirtyRowsHint = unionDirtyRows(nextRows);
-      if (renderNodeId) render.markDirtyRows(renderNodeId, dirtyRowsHint);
+      if (!renderNodeId) return false;
+      if (render.markDirtyRows(renderNodeId, dirtyRowsHint)) return true;
+      dirtyRowsHint = undefined;
+      return false;
     }
 
-    function markViewportDirty(): void {
-      markRowsDirty(viewportRows());
+    function markViewportDirty(): boolean {
+      return markRowsDirty(viewportRows());
     }
 
     function applyScrollTop(
       nextTop: number,
-      strategy: ScrollStrategy = "auto",
       options?: Readonly<{
         emitScroll?: boolean;
+        emitUpdate?: boolean;
         priority?: "low" | "normal" | "high";
         reason?: FramePerfReason;
       }>,
@@ -516,44 +573,14 @@ export const TVirtualList = defineComponent({
       const full = normalizedFullRect();
       const h = r.h;
       if (h <= 0 || full.h <= 0) return false;
-      const clampedTop = clamp(nextTop, 0, maxScrollTop());
+      const clampedTop = clampScrollTop(nextTop);
       const delta = clampedTop - scrollTop.value;
       if (!delta) return false;
-      scrollTop.value = clampedTop;
-      const size = terminal.size();
-      const ownsFullRows = Math.floor(r.x) === 0 && Math.floor(r.w) >= size.cols;
-      const withinTerminalRows = r.y >= 0 && r.y + h <= size.rows;
-      const wantsUnsafeRowScroll = props.rowScrollMode === "unsafe-full-row";
-      const supportsScrollOperations = rendererCapabilities.value.scrollOperations;
-      if (strategy === "auto" && wantsUnsafeRowScroll) {
-        if (!supportsScrollOperations)
-          warnIgnoredRowScroll("renderer does not support scroll operations");
-        else if (!ownsFullRows) warnIgnoredRowScroll("list does not own full terminal rows");
-        else if (isClipped()) warnIgnoredRowScroll("list rect is clipped");
-        else if (!withinTerminalRows) warnIgnoredRowScroll("list rows are outside terminal bounds");
-      }
-      // Row-scroll requires a renderer that consumes terminal scrollOperations.
-      // It also requires unsafe opt-in so consumers acknowledge plane row-shift semantics.
-      const canUseScrollPlane =
-        strategy === "auto" &&
-        wantsUnsafeRowScroll &&
-        supportsScrollOperations &&
-        ownsFullRows &&
-        withinTerminalRows &&
-        !isClipped() &&
-        Math.abs(delta) < h &&
-        !dirtyRowsHint?.length;
-      if (canUseScrollPlane) {
-        warnEnabledRowScroll();
-        render.unsafeScrollPlaneRows(plane.value, r.y, r.y + h, delta);
-        markRowsDirty(exposedRowsForDelta(r.y, h, delta));
-        if (options?.emitScroll) emit("scroll", scrollTop.value);
-        if (options?.priority) invalidateSelf(options.priority, options.reason ?? "scroll");
-        return true;
-      }
-      markViewportDirty();
-      if (options?.emitScroll) emit("scroll", scrollTop.value);
-      if (options?.priority) invalidateSelf(options.priority, options.reason ?? "scroll");
+      if (!isScrollControlled()) scrollTop.value = clampedTop;
+      if (options?.emitUpdate ?? isScrollControlled()) emit("update:scrollTop", clampedTop);
+      const dirty = markViewportDirty();
+      if (options?.emitScroll) emit("scroll", clampedTop);
+      if (options?.priority && dirty) invalidateSelf(options.priority, options.reason ?? "scroll");
       return true;
     }
 

--- a/src/vue/components/TVirtualList.ts
+++ b/src/vue/components/TVirtualList.ts
@@ -63,6 +63,13 @@ function getWheelScrollInput(e: { deltaY?: number; deltaMode?: number }): {
 
 export type RowScrollMode = "off" | "unsafe-full-row";
 
+type ScrollApplyResult = Readonly<{
+  changed: boolean;
+  dirty: boolean;
+  top: number;
+  controlled: boolean;
+}>;
+
 let virtualListInstanceSeq = 0;
 
 export const TVirtualList = defineComponent({
@@ -209,10 +216,13 @@ export const TVirtualList = defineComponent({
         priority?: "low" | "normal" | "high";
         reason?: FramePerfReason;
       }>,
-    ): boolean {
+    ): ScrollApplyResult {
+      const controlled = isScrollControlled();
       const clip = normalizedRect();
       const full = normalizedFullRect();
-      if (clip.h <= 0 || full.h <= 0) return false;
+      if (clip.h <= 0 || full.h <= 0) {
+        return { changed: false, dirty: false, top: scrollTop.value, controlled };
+      }
       const { y: clipY } = clipOffsets();
       const maxTop = maxScrollTop();
       let nextTop = clamp(scrollTop.value, 0, maxTop);
@@ -244,11 +254,11 @@ export const TVirtualList = defineComponent({
           emitScroll: true,
           emitUpdate: true,
         });
-        if (!changed) {
+        if (!changed.changed) {
           resetWheelScrollState(wheelState);
           return;
         }
-        ctx.invalidate({ priority: "high", plane: plane.value, reason: "scroll" });
+        if (changed.dirty) ctx.invalidate({ priority: "high", plane: plane.value, reason: "scroll" });
       },
     });
 
@@ -315,7 +325,7 @@ export const TVirtualList = defineComponent({
         active.value = normalizedModelValue();
         const nextTop = clampScrollTop(scrollTop.value);
         const changed = applyScrollTop(nextTop, { emitScroll });
-        if (!changed) markViewportDirty();
+        if (!changed.changed) markViewportDirty();
         if (pendingWheelTop !== null && !hasPaintableViewport()) {
           cancelWheelScrollFrame();
         } else if (pendingWheelTop !== null) {
@@ -400,8 +410,9 @@ export const TVirtualList = defineComponent({
       active.value = clamp(index, 0, Math.max(0, itemCount.value - 1));
       emit("update:modelValue", active.value);
       const scrolled = ensureActiveVisible();
-      if (scrolled) emit("scroll", scrollTop.value);
-      if (!scrolled || scrollTop.value === prevTop) markViewportDirty();
+      if (scrolled.changed) emit("scroll", scrolled.top);
+      if (scrolled.changed && scrolled.controlled) return;
+      if (!scrolled.changed || scrollTop.value === prevTop) markViewportDirty();
       invalidateSelf("high", "input");
     }
 
@@ -568,20 +579,28 @@ export const TVirtualList = defineComponent({
         priority?: "low" | "normal" | "high";
         reason?: FramePerfReason;
       }>,
-    ): boolean {
+    ): ScrollApplyResult {
+      const controlled = isScrollControlled();
       const r = normalizedRect();
       const full = normalizedFullRect();
       const h = r.h;
-      if (h <= 0 || full.h <= 0) return false;
+      if (h <= 0 || full.h <= 0) {
+        return { changed: false, dirty: false, top: scrollTop.value, controlled };
+      }
       const clampedTop = clampScrollTop(nextTop);
       const delta = clampedTop - scrollTop.value;
-      if (!delta) return false;
-      if (!isScrollControlled()) scrollTop.value = clampedTop;
-      if (options?.emitUpdate ?? isScrollControlled()) emit("update:scrollTop", clampedTop);
+      if (!delta) return { changed: false, dirty: false, top: scrollTop.value, controlled };
+      if (controlled) {
+        if (options?.emitUpdate ?? true) emit("update:scrollTop", clampedTop);
+        if (options?.emitScroll) emit("scroll", clampedTop);
+        return { changed: true, dirty: false, top: clampedTop, controlled };
+      }
+      scrollTop.value = clampedTop;
+      if (options?.emitUpdate) emit("update:scrollTop", clampedTop);
       const dirty = markViewportDirty();
       if (options?.emitScroll) emit("scroll", clampedTop);
       if (options?.priority && dirty) invalidateSelf(options.priority, options.reason ?? "scroll");
-      return true;
+      return { changed: true, dirty, top: clampedTop, controlled };
     }
 
     const renderNode = useRenderNode(() => ({

--- a/test/virtual-list.test.ts
+++ b/test/virtual-list.test.ts
@@ -1207,6 +1207,140 @@ describe("TVirtualList", () => {
     }
   });
 
+  it("waits for controlled wheel scrollTop updates before repainting", async () => {
+    const previousRaf = globalThis.requestAnimationFrame;
+    const previousCancel = globalThis.cancelAnimationFrame;
+    const callbacks = new Map<number, FrameRequestCallback>();
+    let rafId = 0;
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      const id = ++rafId;
+      callbacks.set(id, cb);
+      return id;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((id: number) => {
+      callbacks.delete(id);
+    }) as typeof cancelAnimationFrame;
+
+    const controlledTop = ref(0);
+    const onScroll = vi.fn();
+    const onUpdateScrollTop = vi.fn((value: number) => {
+      controlledTop.value = value;
+    });
+    const App = defineComponent({
+      name: "VirtualListControlledWheelApp",
+      setup() {
+        return () =>
+          h(TVirtualList, {
+            x: 0,
+            y: 0,
+            w: 12,
+            h: 4,
+            itemCount: 200,
+            itemVersion: 1,
+            getItem: (index: number) => `item-${index}`,
+            scrollTop: controlledTop.value,
+            autoFocus: true,
+            onScroll,
+            "onUpdate:scrollTop": onUpdateScrollTop,
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 12, rows: 8, component: App });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      expect(rowText({ terminal: app.terminal } as any, 0)).toBe("item-0");
+
+      const commits: Array<readonly number[] | null> = [];
+      const off = app.terminal.on("commit", ({ dirtyRows }) => commits.push(dirtyRows));
+      app.events.dispatch({ type: "wheel", cellX: 0, cellY: 0, deltaY: 100, time: 1_000 });
+      expect(callbacks.size).toBe(1);
+
+      Array.from(callbacks.values())[0]?.(0);
+      expect(onUpdateScrollTop).toHaveBeenCalledWith(1);
+      expect(onScroll).toHaveBeenCalledWith(1);
+      expect(commits).toEqual([]);
+      expect(rowText({ terminal: app.terminal } as any, 0)).toBe("item-0");
+
+      await nextTick();
+
+      off();
+      expect(rowText({ terminal: app.terminal } as any, 0)).toBe("item-1");
+      expect(commits).toEqual([[0, 1, 2, 3]]);
+      expect(onUpdateScrollTop.mock.calls.map((call) => call[0])).toEqual([1]);
+      expect(onScroll.mock.calls.map((call) => call[0])).toEqual([1]);
+    } finally {
+      app.dispose();
+      globalThis.requestAnimationFrame = previousRaf;
+      globalThis.cancelAnimationFrame = previousCancel;
+    }
+  });
+
+  it("waits for controlled keyboard scrollTop updates before repainting", async () => {
+    const controlledTop = ref(0);
+    const modelValue = ref(0);
+    const onScroll = vi.fn();
+    const onUpdateScrollTop = vi.fn((value: number) => {
+      controlledTop.value = value;
+    });
+    const onUpdateModelValue = vi.fn((value: number) => {
+      modelValue.value = value;
+    });
+    const App = defineComponent({
+      name: "VirtualListControlledKeyboardApp",
+      setup() {
+        return () =>
+          h(TVirtualList, {
+            x: 0,
+            y: 0,
+            w: 12,
+            h: 4,
+            itemCount: 20,
+            itemVersion: 1,
+            getItem: (index: number) => `item-${index}`,
+            modelValue: modelValue.value,
+            scrollTop: controlledTop.value,
+            autoFocus: true,
+            onScroll,
+            "onUpdate:modelValue": onUpdateModelValue,
+            "onUpdate:scrollTop": onUpdateScrollTop,
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 12, rows: 8, component: App });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      expect(rowText({ terminal: app.terminal } as any, 0)).toBe("item-0");
+
+      const commits: Array<readonly number[] | null> = [];
+      const off = app.terminal.on("commit", ({ dirtyRows }) => commits.push(dirtyRows));
+      app.events.dispatch({ type: "keydown", key: "End", code: "End", time: 1_000 });
+
+      expect(onUpdateModelValue).toHaveBeenCalledWith(19);
+      expect(onUpdateScrollTop).toHaveBeenCalledWith(16);
+      expect(onScroll).toHaveBeenCalledWith(16);
+      expect(commits).toEqual([]);
+      expect(rowText({ terminal: app.terminal } as any, 0)).toBe("item-0");
+
+      await nextTick();
+
+      off();
+      expect(rowText({ terminal: app.terminal } as any, 0)).toBe("item-16");
+      expect(rowText({ terminal: app.terminal } as any, 3)).toBe("item-19");
+      expect(commits).toEqual([[0, 1, 2, 3]]);
+      expect(onUpdateModelValue.mock.calls.map((call) => call[0])).toEqual([19]);
+      expect(onUpdateScrollTop.mock.calls.map((call) => call[0])).toEqual([16]);
+      expect(onScroll.mock.calls.map((call) => call[0])).toEqual([16]);
+    } finally {
+      app.dispose();
+    }
+  });
+
   it("clears pending wheel state when queueFrameTask is rejected", async () => {
     const items = Array.from({ length: 100 }, (_, index) => `item-${index}`);
     const onScroll = vi.fn();

--- a/test/virtual-list.test.ts
+++ b/test/virtual-list.test.ts
@@ -13,6 +13,8 @@ import {
   TView,
   TVirtualList,
   useTerminal,
+  vShow,
+  withDirectives,
 } from "./ui-regressions-support.js";
 
 function dispatchWheel(container: HTMLElement): void {
@@ -27,14 +29,18 @@ function dispatchDomWheel(
   container: HTMLElement,
   init: Readonly<{ deltaY: number; deltaMode: number }>,
 ): void {
-  const wheel = new WheelEvent("wheel", {
-    bubbles: true,
-    cancelable: true,
-    clientX: 0,
-    clientY: 0,
-    deltaY: init.deltaY,
-    deltaMode: init.deltaMode,
-  }) as any;
+  const WheelEventCtor = (globalThis as any).WheelEvent;
+  const wheel =
+    typeof WheelEventCtor === "function"
+      ? (new WheelEventCtor("wheel", {
+          bubbles: true,
+          cancelable: true,
+          clientX: 0,
+          clientY: 0,
+          deltaY: init.deltaY,
+          deltaMode: init.deltaMode,
+        }) as any)
+      : (new Event("wheel", { bubbles: true, cancelable: true }) as any);
   Object.defineProperties(wheel, {
     clientX: { value: 0 },
     clientY: { value: 0 },
@@ -94,7 +100,7 @@ describe("TVirtualList", () => {
     mounted.unmount();
   });
 
-  it("uses DOM scrollOperations for full-row unsafe slow wheel scroll", async () => {
+  it("repaints the DOM viewport when rowScrollMode requests unsafe wheel scroll", async () => {
     const items = Array.from({ length: 20 }, (_, index) => `item-${index}`);
     const mounted = await mountTerminal(
       () =>
@@ -126,10 +132,7 @@ describe("TVirtualList", () => {
     await nextTick();
 
     off();
-    expect(commits).toContainEqual({
-      dirtyRows: [3],
-      scrollOperations: [{ startY: 0, endY: 4, delta: 1 }],
-    });
+    expect(commits).toContainEqual({ dirtyRows: [0, 1, 2, 3], scrollOperations: null });
     expect([0, 1, 2, 3].map((y) => rowText(mounted, y))).toEqual([
       "item-1",
       "item-2",
@@ -516,7 +519,7 @@ describe("TVirtualList", () => {
     }
   });
 
-  it("keeps unsafe row-scroll fast path to exposed rows when no DOM renderer is attached", () => {
+  it("keeps render manager unsafe row-scroll exposed rows available", () => {
     const terminal = createTerminal({ cols: 12, rows: 6 });
     const render = createRenderManager(terminal);
     const items = Array.from({ length: 20 }, (_, index) => `item-${index}`);
@@ -545,7 +548,7 @@ describe("TVirtualList", () => {
     expect(terminal.getCell(5, 3).ch).toBe("4");
   });
 
-  it("mounted headless fast path emits only exposed dirty row after wheel", async () => {
+  it("mounted headless wheel scroll repaints the viewport", async () => {
     const items = Array.from({ length: 20 }, (_, index) => `item-${index}`);
     const app = createTerminalApp({
       cols: 12,
@@ -578,9 +581,7 @@ describe("TVirtualList", () => {
     await nextTick();
 
     off();
-    expect(commits).toEqual([
-      { dirtyRows: [3], scrollOperations: [{ startY: 0, endY: 4, delta: 1 }] },
-    ]);
+    expect(commits).toEqual([{ dirtyRows: [0, 1, 2, 3], scrollOperations: null }]);
     expect([0, 1, 2, 3].map((y) => rowText({ terminal: app.terminal } as any, y))).toEqual([
       "item-1",
       "item-2",
@@ -590,7 +591,7 @@ describe("TVirtualList", () => {
     app.dispose();
   });
 
-  it('warns in debug perf mode when rowScrollMode="unsafe-full-row" shifts plane rows', async () => {
+  it('does not warn for rowScrollMode="unsafe-full-row" while using viewport repaint', async () => {
     const previousDebugPerf = (globalThis as any).__VT_DEBUG_PERF__;
     (globalThis as any).__VT_DEBUG_PERF__ = true;
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -620,9 +621,7 @@ describe("TVirtualList", () => {
       await nextTick();
       await nextTick();
 
-      expect(warn).toHaveBeenCalledWith(
-        '[vue-tui] TVirtualList.rowScrollMode="unsafe-full-row" shifts whole plane rows. Use only when these rows are exclusively owned by this component.',
-      );
+      expect(warn).not.toHaveBeenCalled();
     } finally {
       warn.mockRestore();
       app.dispose();
@@ -686,9 +685,7 @@ describe("TVirtualList", () => {
       await nextTick();
 
       off();
-      expect(commits).toEqual([
-        { dirtyRows: [2, 3], scrollOperations: [{ startY: 0, endY: 4, delta: 2 }] },
-      ]);
+      expect(commits).toEqual([{ dirtyRows: [0, 1, 2, 3], scrollOperations: null }]);
       expect([0, 1, 2, 3].map((y) => rowText({ terminal: app.terminal } as any, y))).toEqual([
         "item-2",
         "item-3",
@@ -717,7 +714,7 @@ describe("TVirtualList", () => {
       callbacks.delete(id);
     }) as typeof cancelAnimationFrame;
 
-    const items = Array.from({ length: 1_000 }, (_, index) => `item-${index}`);
+    const itemCount = 100_000;
     const onScroll = vi.fn();
     const onUpdateModelValue = vi.fn();
     let framePerf: ReturnType<typeof useTerminal>["observability"]["framePerf"] | null = null;
@@ -741,13 +738,14 @@ describe("TVirtualList", () => {
             y: 0,
             w: 12,
             h: 4,
-            itemCount: items.length,
+            itemCount,
             itemVersion: 1,
-            getItem: (index: number) => items[index],
+            getItem: (index: number) => `item-${index}`,
             autoFocus: true,
             onScroll,
             "onUpdate:modelValue": onUpdateModelValue,
           }),
+          h(TText, { x: 0, y: 6, w: 12, value: "sibling" }),
         ];
       },
     });
@@ -761,7 +759,7 @@ describe("TVirtualList", () => {
       framePerf!.clear();
       dateNow.mockReturnValue(1_000);
 
-      for (let i = 0; i < 100; i++) {
+      for (let i = 0; i < 1_000; i++) {
         app.events.dispatch({
           type: "wheel",
           cellX: 0,
@@ -778,12 +776,19 @@ describe("TVirtualList", () => {
       expect(onScroll).toHaveBeenCalledTimes(1);
       expect(onScroll.mock.calls[0]![0]).toBeGreaterThan(0);
       expect(onUpdateModelValue).not.toHaveBeenCalled();
-      expect(framePerf!.latest()).toMatchObject({
+      expect(rowText({ terminal: app.terminal } as any, 6)).toBe("sibling");
+      const scrollSample = [...framePerf!.list()]
+        .reverse()
+        .find((sample) => sample.reason === "scroll");
+      expect(scrollSample).toMatchObject({
         reason: "scroll",
         frameTaskCount: 1,
-        coalescedFrameTasks: 99,
+        coalescedFrameTasks: 0,
+        droppedUpdates: 999,
         remainingFrameTasks: 0,
       });
+      expect(scrollSample?.dirtyRows).toBeLessThanOrEqual(4);
+      expect(scrollSample?.paintedNodes).toBe(1);
     } finally {
       dateNow.mockRestore();
       app.dispose();
@@ -943,6 +948,258 @@ describe("TVirtualList", () => {
       expect(
         framePerf!.list().some((sample) => sample.reason === "scroll" && sample.frameTaskCount > 0),
       ).toBe(false);
+    } finally {
+      app.dispose();
+      globalThis.requestAnimationFrame = previousRaf;
+      globalThis.cancelAnimationFrame = previousCancel;
+    }
+  });
+
+  it("drops a pending wheel frame when unmounted before RAF", async () => {
+    const previousRaf = globalThis.requestAnimationFrame;
+    const previousCancel = globalThis.cancelAnimationFrame;
+    const callbacks = new Map<number, FrameRequestCallback>();
+    let rafId = 0;
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      const id = ++rafId;
+      callbacks.set(id, cb);
+      return id;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((id: number) => {
+      callbacks.delete(id);
+    }) as typeof cancelAnimationFrame;
+
+    let hide!: () => void;
+    const onScroll = vi.fn();
+    const App = defineComponent({
+      name: "VirtualListPendingWheelUnmountApp",
+      setup() {
+        const shown = ref(true);
+        hide = () => {
+          shown.value = false;
+        };
+        return () =>
+          shown.value
+            ? h(TVirtualList, {
+                x: 0,
+                y: 0,
+                w: 12,
+                h: 4,
+                itemCount: 200,
+                itemVersion: 1,
+                getItem: (index: number) => `item-${index}`,
+                autoFocus: true,
+                onScroll,
+              })
+            : null;
+      },
+    });
+    const app = createTerminalApp({ cols: 12, rows: 8, component: App });
+
+    try {
+      app.mount();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "wheel", cellX: 0, cellY: 0, deltaY: 1000, time: 1_000 });
+      expect(callbacks.size).toBe(1);
+
+      hide();
+      await nextTick();
+      app.scheduler.flushNow();
+      Array.from(callbacks.values())[0]?.(0);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(onScroll).not.toHaveBeenCalled();
+    } finally {
+      app.dispose();
+      globalThis.requestAnimationFrame = previousRaf;
+      globalThis.cancelAnimationFrame = previousCancel;
+    }
+  });
+
+  it("cancels pending wheel scroll when hidden before RAF", async () => {
+    const previousRaf = globalThis.requestAnimationFrame;
+    const previousCancel = globalThis.cancelAnimationFrame;
+    const callbacks = new Map<number, FrameRequestCallback>();
+    let rafId = 0;
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      const id = ++rafId;
+      callbacks.set(id, cb);
+      return id;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((id: number) => {
+      callbacks.delete(id);
+    }) as typeof cancelAnimationFrame;
+
+    const visible = ref(true);
+    const onScroll = vi.fn();
+    const App = defineComponent({
+      name: "VirtualListPendingWheelHiddenApp",
+      setup() {
+        return () => [
+          h(TText, { x: 0, y: 0, w: 12, value: "visible" }),
+          withDirectives(
+            h(TVirtualList, {
+              x: 0,
+              y: 0,
+              w: 12,
+              h: 4,
+              itemCount: 200,
+              itemVersion: 1,
+              getItem: (index: number) => `item-${index}`,
+              autoFocus: true,
+              onScroll,
+            }),
+            [[vShow, visible.value]],
+          ),
+        ];
+      },
+    });
+    const app = createTerminalApp({ cols: 12, rows: 8, component: App });
+
+    try {
+      app.mount();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "wheel", cellX: 0, cellY: 0, deltaY: 1000, time: 1_000 });
+      expect(callbacks.size).toBe(1);
+
+      visible.value = false;
+      await nextTick();
+      app.scheduler.flushNow();
+      expect(rowText({ terminal: app.terminal } as any, 0)).toBe("visible");
+
+      Array.from(callbacks.values())[0]?.(0);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(onScroll).not.toHaveBeenCalled();
+      expect(rowText({ terminal: app.terminal } as any, 0)).toBe("visible");
+    } finally {
+      app.dispose();
+      globalThis.requestAnimationFrame = previousRaf;
+      globalThis.cancelAnimationFrame = previousCancel;
+    }
+  });
+
+  it("cancels pending wheel scroll when fully clipped before RAF", async () => {
+    const previousRaf = globalThis.requestAnimationFrame;
+    const previousCancel = globalThis.cancelAnimationFrame;
+    const callbacks = new Map<number, FrameRequestCallback>();
+    let rafId = 0;
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      const id = ++rafId;
+      callbacks.set(id, cb);
+      return id;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((id: number) => {
+      callbacks.delete(id);
+    }) as typeof cancelAnimationFrame;
+
+    const clipHeight = ref(4);
+    const onScroll = vi.fn();
+    const App = defineComponent({
+      name: "VirtualListPendingWheelClippedApp",
+      setup() {
+        return () =>
+          h(TView, { x: 0, y: 0, w: 12, h: clipHeight.value }, () =>
+            h(TVirtualList, {
+              x: 0,
+              y: 0,
+              w: 12,
+              h: 4,
+              itemCount: 200,
+              itemVersion: 1,
+              getItem: (index: number) => `item-${index}`,
+              autoFocus: true,
+              onScroll,
+            }),
+          );
+      },
+    });
+    const app = createTerminalApp({ cols: 12, rows: 8, component: App });
+
+    try {
+      app.mount();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "wheel", cellX: 0, cellY: 0, deltaY: 1000, time: 1_000 });
+      expect(callbacks.size).toBe(1);
+
+      clipHeight.value = 0;
+      await nextTick();
+      app.scheduler.flushNow();
+      Array.from(callbacks.values())[0]?.(0);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(onScroll).not.toHaveBeenCalled();
+    } finally {
+      app.dispose();
+      globalThis.requestAnimationFrame = previousRaf;
+      globalThis.cancelAnimationFrame = previousCancel;
+    }
+  });
+
+  it("does not let pending wheel overwrite controlled scrollTop", async () => {
+    const previousRaf = globalThis.requestAnimationFrame;
+    const previousCancel = globalThis.cancelAnimationFrame;
+    const callbacks = new Map<number, FrameRequestCallback>();
+    let rafId = 0;
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      const id = ++rafId;
+      callbacks.set(id, cb);
+      return id;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((id: number) => {
+      callbacks.delete(id);
+    }) as typeof cancelAnimationFrame;
+
+    const controlledTop = ref(10);
+    const onScroll = vi.fn();
+    const onUpdateScrollTop = vi.fn();
+    const App = defineComponent({
+      name: "VirtualListControlledPendingWheelApp",
+      setup() {
+        return () =>
+          h(TVirtualList, {
+            x: 0,
+            y: 0,
+            w: 12,
+            h: 4,
+            itemCount: 200,
+            itemVersion: 1,
+            getItem: (index: number) => `item-${index}`,
+            scrollTop: controlledTop.value,
+            autoFocus: true,
+            onScroll,
+            "onUpdate:scrollTop": onUpdateScrollTop,
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 12, rows: 8, component: App });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      expect(rowText({ terminal: app.terminal } as any, 0)).toBe("item-10");
+
+      app.events.dispatch({ type: "wheel", cellX: 0, cellY: 0, deltaY: 100, time: 1_000 });
+      expect(callbacks.size).toBe(1);
+      expect(onUpdateScrollTop).not.toHaveBeenCalled();
+
+      controlledTop.value = 20;
+      await nextTick();
+      app.scheduler.flushNow();
+      Array.from(callbacks.values())[0]?.(0);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(onUpdateScrollTop).not.toHaveBeenCalled();
+      expect(onScroll).not.toHaveBeenCalled();
+      expect(rowText({ terminal: app.terminal } as any, 0)).toBe("item-20");
     } finally {
       app.dispose();
       globalThis.requestAnimationFrame = previousRaf;
@@ -1378,7 +1635,7 @@ describe("TVirtualList", () => {
     }
   });
 
-  it("keeps headless full-row slow scroll correct across consecutive wheel ticks", async () => {
+  it("keeps headless viewport repaint correct across consecutive wheel ticks", async () => {
     const items = Array.from({ length: 20 }, (_, index) => `item-${index}`);
     const app = createTerminalApp({
       cols: 12,
@@ -1416,7 +1673,10 @@ describe("TVirtualList", () => {
       off();
     }
 
-    expect(commits).toEqual([[3], [3]]);
+    expect(commits).toEqual([
+      [0, 1, 2, 3],
+      [0, 1, 2, 3],
+    ]);
     expect([0, 1, 2, 3].map((y) => rowText({ terminal: app.terminal } as any, y))).toEqual([
       "item-2",
       "item-3",
@@ -1965,7 +2225,7 @@ describe("TVirtualList", () => {
     app.dispose();
   });
 
-  it("normalizes fractional rect values for row-scroll dirty rows", async () => {
+  it("normalizes fractional rect values for viewport dirty rows", async () => {
     const items = Array.from({ length: 20 }, (_, index) => `item-${index}`);
     const app = createTerminalApp({
       cols: 12,
@@ -1993,12 +2253,12 @@ describe("TVirtualList", () => {
     await nextTick();
 
     off();
-    expect(commits).toEqual([[4]]);
+    expect(commits).toEqual([[0, 1, 2, 3, 4]]);
     expect(rowText({ terminal: app.terminal } as any, 4)).toBe("item-5");
     app.dispose();
   });
 
-  it('does not use unsafe row-scroll when rowScrollMode="unsafe-full-row" but list does not own full rows', async () => {
+  it('repaints the viewport when rowScrollMode="unsafe-full-row" but list does not own full rows', async () => {
     const items = Array.from({ length: 20 }, (_, index) => `item-${index}`);
     const App = defineComponent({
       name: "VirtualListWithSideContent",
@@ -2036,7 +2296,7 @@ describe("TVirtualList", () => {
     app.dispose();
   });
 
-  it('does not use unsafe row-scroll when rowScrollMode="unsafe-full-row" but the list is clipped', async () => {
+  it('repaints the viewport when rowScrollMode="unsafe-full-row" but the list is clipped', async () => {
     const items = Array.from({ length: 20 }, (_, index) => `item-${index}`);
     const App = defineComponent({
       name: "ClippedRowScrollVirtualList",
@@ -2097,7 +2357,7 @@ describe("TVirtualList", () => {
             itemVersion: 1,
             getItem: (index: number) => items[index],
             autoFocus: true,
-            // rowScrollMode defaults to off, so this should not use unsafe row-scroll
+            // rowScrollMode defaults to off, so this uses viewport repaint.
           }),
           h(TText, { x: 0, y: 1, w: 6, value: "BADGE", zIndex: 999 }),
         ];
@@ -2114,14 +2374,14 @@ describe("TVirtualList", () => {
     await nextTick();
 
     off();
-    // With rowScrollMode=off, unsafe row-scroll is NOT used, so BADGE is not shifted
+    // With viewport repaint, BADGE is not shifted.
     expect(rowText({ terminal: app.terminal } as any, 1)).toContain("BADGE");
-    // Full viewport repaint, not exposed-only
+    // Full viewport repaint, not exposed-only.
     expect(commits).toEqual([[0, 1, 2, 3]]);
     app.dispose();
   });
 
-  it('documents that rowScrollMode="unsafe-full-row" shifts same-plane full-row overlay content', async () => {
+  it('does not shift same-plane full-row overlay content when rowScrollMode="unsafe-full-row"', async () => {
     const items = Array.from({ length: 20 }, (_, index) => `item-${index}`);
     const App = defineComponent({
       name: "VirtualListWithUnsafeOverlay",
@@ -2150,12 +2410,12 @@ describe("TVirtualList", () => {
     await nextTick();
     await nextTick();
 
-    expect(rowText({ terminal: app.terminal } as any, 0)).toContain("BADGE");
-    expect(rowText({ terminal: app.terminal } as any, 1)).not.toContain("BADGE");
+    expect(rowText({ terminal: app.terminal } as any, 0)).not.toContain("BADGE");
+    expect(rowText({ terminal: app.terminal } as any, 1)).toContain("BADGE");
     app.dispose();
   });
 
-  it("keeps higher-plane overlay stable while default plane unsafe row-scrolls", async () => {
+  it("keeps higher-plane overlay stable during viewport wheel repaint", async () => {
     const items = Array.from({ length: 20 }, (_, index) => `item-${index}`);
     const App = defineComponent({
       name: "VirtualListWithHigherPlaneOverlay",
@@ -2195,12 +2455,7 @@ describe("TVirtualList", () => {
     await nextTick();
 
     off();
-    expect(commits).toEqual([
-      {
-        dirtyRows: [0, 1, 3],
-        scrollOperations: [{ startY: 2, endY: 4, delta: 1 }],
-      },
-    ]);
+    expect(commits).toEqual([{ dirtyRows: [0, 1, 2, 3], scrollOperations: null }]);
     expect(rowText({ terminal: app.terminal } as any, 1)).toMatch(/^BADGE/);
     expect(rowText({ terminal: app.terminal } as any, 0)).toBe("item-1");
     expect(rowText({ terminal: app.terminal } as any, 3)).toBe("item-4");
@@ -2247,7 +2502,7 @@ describe("TVirtualList", () => {
     app.dispose();
   });
 
-  it("repaints viewport when itemVersion changes with pending exposed scroll rows", async () => {
+  it("repaints viewport when itemVersion changes with pending wheel rows", async () => {
     const previousRaf = globalThis.requestAnimationFrame;
     const previousCancel = globalThis.cancelAnimationFrame;
     const callbacks = new Map<number, FrameRequestCallback>();
@@ -2337,7 +2592,7 @@ describe("TVirtualList", () => {
     }
   });
 
-  it("repaints viewport when style changes with pending exposed scroll rows", async () => {
+  it("repaints viewport when style changes with pending wheel rows", async () => {
     const previousRaf = globalThis.requestAnimationFrame;
     const previousCancel = globalThis.cancelAnimationFrame;
     const callbacks = new Map<number, FrameRequestCallback>();
@@ -2519,7 +2774,7 @@ describe("TVirtualList", () => {
     }
   });
 
-  it("active style follows item after rowScrollMode unsafe row-scroll shift", async () => {
+  it("active style follows item after viewport wheel repaint", async () => {
     const items = Array.from({ length: 20 }, (_, index) => `item-${index}`);
     const app = createTerminalApp({
       cols: 12,
@@ -2545,7 +2800,7 @@ describe("TVirtualList", () => {
     expect(app.terminal.getCell(0, 0).style.inverse).toBe(true);
     expect(app.terminal.getCell(0, 1).style.inverse).not.toBe(true);
 
-    // Wheel scroll down by 1 — active stays at item 0 but scrolls out of view
+    // Wheel scroll down by 1: active stays at item 0 but scrolls out of view.
     app.events.dispatch({ type: "wheel", cellX: 0, cellY: 0, deltaY: 100, time: Date.now() });
     await nextTick();
     await nextTick();


### PR DESCRIPTION
## Summary

- **Add controlled `scrollTop` prop** with `update:scrollTop` event, allowing parent components to drive the viewport scroll position externally. When `scrollTop` is bound, the component defers internal scroll state to the prop and emits updates back to the parent.

- **Migrate wheel scroll scheduling from `scheduler.queueFrameTask` to `createFrameMailbox`**, aligning TVirtualList's wheel burst handling with TList. This enables `droppedUpdates` metrics instead of `coalescedFrameTasks`, giving more accurate frame-level observability.

- **Remove exposed-row row-scroll fast path** (`unsafeScrollPlaneRows` / `scrollOperations`). All wheel scroll now uses viewport repaint (`markDirtyRows(viewportRows)`), which is simpler and avoids the correctness pitfalls of shifting plane rows. The `rowScrollMode` prop is preserved as an experimental switch but currently has no effect on the wheel path.

- **Cancel pending wheel on hide, clip, unmount, and controlled scrollTop change** — prevents stale wheel frames from overwriting a new controlled position or running against a hidden/clipped viewport.

- **Update docs and generated API** to reflect the new `scrollTop` prop, `update:scrollTop` event, and the revised scroll behavior description.

## Test plan

- [x] All 59 TVirtualList tests pass (including 4 new tests)
- [x] New: pending wheel dropped when unmounted before RAF
- [x] New: pending wheel cancelled when hidden (v-show) before RAF
- [x] New: pending wheel cancelled when fully clipped before RAF
- [x] New: controlled scrollTop change cancels pending wheel, preventing stale overwrite
- [x] Full test suite passes (all vitest files green)
