### PR TITLE
perf(dom-renderer): add multi-segment span reuse fast path

### DIFF
--- a/src/renderer/dom/dom-renderer.ts
+++ b/src/renderer/dom/dom-renderer.ts
@@ -338,8 +338,38 @@ function isSingleStyledTextRow(segments: readonly RowSegment[]): boolean {
   );
 }
 
+function canReuseSegmentSpans(segments: readonly RowSegment[]): boolean {
+  return segments.length > 1 && segments.every((segment) => !segment.wide && !segment.style.href);
+}
+
 function resetSpanStyle(span: HTMLSpanElement): void {
   span.removeAttribute("style");
+}
+
+function tryUpdateSegmentSpans(
+  lineEl: HTMLElement,
+  segments: readonly RowSegment[],
+  metrics: CellMetrics,
+): boolean {
+  if (lineEl.childNodes.length !== segments.length) return false;
+
+  for (let i = 0; i < segments.length; i++) {
+    const node = lineEl.childNodes[i];
+    if (!(node instanceof HTMLSpanElement)) return false;
+    if (node.dataset.vtFastRow !== "segment") return false;
+    if (node.dataset.vtSegmentIndex !== String(i)) return false;
+  }
+
+  for (let i = 0; i < segments.length; i++) {
+    const span = lineEl.childNodes[i] as HTMLSpanElement;
+    const seg = segments[i]!;
+    span.textContent = seg.text;
+    resetSpanStyle(span);
+    span.style.cssText = `display:inline-block;width:${seg.cols * metrics.cellWidth}px;height:${metrics.cellHeight}px;overflow:hidden;white-space:pre;vertical-align:top`;
+    applyStyle(span, seg.style);
+  }
+
+  return true;
 }
 
 function renderRow(
@@ -398,11 +428,19 @@ function renderRow(
     return;
   }
 
+  const canReuseSpans = canReuseSegmentSpans(segments);
+  if (canReuseSpans && tryUpdateSegmentSpans(lineEl, segments, metrics)) return;
+
   // Use DocumentFragment to batch DOM operations and avoid layout thrashing
   const fragment = document.createDocumentFragment();
 
-  for (const seg of segments) {
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i]!;
     const span = document.createElement("span");
+    if (canReuseSpans) {
+      span.dataset.vtFastRow = "segment";
+      span.dataset.vtSegmentIndex = String(i);
+    }
     if (seg.wide && wideScaleX > 1.01) {
       const inner = document.createElement("span");
       inner.textContent = seg.text;

--- a/test/dom-renderer.test.ts
+++ b/test/dom-renderer.test.ts
@@ -115,6 +115,88 @@ describe("DomRenderer row rendering", () => {
     }
   });
 
+  it("reuses multi-segment row spans", () => {
+    const { terminal, container, renderer } = setup(4);
+
+    try {
+      terminal.fill(0, 0, 2, 1, "A", { fg: "red" });
+      terminal.fill(2, 0, 2, 1, "B", { fg: "blue" });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const line = lineEl(container);
+      const firstSpan = line.childNodes[0];
+      const secondSpan = line.childNodes[1];
+      expect(line.childNodes).toHaveLength(2);
+      expect((firstSpan as HTMLSpanElement).dataset.vtFastRow).toBe("segment");
+      expect((secondSpan as HTMLSpanElement).dataset.vtFastRow).toBe("segment");
+
+      terminal.fill(0, 0, 2, 1, "C", { fg: "red" });
+      terminal.fill(2, 0, 2, 1, "D", { fg: "blue" });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      expect(line.childNodes).toHaveLength(2);
+      expect(line.childNodes[0]).toBe(firstSpan);
+      expect(line.childNodes[1]).toBe(secondSpan);
+      expect(line.textContent).toBe("CCDD");
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("resets reused multi-segment row span styles", () => {
+    const { terminal, container, renderer } = setup(4);
+
+    try {
+      terminal.fill(0, 0, 2, 1, "A", { fg: "red", underline: true });
+      terminal.fill(2, 0, 2, 1, "B", { fg: "blue" });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const line = lineEl(container);
+      const span = line.childNodes[0] as HTMLSpanElement;
+      expect(span.style.textDecoration).toBe("underline");
+
+      terminal.fill(0, 0, 2, 1, "C", { fg: "blue" });
+      terminal.fill(2, 0, 2, 1, "D", { fg: "red" });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      expect(line.childNodes[0]).toBe(span);
+      expect(span.style.color).toBe("var(--vt-color-blue)");
+      expect(span.style.textDecoration).toBe("");
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("replaces multi-segment row spans when the segment count changes", () => {
+    const { terminal, container, renderer } = setup(6);
+
+    try {
+      terminal.fill(0, 0, 3, 1, "A", { fg: "red" });
+      terminal.fill(3, 0, 3, 1, "B", { fg: "blue" });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const line = lineEl(container);
+      const firstSpan = line.childNodes[0];
+      const secondSpan = line.childNodes[1];
+      expect(line.childNodes).toHaveLength(2);
+
+      terminal.fill(0, 0, 2, 1, "C", { fg: "red" });
+      terminal.fill(2, 0, 2, 1, "D", { fg: "blue" });
+      terminal.fill(4, 0, 2, 1, "E", { fg: "green" });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      expect(line.childNodes).toHaveLength(3);
+      expect(line.childNodes[0]).not.toBe(firstSpan);
+      expect(line.childNodes[1]).not.toBe(secondSpan);
+      expect(line.textContent).toBe("CCDDEE");
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
   it("renders styled rows as plain text when they become plain", () => {
     const { terminal, container, renderer } = setup(3);
 
@@ -153,6 +235,41 @@ describe("DomRenderer row rendering", () => {
       expect(line.firstChild).toBeInstanceOf(HTMLSpanElement);
       expect((line.firstChild as HTMLSpanElement).dataset.vtFastRow).toBe("styled");
       expect(line.textContent).toBe("BBB");
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("does not mark href multi-segment rows for reuse", () => {
+    const { terminal, container, renderer } = setup(4);
+
+    try {
+      terminal.fill(0, 0, 2, 1, "A", { href: "https://example.com" });
+      terminal.fill(2, 0, 2, 1, "B", { fg: "blue" });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const line = lineEl(container);
+      expect(line.childNodes).toHaveLength(2);
+      for (const child of Array.from(line.children) as HTMLSpanElement[])
+        expect(child.dataset.vtFastRow).toBeUndefined();
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("does not mark wide multi-segment rows for reuse", () => {
+    const { terminal, container, renderer } = setup(4);
+
+    try {
+      terminal.write("中", { x: 0, y: 0, style: { fg: "red" } });
+      terminal.fill(2, 0, 2, 1, "B", { fg: "blue" });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const line = lineEl(container);
+      expect(line.textContent).toContain("中");
+      expect(line.querySelector('[data-vt-fast-row="segment"]')).toBeNull();
     } finally {
       renderer.dispose();
       container.remove();


### PR DESCRIPTION
## Summary

Reuse existing span DOM nodes when a multi-segment row is re-rendered with the same segment count and no wide/href segments. This avoids destroying and recreating DOM elements on every repaint, reducing GC pressure and layout thrashing for common styled-row updates.

## Changes

- Add `canReuseSegmentSpans()` guard that excludes wide and href segments
- Add `tryUpdateSegmentSpans()` for in-place text/style update of existing spans
- Mark reusable spans with `data-vt-fast-row="segment"` and `data-vt-segment-index`
- Fall back to the existing DocumentFragment rebuild when segment count changes
- Add 5 new tests covering: reuse, style reset, count change, href exclusion, wide exclusion

## Test plan

- [x] All 17 dom-renderer tests pass
- [ ] Manual verification with browser examples (optional)