### PR TITLE
fix(TDialog): underline only selected button and prevent double click confirm

### DIFF
--- a/src/vue/components/TDialog.ts
+++ b/src/vue/components/TDialog.ts
@@ -968,6 +968,8 @@ export const TDialog = defineComponent({
       name: "TDialogContent",
       setup() {
         provide(DialogContextKey, true);
+        let pointerDownButton: { index: number; cellX: number; cellY: number } | null = null;
+        let suppressClickButtonIndex: number | null = null;
         return () => {
           const children = slots.default?.() ?? null;
           if (!props.buttons.length) return children;
@@ -991,7 +993,7 @@ export const TDialog = defineComponent({
             const variantStyle: Style =
               b.style ??
               (isPrimary
-                ? { bold: true, underline: true }
+                ? { bold: true }
                 : isDanger
                   ? { bold: true }
                   : isAccent
@@ -1043,8 +1045,27 @@ export const TDialog = defineComponent({
                   e.stopPropagation?.();
                   confirmButton(selectedButtonIndex.value);
                 },
+                onPointerdown: (e: any) => {
+                  e?.stopPropagation?.();
+                  selectedButtonIndex.value = i;
+                  pointerDownButton = { index: i, cellX: e.cellX, cellY: e.cellY };
+                },
+                onPointerup: (e: any) => {
+                  e?.stopPropagation?.();
+                  const down = pointerDownButton;
+                  pointerDownButton = null;
+                  if (!down || down.index !== i || down.cellX !== e.cellX || down.cellY !== e.cellY)
+                    return;
+                  selectedButtonIndex.value = i;
+                  suppressClickButtonIndex = i;
+                  confirmButton(i);
+                },
                 onClick: (e: any) => {
                   e?.stopPropagation?.();
+                  if (suppressClickButtonIndex === i) {
+                    suppressClickButtonIndex = null;
+                    return;
+                  }
                   selectedButtonIndex.value = i;
                   confirmButton(i);
                 },

--- a/test/ui-regressions-dialog.test.ts
+++ b/test/ui-regressions-dialog.test.ts
@@ -539,6 +539,57 @@ describe("ui regressions dialog", () => {
     mounted.unmount();
   });
 
+  it("TDialog only underlines the selected footer button", async () => {
+    const open = ref(true);
+    const mounted = await mountTerminal(
+      () =>
+        h(
+          TDialog as any,
+          {
+            modelValue: open.value,
+            "onUpdate:modelValue": (v: boolean) => (open.value = v),
+            w: 34,
+            h: 7,
+            title: "Confirm",
+            placement: "center",
+            teleport: true,
+            contentStyle: { bg: "black" },
+            buttons: [
+              { label: "Apply", value: "apply", kind: "primary", default: true },
+              { label: "Cancel", value: "cancel" },
+            ],
+          },
+          () => h(TText, { x: 0, y: 0, w: 28, value: "Hi" }),
+        ),
+      48,
+      12,
+    );
+
+    const container = mounted.container()!;
+    await nextTick();
+    await nextTick();
+
+    const initialLines = mounted.terminal.snapshot().lines;
+    const buttonY = initialLines.findIndex((line) => line.includes("[ Apply ]"));
+    const applyX = initialLines[buttonY]!.indexOf("[ Apply ]") + 2;
+    const cancelX = initialLines[buttonY]!.indexOf("[ Cancel ]") + 2;
+    expect(mounted.terminal.getCell(applyX, buttonY).style.underline).toBe(true);
+    expect(mounted.terminal.getCell(cancelX, buttonY).style.underline).not.toBe(true);
+
+    container.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "ArrowRight",
+        code: "ArrowRight",
+        bubbles: true,
+      }),
+    );
+    await nextTick();
+
+    expect(mounted.terminal.getCell(applyX, buttonY).style.underline).not.toBe(true);
+    expect(mounted.terminal.getCell(cancelX, buttonY).style.underline).toBe(true);
+    mounted.unmount();
+  });
+
   it("TDialog keeps Tab order in sync after ArrowLeft/Right button navigation", async () => {
     const open = ref(true);
     const confirmed = ref("");


### PR DESCRIPTION
## Summary

Two fixes for TDialog button behavior:

### 1. Underline only the selected button

Previously, the `primary` button variant always had `{ bold: true, underline: true }`, causing all primary buttons to show underline regardless of selection state. Now the primary variant uses only `{ bold: true }`, and underline is applied exclusively via the `isSelected` check — so only the currently focused/selected button gets underlined.

### 2. Prevent double confirm on click

In terminal environments, both `pointerup` and `click` events fire when a button is pressed, causing `confirmButton()` to be called twice. This fix:
- Tracks pointer-down position on `onPointerdown`
- Confirms the button on `onPointerup` only if the pointer is still on the same cell
- Suppresses the subsequent `onClick` when `pointerup` already handled the confirmation

### Test

Added regression test verifying that only the selected footer button has underline styling.

## Files changed

- `src/vue/components/TDialog.ts` — primary style + pointer event handling
- `test/ui-regressions-dialog.test.ts` — new underline selection regression test