### PR TITLE
perf(dom-renderer): add plain-text fast path for unstyled rows

### DIFF
--- a/src/renderer/dom/dom-renderer.ts
+++ b/src/renderer/dom/dom-renderer.ts
@@ -325,6 +325,10 @@ function isTransparentBlankRow(segments: readonly RowSegment[]): boolean {
   );
 }
 
+function isPlainTextRow(segments: readonly RowSegment[]): boolean {
+  return segments.length === 1 && !segments[0]!.wide && isPlainStyle(segments[0]!.style);
+}
+
 function renderRow(
   terminal: Terminal,
   metrics: CellMetrics,
@@ -343,6 +347,17 @@ function renderRow(
 
   if (isTransparentBlankRow(segments)) {
     lineEl.replaceChildren();
+    return;
+  }
+
+  if (isPlainTextRow(segments)) {
+    const text = segments[0]!.text;
+    const firstChild = lineEl.firstChild;
+    if (lineEl.childNodes.length === 1 && firstChild?.nodeType === Node.TEXT_NODE) {
+      firstChild.nodeValue = text;
+    } else {
+      lineEl.textContent = text;
+    }
     return;
   }
 

--- a/test/dom-renderer.test.ts
+++ b/test/dom-renderer.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { createDomRenderer, createTerminal } from "../src/index.js";
+
+function setup(cols = 8, rows = 1) {
+  const terminal = createTerminal({ cols, rows });
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const renderer = createDomRenderer(terminal, container);
+  return { terminal, container, renderer };
+}
+
+function lineEl(container: HTMLElement, y = 0): HTMLElement {
+  const layer = container.querySelector('[data-vt-plane="default"]');
+  const line = layer?.children[0]?.children[y] as HTMLElement | undefined;
+  expect(line).toBeDefined();
+  return line!;
+}
+
+describe("DomRenderer row rendering", () => {
+  it("renders plain rows as a text node", () => {
+    const { terminal, container, renderer } = setup();
+
+    try {
+      terminal.write("hello", { x: 0, y: 0 });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const line = lineEl(container);
+      expect(line.childNodes).toHaveLength(1);
+      expect(line.firstChild?.nodeType).toBe(Node.TEXT_NODE);
+      expect(line.querySelector("span")).toBeNull();
+      expect(line.textContent).toBe("hello   ");
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("keeps styled rows on the span path", () => {
+    const { terminal, container, renderer } = setup();
+
+    try {
+      terminal.write("red", { x: 0, y: 0, style: { fg: "red" } });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const line = lineEl(container);
+      const span = Array.from(line.querySelectorAll("span")).find((el) =>
+        el.textContent?.includes("red"),
+      ) as HTMLElement | undefined;
+      expect(line.firstChild?.nodeName).toBe("SPAN");
+      expect(span).toBeDefined();
+      expect(span!.style.color).toBe("var(--vt-color-red)");
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("keeps wide rows on the span path", () => {
+    const { terminal, container, renderer } = setup();
+
+    try {
+      terminal.write("中", { x: 0, y: 0 });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const line = lineEl(container);
+      expect(line.firstChild?.nodeName).toBe("SPAN");
+      expect(line.querySelector("span")?.textContent).toContain("中");
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("clears styled spans when a row becomes plain again", () => {
+    const { terminal, container, renderer } = setup();
+
+    try {
+      terminal.fill(0, 0, 8, 1, "A");
+      terminal.commit({ planes: ["default"], sync: true });
+      expect(lineEl(container).firstChild?.nodeType).toBe(Node.TEXT_NODE);
+
+      terminal.fill(0, 0, 8, 1, "B", { fg: "red" });
+      terminal.commit({ planes: ["default"], sync: true });
+      expect(lineEl(container).firstChild?.nodeName).toBe("SPAN");
+
+      terminal.fill(0, 0, 8, 1, "C");
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const line = lineEl(container);
+      expect(line.childNodes).toHaveLength(1);
+      expect(line.firstChild?.nodeType).toBe(Node.TEXT_NODE);
+      expect(line.querySelector("span")).toBeNull();
+      expect(line.textContent).toBe("CCCCCCCC");
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("skips DOM writes when the row cache matches", () => {
+    const { terminal, container, renderer } = setup();
+
+    try {
+      terminal.fill(0, 0, 8, 1, "A");
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const line = lineEl(container);
+      const textNode = line.firstChild!;
+      let nodeValue = textNode.nodeValue;
+      let nodeValueWrites = 0;
+      Object.defineProperty(textNode, "nodeValue", {
+        configurable: true,
+        get: () => nodeValue,
+        set: (next: string | null) => {
+          nodeValueWrites++;
+          nodeValue = next;
+        },
+      });
+
+      terminal.fill(0, 0, 8, 1, "A");
+      terminal.commit({ planes: ["default"], sync: true });
+
+      expect(line.firstChild).toBe(textNode);
+      expect(nodeValueWrites).toBe(0);
+      expect(line.textContent).toBe("AAAAAAAA");
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

When a row contains a single segment with no style and no wide characters, render it as a bare text node instead of creating `<span>` elements. This avoids unnecessary DOM node creation and improves rendering performance for the common case of plain text lines.

## Changes

- Add `isPlainTextRow()` check in `renderRow` to detect single-segment, unstyled, non-wide rows
- Reuse existing text node via `nodeValue` update when the line already has a single text child
- Fall back to `textContent` assignment when the previous DOM structure doesn't match

## Tests

- Plain rows render as a single text node (no `<span>`)
- Styled rows stay on the span path
- Wide-character rows stay on the span path
- Transitioning from styled → plain clears spans and replaces with a text node
- Row cache match skips DOM writes entirely