### PR TITLE
perf(dom-renderer): add single-styled-row fast path

### DIFF
--- a/src/renderer/dom/dom-renderer.ts
+++ b/src/renderer/dom/dom-renderer.ts
@@ -329,6 +329,19 @@ function isPlainTextRow(segments: readonly RowSegment[]): boolean {
   return segments.length === 1 && !segments[0]!.wide && isPlainStyle(segments[0]!.style);
 }
 
+function isSingleStyledTextRow(segments: readonly RowSegment[]): boolean {
+  return (
+    segments.length === 1 &&
+    !segments[0]!.wide &&
+    !segments[0]!.style.href &&
+    !isPlainStyle(segments[0]!.style)
+  );
+}
+
+function resetSpanStyle(span: HTMLSpanElement): void {
+  span.removeAttribute("style");
+}
+
 function renderRow(
   terminal: Terminal,
   metrics: CellMetrics,
@@ -358,6 +371,30 @@ function renderRow(
     } else {
       lineEl.textContent = text;
     }
+    return;
+  }
+
+  if (isSingleStyledTextRow(segments)) {
+    const seg = segments[0]!;
+    const firstChild = lineEl.firstChild;
+    let span: HTMLSpanElement;
+
+    if (
+      lineEl.childNodes.length === 1 &&
+      firstChild instanceof HTMLSpanElement &&
+      firstChild.dataset.vtFastRow === "styled"
+    ) {
+      span = firstChild;
+    } else {
+      span = document.createElement("span");
+      span.dataset.vtFastRow = "styled";
+      lineEl.replaceChildren(span);
+    }
+
+    span.textContent = seg.text;
+    resetSpanStyle(span);
+    span.style.cssText = `display:inline-block;width:${seg.cols * metrics.cellWidth}px;height:${metrics.cellHeight}px;overflow:hidden;white-space:pre;vertical-align:top`;
+    applyStyle(span, seg.style);
     return;
   }
 

--- a/test/dom-renderer.test.ts
+++ b/test/dom-renderer.test.ts
@@ -55,6 +55,145 @@ describe("DomRenderer row rendering", () => {
     }
   });
 
+  it("renders single styled rows as one span", () => {
+    const { terminal, container, renderer } = setup(3);
+
+    try {
+      terminal.write("red", { x: 0, y: 0, style: { fg: "red" } });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const line = lineEl(container);
+      expect(line.childNodes).toHaveLength(1);
+      expect(line.firstChild).toBeInstanceOf(HTMLSpanElement);
+      expect((line.firstChild as HTMLSpanElement).textContent).toBe("red");
+      expect((line.firstChild as HTMLSpanElement).dataset.vtFastRow).toBe("styled");
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("reuses the single styled row span", () => {
+    const { terminal, container, renderer } = setup(3);
+
+    try {
+      terminal.fill(0, 0, 3, 1, "A", { fg: "red" });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const span = lineEl(container).firstChild;
+
+      terminal.fill(0, 0, 3, 1, "B", { fg: "blue" });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      expect(lineEl(container).firstChild).toBe(span);
+      expect(lineEl(container).textContent).toBe("BBB");
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("resets reused single styled row span styles", () => {
+    const { terminal, container, renderer } = setup(3);
+
+    try {
+      terminal.fill(0, 0, 3, 1, "A", { fg: "red", underline: true });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const span = lineEl(container).firstChild as HTMLSpanElement;
+      expect(span.style.textDecoration).toBe("underline");
+
+      terminal.fill(0, 0, 3, 1, "B", { fg: "blue" });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      expect(lineEl(container).firstChild).toBe(span);
+      expect(span.style.color).toBe("var(--vt-color-blue)");
+      expect(span.style.textDecoration).toBe("");
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("renders styled rows as plain text when they become plain", () => {
+    const { terminal, container, renderer } = setup(3);
+
+    try {
+      terminal.fill(0, 0, 3, 1, "A", { fg: "red" });
+      terminal.commit({ planes: ["default"], sync: true });
+      expect(lineEl(container).firstChild).toBeInstanceOf(HTMLSpanElement);
+
+      terminal.fill(0, 0, 3, 1, "B");
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const line = lineEl(container);
+      expect(line.childNodes).toHaveLength(1);
+      expect(line.firstChild?.nodeType).toBe(Node.TEXT_NODE);
+      expect(line.querySelector("span")).toBeNull();
+      expect(line.textContent).toBe("BBB");
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("replaces plain text nodes with one span when rows become styled", () => {
+    const { terminal, container, renderer } = setup(3);
+
+    try {
+      terminal.fill(0, 0, 3, 1, "A");
+      terminal.commit({ planes: ["default"], sync: true });
+      expect(lineEl(container).firstChild?.nodeType).toBe(Node.TEXT_NODE);
+
+      terminal.fill(0, 0, 3, 1, "B", { fg: "red" });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const line = lineEl(container);
+      expect(line.childNodes).toHaveLength(1);
+      expect(line.firstChild).toBeInstanceOf(HTMLSpanElement);
+      expect((line.firstChild as HTMLSpanElement).dataset.vtFastRow).toBe("styled");
+      expect(line.textContent).toBe("BBB");
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("keeps href rows on the fragment span path", () => {
+    const { terminal, container, renderer } = setup(3);
+
+    try {
+      terminal.write("url", { x: 0, y: 0, style: { href: "https://example.com" } });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const line = lineEl(container);
+      expect(line.childNodes).toHaveLength(1);
+      expect(line.firstChild).toBeInstanceOf(HTMLSpanElement);
+      expect((line.firstChild as HTMLSpanElement).dataset.vtFastRow).toBeUndefined();
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("keeps wide styled rows on the fragment span path", () => {
+    const { terminal, container, renderer } = setup(2);
+
+    try {
+      terminal.write("中", { x: 0, y: 0, style: { fg: "red" } });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const line = lineEl(container);
+      expect(line.childNodes).toHaveLength(1);
+      expect(line.firstChild).toBeInstanceOf(HTMLSpanElement);
+      expect((line.firstChild as HTMLSpanElement).dataset.vtFastRow).toBeUndefined();
+      expect(line.textContent).toContain("中");
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
   it("keeps wide rows on the span path", () => {
     const { terminal, container, renderer } = setup();
 


### PR DESCRIPTION
## Summary

Extends the existing plain-text fast path to also handle rows with a single styled segment (non-plain style, no wide chars, no hrefs). This avoids `DocumentFragment` creation and per-segment span allocation for the common case of a monochrome colored line.

## Changes

- Add `isSingleStyledTextRow()` detection for rows with one non-plain, non-wide, non-href segment
- Reuse span element via `data-vt-fast-row="styled"` marker (mirrors the plain-text fast row pattern)
- Reset stale inline styles before re-applying on reuse via `resetSpanStyle()`
- Fall through to fragment path for href/wide segments
- Add 7 tests covering styled span creation, reuse, style reset, plain↔styled transitions, and href/wide exclusions

## Test plan

- [x] `vitest run test/dom-renderer.test.ts` — 12/12 tests pass
