### PR TITLE
feat(dom-renderer): add row-level render stats to debug API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,8 @@ export type {
   DomRendererFlushSample,
   DomRendererFlushStats,
   DomRendererOptions,
+  DomRendererRowRenderDebugStats,
+  DomRendererRowRenderStats,
   DomRendererSyncFlushDecision,
   DomRendererSyncFlushStats,
   TerminalRendererLike,

--- a/src/renderer/dom/dom-renderer.ts
+++ b/src/renderer/dom/dom-renderer.ts
@@ -38,9 +38,29 @@ export type DomRendererFlushStats = Readonly<{
   last: DomRendererFlushSample | null;
 }>;
 
+export type DomRendererRowRenderStats = Readonly<{
+  rows: number;
+  cacheHits: number;
+  transparentBlankRows: number;
+  plainTextRows: number;
+  singleStyledRows: number;
+  segmentReuseRows: number;
+  fragmentRows: number;
+  spansCreated: number;
+  spansReused: number;
+  textNodeUpdates: number;
+  replaceChildren: number;
+}>;
+
+export type DomRendererRowRenderDebugStats = Readonly<{
+  total: DomRendererRowRenderStats;
+  lastFlush: DomRendererRowRenderStats | null;
+}>;
+
 export type DomRendererDebugStats = Readonly<{
   syncFlush: DomRendererSyncFlushStats;
   flush: DomRendererFlushStats;
+  rowRender: DomRendererRowRenderDebugStats;
 }>;
 
 export interface DomRenderer {
@@ -100,6 +120,44 @@ const DEFAULT_SYNC_FLUSH_MAX_ROWS = 32;
 const DEFAULT_SYNC_FLUSH_CELL_BUDGET = 4096;
 
 const styleKeyCache = new WeakMap<object, string>();
+
+type RowRenderMutableStats = {
+  -readonly [K in keyof DomRendererRowRenderStats]: DomRendererRowRenderStats[K];
+};
+
+function createEmptyRowStats(): RowRenderMutableStats {
+  return {
+    rows: 0,
+    cacheHits: 0,
+    transparentBlankRows: 0,
+    plainTextRows: 0,
+    singleStyledRows: 0,
+    segmentReuseRows: 0,
+    fragmentRows: 0,
+    spansCreated: 0,
+    spansReused: 0,
+    textNodeUpdates: 0,
+    replaceChildren: 0,
+  };
+}
+
+function freezeRowStats(stats: RowRenderMutableStats): DomRendererRowRenderStats {
+  return Object.freeze({ ...stats });
+}
+
+function addRowStats(target: RowRenderMutableStats, source: RowRenderMutableStats): void {
+  target.rows += source.rows;
+  target.cacheHits += source.cacheHits;
+  target.transparentBlankRows += source.transparentBlankRows;
+  target.plainTextRows += source.plainTextRows;
+  target.singleStyledRows += source.singleStyledRows;
+  target.segmentReuseRows += source.segmentReuseRows;
+  target.fragmentRows += source.fragmentRows;
+  target.spansCreated += source.spansCreated;
+  target.spansReused += source.spansReused;
+  target.textNodeUpdates += source.textNodeUpdates;
+  target.replaceChildren += source.replaceChildren;
+}
 
 function styleKey(style: Style): string {
   const cached = styleKeyCache.get(style as any);
@@ -378,22 +436,31 @@ function renderRow(
   wideScaleX: number,
   y: number,
   lineEl: HTMLElement,
+  stats: RowRenderMutableStats,
 ): void {
+  stats.rows++;
   const segments = computeRowSegments(terminal, y);
   const newKey = segmentsToKey(segments);
 
   // Skip DOM update if content hasn't changed
   const cachedKey = rowCache.get(lineEl);
-  if (cachedKey === newKey) return;
+  if (cachedKey === newKey) {
+    stats.cacheHits++;
+    return;
+  }
 
   rowCache.set(lineEl, newKey);
 
   if (isTransparentBlankRow(segments)) {
+    stats.transparentBlankRows++;
+    stats.replaceChildren++;
     lineEl.replaceChildren();
     return;
   }
 
   if (isPlainTextRow(segments)) {
+    stats.plainTextRows++;
+    stats.textNodeUpdates++;
     const text = segments[0]!.text;
     const firstChild = lineEl.firstChild;
     if (lineEl.childNodes.length === 1 && firstChild?.nodeType === Node.TEXT_NODE) {
@@ -415,11 +482,15 @@ function renderRow(
       firstChild.dataset.vtFastRow === "styled"
     ) {
       span = firstChild;
+      stats.spansReused++;
     } else {
       span = document.createElement("span");
       span.dataset.vtFastRow = "styled";
+      stats.spansCreated++;
+      stats.replaceChildren++;
       lineEl.replaceChildren(span);
     }
+    stats.singleStyledRows++;
 
     span.textContent = seg.text;
     resetSpanStyle(span);
@@ -429,7 +500,15 @@ function renderRow(
   }
 
   const canReuseSpans = canReuseSegmentSpans(segments);
-  if (canReuseSpans && tryUpdateSegmentSpans(lineEl, segments, metrics)) return;
+  if (canReuseSpans && tryUpdateSegmentSpans(lineEl, segments, metrics)) {
+    stats.segmentReuseRows++;
+    stats.spansReused += segments.length;
+    return;
+  }
+
+  stats.fragmentRows++;
+  stats.spansCreated += segments.length;
+  stats.replaceChildren++;
 
   // Use DocumentFragment to batch DOM operations and avoid layout thrashing
   const fragment = document.createDocumentFragment();
@@ -501,6 +580,8 @@ export function createDomRenderer(
   let lastSyncFlushDecision: DomRendererSyncFlushDecision | null = null;
   let domFlushCount = 0;
   let lastDomFlush: DomRendererFlushSample | null = null;
+  const rowRenderTotal = createEmptyRowStats();
+  let lastRowRenderStats: DomRendererRowRenderStats | null = null;
   const debugStats: DomRendererDebugStats = {
     get syncFlush() {
       return {
@@ -516,7 +597,19 @@ export function createDomRenderer(
         last: lastDomFlush,
       };
     },
+    get rowRender() {
+      return {
+        total: freezeRowStats(rowRenderTotal),
+        lastFlush: lastRowRenderStats,
+      };
+    },
   };
+
+  function recordRowRenderStats(stats: RowRenderMutableStats): void {
+    if (stats.rows === 0) return;
+    addRowStats(rowRenderTotal, stats);
+    lastRowRenderStats = freezeRowStats(stats);
+  }
 
   function applyPlaneOffset(plane: TerminalRenderPlane, offsetPx: number): void {
     const layer = planeLayers.get(plane);
@@ -628,12 +721,14 @@ export function createDomRenderer(
     wideScaleX = wideW > 0 ? Math.max(1, Math.min(2, (metrics.cellWidth * 2) / wideW)) : 1;
     rebuildLines();
     const size = terminal.size();
+    const rowStats = createEmptyRowStats();
     for (const plane of TERMINAL_RENDER_PLANES) {
       const layer = planeLayers.get(plane);
       if (!layer) continue;
       for (let y = 0; y < size.rows; y++)
-        renderRow(layer.terminal, metrics, wideScaleX, y, layer.lines[y]!);
+        renderRow(layer.terminal, metrics, wideScaleX, y, layer.lines[y]!, rowStats);
     }
+    recordRowRenderStats(rowStats);
   }
 
   interface FlushScope {
@@ -917,6 +1012,7 @@ export function createDomRenderer(
     const startedAt = nowMs();
     const planesToFlush = scope?.planes ?? TERMINAL_RENDER_PLANES;
     let flushedRows = 0;
+    const rowStats = createEmptyRowStats();
 
     for (const plane of planesToFlush) {
       const layer = planeLayers.get(plane);
@@ -926,7 +1022,7 @@ export function createDomRenderer(
       const flushRow = (y: number): void => {
         if (!rows.has(y)) return;
         const line = layer.lines[y];
-        if (line) renderRow(layer.terminal, metrics, wideScaleX, y, line);
+        if (line) renderRow(layer.terminal, metrics, wideScaleX, y, line, rowStats);
         deletePendingRow(plane, rows, y);
         flushedRows++;
       };
@@ -941,6 +1037,7 @@ export function createDomRenderer(
     }
 
     if (flushedRows > 0) {
+      recordRowRenderStats(rowStats);
       domFlushCount++;
       lastDomFlush = {
         mode: options?.mode ?? "deferred",

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -10,6 +10,8 @@ export type {
   DomRendererFlushSample,
   DomRendererFlushStats,
   DomRendererOptions,
+  DomRendererRowRenderDebugStats,
+  DomRendererRowRenderStats,
   DomRendererSyncFlushDecision,
   DomRendererSyncFlushStats,
 } from "./dom/dom-renderer.js";

--- a/test/dom-renderer.test.ts
+++ b/test/dom-renderer.test.ts
@@ -16,7 +16,27 @@ function lineEl(container: HTMLElement, y = 0): HTMLElement {
   return line!;
 }
 
+function lastRowStats(renderer: ReturnType<typeof createDomRenderer>) {
+  const stats = renderer.debugStats.rowRender.lastFlush;
+  expect(stats).not.toBeNull();
+  return stats!;
+}
+
 describe("DomRenderer row rendering", () => {
+  it("records row stats during refresh", () => {
+    const { container, renderer } = setup(4, 2);
+
+    try {
+      const stats = lastRowStats(renderer);
+      expect(stats.rows).toBeGreaterThan(0);
+      expect(stats.transparentBlankRows).toBe(stats.rows);
+      expect(stats.replaceChildren).toBe(stats.rows);
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
   it("renders plain rows as a text node", () => {
     const { terminal, container, renderer } = setup();
 
@@ -29,6 +49,12 @@ describe("DomRenderer row rendering", () => {
       expect(line.firstChild?.nodeType).toBe(Node.TEXT_NODE);
       expect(line.querySelector("span")).toBeNull();
       expect(line.textContent).toBe("hello   ");
+      expect(lastRowStats(renderer)).toMatchObject({
+        rows: 1,
+        plainTextRows: 1,
+        textNodeUpdates: 1,
+        fragmentRows: 0,
+      });
     } finally {
       renderer.dispose();
       container.remove();
@@ -67,6 +93,12 @@ describe("DomRenderer row rendering", () => {
       expect(line.firstChild).toBeInstanceOf(HTMLSpanElement);
       expect((line.firstChild as HTMLSpanElement).textContent).toBe("red");
       expect((line.firstChild as HTMLSpanElement).dataset.vtFastRow).toBe("styled");
+      expect(lastRowStats(renderer)).toMatchObject({
+        rows: 1,
+        singleStyledRows: 1,
+        spansCreated: 1,
+        replaceChildren: 1,
+      });
     } finally {
       renderer.dispose();
       container.remove();
@@ -138,6 +170,12 @@ describe("DomRenderer row rendering", () => {
       expect(line.childNodes[0]).toBe(firstSpan);
       expect(line.childNodes[1]).toBe(secondSpan);
       expect(line.textContent).toBe("CCDD");
+      expect(lastRowStats(renderer)).toMatchObject({
+        rows: 1,
+        segmentReuseRows: 1,
+        fragmentRows: 0,
+        spansReused: 2,
+      });
     } finally {
       renderer.dispose();
       container.remove();
@@ -191,6 +229,13 @@ describe("DomRenderer row rendering", () => {
       expect(line.childNodes[0]).not.toBe(firstSpan);
       expect(line.childNodes[1]).not.toBe(secondSpan);
       expect(line.textContent).toBe("CCDDEE");
+      expect(lastRowStats(renderer)).toMatchObject({
+        rows: 1,
+        segmentReuseRows: 0,
+        fragmentRows: 1,
+        spansCreated: 3,
+        replaceChildren: 1,
+      });
     } finally {
       renderer.dispose();
       container.remove();
@@ -287,6 +332,11 @@ describe("DomRenderer row rendering", () => {
       expect(line.childNodes).toHaveLength(1);
       expect(line.firstChild).toBeInstanceOf(HTMLSpanElement);
       expect((line.firstChild as HTMLSpanElement).dataset.vtFastRow).toBeUndefined();
+      expect(lastRowStats(renderer)).toMatchObject({
+        rows: 1,
+        fragmentRows: 1,
+        spansCreated: 1,
+      });
     } finally {
       renderer.dispose();
       container.remove();
@@ -305,6 +355,11 @@ describe("DomRenderer row rendering", () => {
       expect(line.firstChild).toBeInstanceOf(HTMLSpanElement);
       expect((line.firstChild as HTMLSpanElement).dataset.vtFastRow).toBeUndefined();
       expect(line.textContent).toContain("中");
+      expect(lastRowStats(renderer)).toMatchObject({
+        rows: 1,
+        fragmentRows: 1,
+        spansCreated: 1,
+      });
     } finally {
       renderer.dispose();
       container.remove();
@@ -379,6 +434,16 @@ describe("DomRenderer row rendering", () => {
       expect(line.firstChild).toBe(textNode);
       expect(nodeValueWrites).toBe(0);
       expect(line.textContent).toBe("AAAAAAAA");
+      expect(lastRowStats(renderer)).toMatchObject({
+        rows: 1,
+        cacheHits: 1,
+        plainTextRows: 0,
+        singleStyledRows: 0,
+        segmentReuseRows: 0,
+        fragmentRows: 0,
+        textNodeUpdates: 0,
+        replaceChildren: 0,
+      });
     } finally {
       renderer.dispose();
       container.remove();


### PR DESCRIPTION
## Summary

Add row-level render statistics to the DomRenderer debug API, making it easy to inspect which rendering fast paths are being hit and how many DOM operations are occurring.

## Changes

- **New types**: `DomRendererRowRenderStats` and `DomRendererRowRenderDebugStats` tracking per-row rendering details:
  - `rows` — total rows rendered
  - `cacheHits` — rows skipped due to unchanged cache key
  - `transparentBlankRows`, `plainTextRows`, `singleStyledRows`, `segmentReuseRows`, `fragmentRows` — fast-path breakdown
  - `spansCreated`, `spansReused` — span element creation vs reuse
  - `textNodeUpdates`, `replaceChildren` — DOM mutation counts

- **Debug API**: `renderer.debugStats.rowRender` exposes `total` (cumulative) and `lastFlush` (most recent flush) snapshots

- **Exports**: New types exported from `src/renderer/index.ts` and `src/index.ts`

- **Tests**: Assertions added to each `dom-renderer.test.ts` case verifying correct stats for:
  - Transparent blank rows (refresh)
  - Plain text rows
  - Single-styled rows
  - Segment reuse rows
  - Fragment fallback rows
  - Cache hit (unchanged row)

## Validation

- All 933 tests pass (97 files)
- Typecheck clean
- Lint clean (0 warnings, 0 errors)