### PR TITLE
feat: add custom palette support for stdout renderer and row key prepass stats

### DIFF
--- a/scripts/bench-dom-renderer.ts
+++ b/scripts/bench-dom-renderer.ts
@@ -147,6 +147,18 @@ function runPrepassModes<T>(run: (enableRowKeyPrepass: boolean) => T): {
   };
 }
 
+function assertRowKeyPrepassStats(
+  stats: DomRendererRowRenderStats,
+  options: PrepassOptions,
+  enabledChecks: number,
+  enabledHits: number,
+  enabledMisses: number,
+): void {
+  assert.equal(stats.rowKeyPrepassChecks, options.enableRowKeyPrepass ? enabledChecks : 0);
+  assert.equal(stats.rowKeyPrepassHits, options.enableRowKeyPrepass ? enabledHits : 0);
+  assert.equal(stats.rowKeyPrepassMisses, options.enableRowKeyPrepass ? enabledMisses : 0);
+}
+
 function benchPlainRows(): RowRenderSnapshot {
   return runScenario((scenario) => {
     writePlainRows(scenario, "line");
@@ -171,6 +183,7 @@ function benchChangedPlainRows(options: PrepassOptions): RoundSnapshot {
     assert.ok(secondFlush.plainTextRows > 0);
     assert.equal(secondFlush.cacheHits, 0);
     assert.equal(secondFlush.fragmentRows, 0);
+    assertRowKeyPrepassStats(secondFlush, options, ROWS, 0, ROWS);
 
     return {
       firstFlush,
@@ -196,6 +209,7 @@ function benchSingleStyledRows(options: PrepassOptions): RoundSnapshot {
     assert.ok(secondFlush.spansReused > 0);
     assert.equal(secondFlush.fragmentRows, 0);
     assert.equal(secondFlush.replaceChildren, 0);
+    assertRowKeyPrepassStats(secondFlush, options, ROWS, 0, ROWS);
 
     return {
       firstFlush,
@@ -220,6 +234,7 @@ function benchChangedMultiSegmentRows(options: PrepassOptions): RoundSnapshot {
     assert.ok(secondFlush.segmentReuseRows > 0);
     assert.ok(secondFlush.spansReused > 0);
     assert.equal(secondFlush.fragmentRows, 0);
+    assertRowKeyPrepassStats(secondFlush, options, ROWS, 0, ROWS);
 
     return {
       firstFlush,
@@ -252,6 +267,7 @@ function benchCacheHits(options: PrepassOptions): RoundSnapshot {
     assert.ok(secondFlush.cacheHits > 0);
     assert.equal(secondFlush.plainTextRows, 0);
     assert.equal(secondFlush.fragmentRows, 0);
+    assertRowKeyPrepassStats(secondFlush, options, ROWS, ROWS, 0);
 
     return {
       firstFlush,
@@ -273,6 +289,7 @@ function benchSingleStyledCacheHits(options: PrepassOptions): RoundSnapshot {
     assert.equal(secondFlush.singleStyledRows, 0);
     assert.equal(secondFlush.spansReused, 0);
     assert.equal(secondFlush.replaceChildren, 0);
+    assertRowKeyPrepassStats(secondFlush, options, ROWS, ROWS, 0);
 
     return {
       firstFlush,
@@ -294,6 +311,7 @@ function benchMultiSegmentCacheHits(options: PrepassOptions): RoundSnapshot {
     assert.equal(secondFlush.segmentReuseRows, 0);
     assert.equal(secondFlush.spansReused, 0);
     assert.equal(secondFlush.fragmentRows, 0);
+    assertRowKeyPrepassStats(secondFlush, options, ROWS, ROWS, 0);
 
     return {
       firstFlush,
@@ -305,9 +323,7 @@ function benchMultiSegmentCacheHits(options: PrepassOptions): RoundSnapshot {
 
 const results = {
   plain: benchPlainRows(),
-  cacheHitPlain: runPrepassModes((enableRowKeyPrepass) =>
-    benchCacheHits({ enableRowKeyPrepass }),
-  ),
+  cacheHitPlain: runPrepassModes((enableRowKeyPrepass) => benchCacheHits({ enableRowKeyPrepass })),
   cacheHitSingleStyled: runPrepassModes((enableRowKeyPrepass) =>
     benchSingleStyledCacheHits({ enableRowKeyPrepass }),
   ),

--- a/src/renderer/cli/stdout-renderer.ts
+++ b/src/renderer/cli/stdout-renderer.ts
@@ -82,11 +82,13 @@ export type StdoutRenderer = Readonly<{
   updateTheme?: (
     next: Readonly<{
       defaultBg?: string | null;
+      palette?: ThemePalette | null;
     }>,
   ) => void;
 }>;
 
 export type StdoutColorMode = "auto" | "truecolor" | "ansi256" | "ansi16" | "ansi8";
+export type ThemePalette = Partial<Record<AnsiColorName, string>>;
 
 export function createStdoutRenderer(
   terminal: Terminal,
@@ -97,6 +99,8 @@ export function createStdoutRenderer(
     altScreen?: boolean;
     /** Fallback background color when a cell has no explicit bg. `null` = transparent (terminal default). */
     defaultBg?: string | null;
+    /** Optional ANSI-name palette used when emitting ansi256/truecolor sequences. */
+    palette?: ThemePalette | null;
     /** Track TTY resize events (process.stdout 'resize') and call terminal.resize(). */
     trackResize?: boolean;
     /** Color mode for ANSI output (auto detects truecolor via env). */
@@ -117,6 +121,7 @@ export function createStdoutRenderer(
     options?.defaultBg == null || options?.defaultBg === "transparent"
       ? undefined
       : (options?.defaultBg ?? "black");
+  let palette: ThemePalette | null = options?.palette ?? null;
   const trackResize = options?.trackResize ?? true;
   const getImeAnchor = options?.getImeAnchor;
   const cliLatency = getCliLatencyProfiler();
@@ -349,6 +354,12 @@ export function createStdoutRenderer(
     return typeof value === "string" && value ? value : null;
   }
 
+  function resolveAnsiColorRgb(name: AnsiColorName) {
+    const hex = palette?.[name];
+    if (hex) return ansiHexToRgb(hex) ?? ansiColorRgb(name);
+    return ansiColorRgb(name);
+  }
+
   function openColor(fg?: string): string {
     if (!fg) return "";
     // 'transparent' → reset to terminal default foreground
@@ -365,7 +376,7 @@ export function createStdoutRenderer(
     // AnsiColorName path (fallback layer + legacy themes)
     if (colorMode === "ansi8") return ansi8FgOpen(fg as AnsiColorName);
     if (colorMode === "ansi16") return ansi16FgOpen(fg as AnsiColorName);
-    const rgb = ansiColorRgb(fg as AnsiColorName);
+    const rgb = resolveAnsiColorRgb(fg as AnsiColorName);
     if (!rgb) return "";
     if (colorMode === "ansi256") return ansi256FgOpen(rgbToAnsi256(rgb));
     return truecolorFgOpen(rgb);
@@ -387,7 +398,7 @@ export function createStdoutRenderer(
     // AnsiColorName path (fallback layer + legacy themes)
     if (colorMode === "ansi8") return ansi8BgOpen(bg as AnsiColorName);
     if (colorMode === "ansi16") return ansi16BgOpen(bg as AnsiColorName);
-    const rgb = ansiColorRgb(bg as AnsiColorName);
+    const rgb = resolveAnsiColorRgb(bg as AnsiColorName);
     if (!rgb) return "";
     if (colorMode === "ansi256") return ansi256BgOpen(rgbToAnsi256(rgb));
     return truecolorBgOpen(rgb);
@@ -2101,6 +2112,7 @@ export function createStdoutRenderer(
   const updateTheme = (
     next: Readonly<{
       defaultBg?: string | null;
+      palette?: ThemePalette | null;
     }>,
   ): void => {
     if (disposed) return;
@@ -2113,6 +2125,7 @@ export function createStdoutRenderer(
             : next.defaultBg;
       if (nextBg !== defaultBg) defaultBg = nextBg;
     }
+    if ("palette" in next) palette = next.palette ?? null;
     styleKeyCache = new WeakMap<Style, number>();
     // Reset dynamic hex color indices so the new theme's colors get fresh
     // slots.  The 5-bit color index only has 15 dynamic slots (17-31);

--- a/src/renderer/dom/dom-renderer.ts
+++ b/src/renderer/dom/dom-renderer.ts
@@ -41,6 +41,9 @@ export type DomRendererFlushStats = Readonly<{
 export type DomRendererRowRenderStats = Readonly<{
   rows: number;
   cacheHits: number;
+  rowKeyPrepassChecks: number;
+  rowKeyPrepassHits: number;
+  rowKeyPrepassMisses: number;
   transparentBlankRows: number;
   plainTextRows: number;
   singleStyledRows: number;
@@ -134,6 +137,9 @@ function createEmptyRowStats(): RowRenderMutableStats {
   return {
     rows: 0,
     cacheHits: 0,
+    rowKeyPrepassChecks: 0,
+    rowKeyPrepassHits: 0,
+    rowKeyPrepassMisses: 0,
     transparentBlankRows: 0,
     plainTextRows: 0,
     singleStyledRows: 0,
@@ -153,6 +159,9 @@ function freezeRowStats(stats: RowRenderMutableStats): DomRendererRowRenderStats
 function addRowStats(target: RowRenderMutableStats, source: RowRenderMutableStats): void {
   target.rows += source.rows;
   target.cacheHits += source.cacheHits;
+  target.rowKeyPrepassChecks += source.rowKeyPrepassChecks;
+  target.rowKeyPrepassHits += source.rowKeyPrepassHits;
+  target.rowKeyPrepassMisses += source.rowKeyPrepassMisses;
   target.transparentBlankRows += source.transparentBlankRows;
   target.plainTextRows += source.plainTextRows;
   target.singleStyledRows += source.singleStyledRows;
@@ -552,11 +561,15 @@ function renderRow(
   stats.rows++;
   const cachedKey = rowCache.get(lineEl);
   if (enableRowKeyPrepass && cachedKey != null) {
+    stats.rowKeyPrepassChecks++;
     const prepassKey = computeRowKey(terminal, y);
     if (cachedKey === prepassKey) {
+      stats.rowKeyPrepassHits++;
       stats.cacheHits++;
       return;
     }
+
+    stats.rowKeyPrepassMisses++;
   }
 
   const { segments, key: newKey } = computeRowSegmentsWithKey(terminal, y);

--- a/test/dom-renderer.test.ts
+++ b/test/dom-renderer.test.ts
@@ -502,10 +502,28 @@ describe("DomRenderer row rendering", () => {
       expect(lastRowStats(renderer)).toMatchObject({
         rows: 1,
         cacheHits: 1,
+        rowKeyPrepassChecks: 0,
+        rowKeyPrepassHits: 0,
+        rowKeyPrepassMisses: 0,
         plainTextRows: 0,
         fragmentRows: 0,
         textNodeUpdates: 0,
         replaceChildren: 0,
+      });
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("does not count the initial opt-in render as a row key prepass check", () => {
+    const { container, renderer } = setup(8, 1, { enableRowKeyPrepass: true });
+
+    try {
+      expect(lastRowStats(renderer)).toMatchObject({
+        rowKeyPrepassChecks: 0,
+        rowKeyPrepassHits: 0,
+        rowKeyPrepassMisses: 0,
       });
     } finally {
       renderer.dispose();
@@ -542,6 +560,9 @@ describe("DomRenderer row rendering", () => {
       expect(lastRowStats(renderer)).toMatchObject({
         rows: 1,
         cacheHits: 1,
+        rowKeyPrepassChecks: 1,
+        rowKeyPrepassHits: 1,
+        rowKeyPrepassMisses: 0,
         plainTextRows: 0,
         singleStyledRows: 0,
         segmentReuseRows: 0,
@@ -571,6 +592,9 @@ describe("DomRenderer row rendering", () => {
       expect(lastRowStats(renderer)).toMatchObject({
         rows: 1,
         cacheHits: 0,
+        rowKeyPrepassChecks: 1,
+        rowKeyPrepassHits: 0,
+        rowKeyPrepassMisses: 1,
         plainTextRows: 1,
       });
     } finally {

--- a/test/stdout-renderer-color-mode.test.ts
+++ b/test/stdout-renderer-color-mode.test.ts
@@ -143,6 +143,57 @@ describe("stdoutRenderer color mode", () => {
     expect(out).not.toContain("\u001B[48;5;");
   });
 
+  it("uses custom palettes for ansi names in truecolor output", () => {
+    const terminal = createTerminal({ cols: 3, rows: 1 });
+    const cap = createCapture(false);
+    createStdoutRenderer(terminal, {
+      output: cap.output,
+      clear: false,
+      hideCursor: false,
+      altScreen: false,
+      colorMode: "truecolor",
+      palette: {
+        red: "#112233",
+        blue: "#445566",
+      },
+    });
+
+    terminal.put(0, 0, "X", { fg: "red", bg: "blue" });
+    terminal.commit();
+
+    const out = cap.getOut();
+    expect(out).toContain("\u001B[38;2;17;34;51m");
+    expect(out).toContain("\u001B[48;2;68;85;102m");
+  });
+
+  it("updates custom palettes without recreating the stdout renderer", () => {
+    const terminal = createTerminal({ cols: 3, rows: 1 });
+    const cap = createCapture(false);
+    const renderer = createStdoutRenderer(terminal, {
+      output: cap.output,
+      clear: false,
+      hideCursor: false,
+      altScreen: false,
+      colorMode: "truecolor",
+      palette: {
+        red: "#112233",
+      },
+    });
+
+    terminal.put(0, 0, "X", { fg: "red" });
+    terminal.commit();
+    expect(cap.getOut()).toContain("\u001B[38;2;17;34;51m");
+
+    renderer.updateTheme?.({
+      palette: {
+        red: "#010203",
+      },
+    });
+
+    expect(cap.getOut()).toContain("\u001B[38;2;1;2;3m");
+    renderer.dispose();
+  });
+
   it("auto mode respects DIMCODE_COLOR_MODE=ansi256", () => {
     withEnv("DIMCODE_COLOR_MODE", "ansi256", () => {
       const terminal = createTerminal({ cols: 3, rows: 1 });


### PR DESCRIPTION
## Summary

Two related renderer improvements:

### 1. Custom Palette Support for Stdout Renderer
- Add `ThemePalette` type (`Partial<Record<AnsiColorName, string>>`) allowing theme authors to remap ANSI color names to custom hex values
- Add `palette` option to `createStdoutRenderer` constructor
- ANSI color names are now resolved through the custom palette before falling back to default RGB values
- Support `updateTheme({ palette })` for live theme switching without recreating the renderer

### 2. Row Key Prepass Stats for DOM Renderer
- Add `rowKeyPrepassChecks`, `rowKeyPrepassHits`, `rowKeyPrepassMisses` to `DomRendererRowRenderStats`
- These stats track the effectiveness of the opt-in row key prepass cache
- Update `bench-dom-renderer` to assert prepass stats in all benchmark scenarios
- Add unit tests for prepass stats tracking

## Changed Files
- `src/renderer/cli/stdout-renderer.ts` — palette option, resolveAnsiColorRgb, updateTheme support
- `src/renderer/dom/dom-renderer.ts` — rowKeyPrepass stats fields and tracking
- `scripts/bench-dom-renderer.ts` — prepass stats assertions
- `test/dom-renderer.test.ts` — prepass stats unit tests
- `test/stdout-renderer-color-mode.test.ts` — palette truecolor and update tests