### PR TITLE
perf(dom-renderer): optimize segmentsToKey cache key generation

### DIFF
--- a/src/renderer/dom/dom-renderer.ts
+++ b/src/renderer/dom/dom-renderer.ts
@@ -358,8 +358,23 @@ function nowMs(): number {
   return Date.now();
 }
 
-function segmentsToKey(segments: RowSegment[]): string {
-  return segments.map((s) => `${s.key}:${s.text}:${s.cols}:${s.wide}`).join("|");
+function segmentsToKey(segments: readonly RowSegment[]): string {
+  if (segments.length === 0) return "0";
+
+  if (segments.length === 1) {
+    const s = segments[0]!;
+    const plain = isPlainStyle(s.style);
+    if (!s.wide && plain) return `p:${s.text}:${s.cols}`;
+    if (!s.wide && !s.style.href && !plain) return `s:${s.key}:${s.text}:${s.cols}`;
+    return `1:${s.key}:${s.text}:${s.cols}:${s.wide ? 1 : 0}`;
+  }
+
+  let out = String(segments.length);
+  for (let i = 0; i < segments.length; i++) {
+    const s = segments[i]!;
+    out += `|${s.key}:${s.text}:${s.cols}:${s.wide ? 1 : 0}`;
+  }
+  return out;
 }
 
 function isPlainStyle(style: Style): boolean {

--- a/test/dom-renderer.test.ts
+++ b/test/dom-renderer.test.ts
@@ -449,4 +449,138 @@ describe("DomRenderer row rendering", () => {
       container.remove();
     }
   });
+
+  it("invalidates the plain row cache when text changes", () => {
+    const { terminal, container, renderer } = setup(4);
+
+    try {
+      terminal.fill(0, 0, 4, 1, "A");
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const line = lineEl(container);
+      const textNode = line.firstChild;
+
+      terminal.fill(0, 0, 4, 1, "B");
+      terminal.commit({ planes: ["default"], sync: true });
+
+      expect(line.firstChild).toBe(textNode);
+      expect(line.textContent).toBe("BBBB");
+      expect(lastRowStats(renderer)).toMatchObject({
+        rows: 1,
+        cacheHits: 0,
+        plainTextRows: 1,
+        textNodeUpdates: 1,
+      });
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("invalidates the single styled row cache when style changes", () => {
+    const { terminal, container, renderer } = setup(3);
+
+    try {
+      terminal.fill(0, 0, 3, 1, "A", { fg: "red" });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const span = lineEl(container).firstChild as HTMLSpanElement;
+
+      terminal.fill(0, 0, 3, 1, "A", { fg: "blue" });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      expect(lineEl(container).firstChild).toBe(span);
+      expect(span.style.color).toBe("var(--vt-color-blue)");
+      expect(lastRowStats(renderer)).toMatchObject({
+        rows: 1,
+        cacheHits: 0,
+        singleStyledRows: 1,
+        spansReused: 1,
+      });
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("skips single styled DOM writes when the row cache matches", () => {
+    const { terminal, container, renderer } = setup(3);
+
+    try {
+      terminal.fill(0, 0, 3, 1, "A", { fg: "red" });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const span = lineEl(container).firstChild;
+
+      terminal.fill(0, 0, 3, 1, "A", { fg: "red" });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      expect(lineEl(container).firstChild).toBe(span);
+      expect(lastRowStats(renderer)).toMatchObject({
+        rows: 1,
+        cacheHits: 1,
+        singleStyledRows: 0,
+        fragmentRows: 0,
+        replaceChildren: 0,
+      });
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("keeps multi-segment order in the row cache key", () => {
+    const { terminal, container, renderer } = setup(4);
+
+    try {
+      terminal.fill(0, 0, 2, 1, "A", { fg: "red" });
+      terminal.fill(2, 0, 2, 1, "B", { fg: "blue" });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const line = lineEl(container);
+      const firstSpan = line.childNodes[0] as HTMLSpanElement;
+      const secondSpan = line.childNodes[1] as HTMLSpanElement;
+
+      terminal.fill(0, 0, 2, 1, "A", { fg: "blue" });
+      terminal.fill(2, 0, 2, 1, "B", { fg: "red" });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      expect(line.childNodes[0]).toBe(firstSpan);
+      expect(line.childNodes[1]).toBe(secondSpan);
+      expect(firstSpan.style.color).toBe("var(--vt-color-blue)");
+      expect(secondSpan.style.color).toBe("var(--vt-color-red)");
+      expect(lastRowStats(renderer)).toMatchObject({
+        rows: 1,
+        cacheHits: 0,
+        segmentReuseRows: 1,
+      });
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("invalidates the row cache when a plain row becomes wide", () => {
+    const { terminal, container, renderer } = setup(2);
+
+    try {
+      terminal.fill(0, 0, 2, 1, "A");
+      terminal.commit({ planes: ["default"], sync: true });
+
+      terminal.write("中", { x: 0, y: 0 });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const line = lineEl(container);
+      expect(line.firstChild).toBeInstanceOf(HTMLSpanElement);
+      expect(line.textContent).toContain("中");
+      expect(lastRowStats(renderer)).toMatchObject({
+        rows: 1,
+        cacheHits: 0,
+        fragmentRows: 1,
+      });
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Optimize the `segmentsToKey` function in `dom-renderer.ts` to reduce string allocation overhead for cache key generation.

### Changes

- **Empty segment fast path**: return `"0"` immediately for empty arrays
- **Single plain segment**: use compact `p:text:cols` format (no key/wide needed)
- **Single styled segment (no href)**: use compact `s:key:text:cols` format
- **Single complex segment**: use `1:` prefix with numeric wide flag
- **Multi-segment**: use segment count prefix and numeric `0/1` wide encoding instead of boolean strings

### Tests Added

5 new test cases in `dom-renderer.test.ts`:
- Invalidates the plain row cache when text changes
- Invalidates the single styled row cache when style changes
- Skips single styled DOM writes when the row cache matches
- Keeps multi-segment order in the row cache key
- Invalidates the row cache when a plain row becomes wide

All 938 tests passing.