### PR TITLE
perf(dom-renderer): reduce row segment allocation overhead

### DIFF
--- a/src/renderer/dom/dom-renderer.ts
+++ b/src/renderer/dom/dom-renderer.ts
@@ -297,7 +297,7 @@ function computeRowSegments(terminal: Terminal, y: number): RowSegment[] {
   const cells = terminal.getRow(y);
   let currentKey: string | null = null;
   let currentStyle: Style | null = null;
-  let currentParts: string[] = [];
+  let currentText = "";
   let currentCols = 0;
   let currentWide = false;
   const spans: RowSegment[] = [];
@@ -313,18 +313,18 @@ function computeRowSegments(terminal: Terminal, y: number): RowSegment[] {
     if (currentKey == null) {
       currentKey = key;
       currentStyle = nextStyle;
-      currentParts = [ch];
+      currentText = ch;
       currentCols = cols;
       currentWide = wide;
       continue;
     }
     if (key === currentKey && wide === currentWide) {
-      currentParts.push(ch);
+      currentText += ch;
       currentCols += cols;
       continue;
     }
     spans.push({
-      text: currentParts.join(""),
+      text: currentText,
       cols: currentCols,
       wide: currentWide,
       style: currentStyle!,
@@ -332,13 +332,13 @@ function computeRowSegments(terminal: Terminal, y: number): RowSegment[] {
     });
     currentKey = key;
     currentStyle = nextStyle;
-    currentParts = [ch];
+    currentText = ch;
     currentCols = cols;
     currentWide = wide;
   }
   if (currentKey != null) {
     spans.push({
-      text: currentParts.join(""),
+      text: currentText,
       cols: currentCols,
       wide: currentWide,
       style: currentStyle!,

--- a/test/dom-renderer.test.ts
+++ b/test/dom-renderer.test.ts
@@ -182,6 +182,28 @@ describe("DomRenderer row rendering", () => {
     }
   });
 
+  it("keeps separated style runs as separate segments", () => {
+    const { terminal, container, renderer } = setup(3);
+
+    try {
+      terminal.write("A", { x: 0, y: 0, style: { fg: "red" } });
+      terminal.write("B", { x: 1, y: 0, style: { fg: "blue" } });
+      terminal.write("C", { x: 2, y: 0, style: { fg: "red" } });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const line = lineEl(container);
+      const spans = Array.from(line.querySelectorAll("span"));
+      expect(spans).toHaveLength(3);
+      expect(spans.map((span) => span.textContent)).toEqual(["A", "B", "C"]);
+      expect(spans[0]!.style.color).toBe("var(--vt-color-red)");
+      expect(spans[1]!.style.color).toBe("var(--vt-color-blue)");
+      expect(spans[2]!.style.color).toBe("var(--vt-color-red)");
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
   it("resets reused multi-segment row span styles", () => {
     const { terminal, container, renderer } = setup(4);
 
@@ -360,6 +382,22 @@ describe("DomRenderer row rendering", () => {
         fragmentRows: 1,
         spansCreated: 1,
       });
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("skips wide continuation cells", () => {
+    const { terminal, container, renderer } = setup(4);
+
+    try {
+      terminal.write("中", { x: 0, y: 0 });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const line = lineEl(container);
+      expect(line.textContent).toBe("中  ");
+      expect(line.querySelectorAll("span")).toHaveLength(2);
     } finally {
       renderer.dispose();
       container.remove();


### PR DESCRIPTION
## Summary
- Replace per-segment `string[]` accumulation in `computeRowSegments()` with direct string accumulation.
- Keep `RowSegment` shape, style/wide boundaries, and render fast paths unchanged.
- Add DOM renderer tests for separated style runs and wide continuation skipping.

## Validation
- `pnpm exec vitest run test/dom-renderer.test.ts`
- `pnpm run bench:dom-renderer`
- `pnpm run bench:scroll-mailbox`
- `pnpm run typecheck`
- `pnpm run lint`