### PR TITLE
perf(dom-renderer): merge computeRowSegments and segmentsToKey into single pass

### DIFF
--- a/src/renderer/dom/dom-renderer.ts
+++ b/src/renderer/dom/dom-renderer.ts
@@ -293,14 +293,32 @@ interface RowSegment {
   key: string;
 }
 
-function computeRowSegments(terminal: Terminal, y: number): RowSegment[] {
+type RowSegmentsResult = Readonly<{
+  segments: RowSegment[];
+  key: string;
+}>;
+
+function computeRowSegmentsWithKey(terminal: Terminal, y: number): RowSegmentsResult {
   const cells = terminal.getRow(y);
   let currentKey: string | null = null;
   let currentStyle: Style | null = null;
   let currentText = "";
   let currentCols = 0;
   let currentWide = false;
-  const spans: RowSegment[] = [];
+  const segments: RowSegment[] = [];
+  let keyBody = "";
+  let segmentCount = 0;
+
+  function pushSegment(segment: RowSegment): void {
+    if (segmentCount === 1) {
+      const first = segments[0]!;
+      keyBody += `|${first.key}:${first.text}:${first.cols}:${first.wide ? 1 : 0}`;
+    }
+    segments.push(segment);
+    segmentCount++;
+    if (segmentCount > 1)
+      keyBody += `|${segment.key}:${segment.text}:${segment.cols}:${segment.wide ? 1 : 0}`;
+  }
 
   for (const cell of cells as Cell[]) {
     if (cell.continuation) continue;
@@ -323,7 +341,7 @@ function computeRowSegments(terminal: Terminal, y: number): RowSegment[] {
       currentCols += cols;
       continue;
     }
-    spans.push({
+    pushSegment({
       text: currentText,
       cols: currentCols,
       wide: currentWide,
@@ -337,7 +355,7 @@ function computeRowSegments(terminal: Terminal, y: number): RowSegment[] {
     currentWide = wide;
   }
   if (currentKey != null) {
-    spans.push({
+    pushSegment({
       text: currentText,
       cols: currentCols,
       wide: currentWide,
@@ -346,7 +364,18 @@ function computeRowSegments(terminal: Terminal, y: number): RowSegment[] {
     });
   }
 
-  return spans;
+  if (segmentCount === 0) return { segments, key: "0" };
+
+  if (segmentCount === 1) {
+    const s = segments[0]!;
+    const plain = isPlainStyle(s.style);
+    if (!s.wide && plain) return { segments, key: `p:${s.text}:${s.cols}` };
+    if (!s.wide && !s.style.href && !plain)
+      return { segments, key: `s:${s.key}:${s.text}:${s.cols}` };
+    return { segments, key: `1:${s.key}:${s.text}:${s.cols}:${s.wide ? 1 : 0}` };
+  }
+
+  return { segments, key: `${segmentCount}${keyBody}` };
 }
 
 // Cache for row content comparison - avoids unnecessary DOM updates
@@ -356,25 +385,6 @@ function nowMs(): number {
   const p = (globalThis as any).performance;
   if (p && typeof p.now === "function") return p.now();
   return Date.now();
-}
-
-function segmentsToKey(segments: readonly RowSegment[]): string {
-  if (segments.length === 0) return "0";
-
-  if (segments.length === 1) {
-    const s = segments[0]!;
-    const plain = isPlainStyle(s.style);
-    if (!s.wide && plain) return `p:${s.text}:${s.cols}`;
-    if (!s.wide && !s.style.href && !plain) return `s:${s.key}:${s.text}:${s.cols}`;
-    return `1:${s.key}:${s.text}:${s.cols}:${s.wide ? 1 : 0}`;
-  }
-
-  let out = String(segments.length);
-  for (let i = 0; i < segments.length; i++) {
-    const s = segments[i]!;
-    out += `|${s.key}:${s.text}:${s.cols}:${s.wide ? 1 : 0}`;
-  }
-  return out;
 }
 
 function isPlainStyle(style: Style): boolean {
@@ -454,8 +464,7 @@ function renderRow(
   stats: RowRenderMutableStats,
 ): void {
   stats.rows++;
-  const segments = computeRowSegments(terminal, y);
-  const newKey = segmentsToKey(segments);
+  const { segments, key: newKey } = computeRowSegmentsWithKey(terminal, y);
 
   // Skip DOM update if content hasn't changed
   const cachedKey = rowCache.get(lineEl);

--- a/test/dom-renderer.test.ts
+++ b/test/dom-renderer.test.ts
@@ -204,6 +204,26 @@ describe("DomRenderer row rendering", () => {
     }
   });
 
+  it("merges continuous same-style runs", () => {
+    const { terminal, container, renderer } = setup(3);
+
+    try {
+      terminal.write("A", { x: 0, y: 0, style: { fg: "red" } });
+      terminal.write("B", { x: 1, y: 0, style: { fg: "red" } });
+      terminal.write("C", { x: 2, y: 0, style: { fg: "blue" } });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const spans = Array.from(lineEl(container).querySelectorAll("span"));
+      expect(spans).toHaveLength(2);
+      expect(spans.map((span) => span.textContent)).toEqual(["AB", "C"]);
+      expect(spans[0]!.style.color).toBe("var(--vt-color-red)");
+      expect(spans[1]!.style.color).toBe("var(--vt-color-blue)");
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
   it("resets reused multi-segment row span styles", () => {
     const { terminal, container, renderer } = setup(4);
 
@@ -358,6 +378,27 @@ describe("DomRenderer row rendering", () => {
         rows: 1,
         fragmentRows: 1,
         spansCreated: 1,
+      });
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("invalidates the row cache when href changes", () => {
+    const { terminal, container, renderer } = setup(3);
+
+    try {
+      terminal.write("url", { x: 0, y: 0, style: { href: "https://a.example" } });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      terminal.write("url", { x: 0, y: 0, style: { href: "https://b.example" } });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      expect(lastRowStats(renderer)).toMatchObject({
+        rows: 1,
+        cacheHits: 0,
+        fragmentRows: 1,
       });
     } finally {
       renderer.dispose();


### PR DESCRIPTION
## Summary

Combine `computeRowSegments` and `segmentsToKey` into `computeRowSegmentsWithKey` which builds the cache key incrementally during segment computation, eliminating the second iteration over segments for key generation.

## Changes

- **`src/renderer/dom/dom-renderer.ts`**: Merged `computeRowSegments` + `segmentsToKey` into `computeRowSegmentsWithKey` that returns both `segments` and `key` in a single pass.
- **`test/dom-renderer.test.ts`**: Added tests for continuous same-style merge and href cache invalidation.

## Performance impact

Previously each row required two passes: one to build segments, another to compute the cache key. Now the key is constructed incrementally as segments are created, reducing per-row overhead.