### PR TITLE
fix(event-manager): prevent stale remount nodes from receiving bubbled events

### DIFF
--- a/src/events/manager/cli-event-manager.ts
+++ b/src/events/manager/cli-event-manager.ts
@@ -31,6 +31,10 @@ function area(rect: Rect): number {
   return Math.max(0, rect.w) * Math.max(0, rect.h);
 }
 
+function sameRect(a: Rect, b: Rect): boolean {
+  return a.x === b.x && a.y === b.y && a.w === b.w && a.h === b.h;
+}
+
 function isVisible(node: TerminalNode): boolean {
   return node.visible !== false;
 }
@@ -210,14 +214,21 @@ export function createCliEventManager(
     let target: TerminalNode = list[0]!;
     for (const n of list) {
       if (n.zIndex > target.zIndex) target = n;
-      else if (n.zIndex === target.zIndex && area(n.rect) < area(target.rect)) target = n;
+      else if (n.zIndex === target.zIndex && area(n.rect) <= area(target.rect)) target = n;
     }
     return target;
   }
 
   function pathOuterToInner(list: TerminalNode[], target: TerminalNode | null): TerminalNode[] {
     if (!target) return [];
-    const filtered = list.filter((n) => n.id !== target.id);
+    const filtered = list.filter(
+      (n) =>
+        n.id !== target.id &&
+        (!n.focusable ||
+          !target.focusable ||
+          n.zIndex !== target.zIndex ||
+          !sameRect(n.rect, target.rect)),
+    );
     return [...filtered, target];
   }
 

--- a/src/events/manager/event-manager.ts
+++ b/src/events/manager/event-manager.ts
@@ -32,6 +32,10 @@ function area(rect: Rect): number {
   return Math.max(0, rect.w) * Math.max(0, rect.h);
 }
 
+function sameRect(a: Rect, b: Rect): boolean {
+  return a.x === b.x && a.y === b.y && a.w === b.w && a.h === b.h;
+}
+
 function now(): number {
   return typeof performance !== "undefined" ? performance.now() : Date.now();
 }
@@ -262,14 +266,21 @@ export function createEventManager(
     let target: TerminalNode = list[0]!;
     for (const n of list) {
       if (n.zIndex > target.zIndex) target = n;
-      else if (n.zIndex === target.zIndex && area(n.rect) < area(target.rect)) target = n;
+      else if (n.zIndex === target.zIndex && area(n.rect) <= area(target.rect)) target = n;
     }
     return target;
   }
 
   function pathOuterToInner(list: TerminalNode[], target: TerminalNode | null): TerminalNode[] {
     if (!target) return [];
-    const filtered = list.filter((n) => n.id !== target.id);
+    const filtered = list.filter(
+      (n) =>
+        n.id !== target.id &&
+        (!n.focusable ||
+          !target.focusable ||
+          n.zIndex !== target.zIndex ||
+          !sameRect(n.rect, target.rect)),
+    );
     return [...filtered, target];
   }
 

--- a/test/ui-regressions-dialog.test.ts
+++ b/test/ui-regressions-dialog.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   createCliEventManager,
   createEventManager,
@@ -587,6 +587,164 @@ describe("ui regressions dialog", () => {
 
     expect(mounted.terminal.getCell(applyX, buttonY).style.underline).not.toBe(true);
     expect(mounted.terminal.getCell(cancelX, buttonY).style.underline).toBe(true);
+    mounted.unmount();
+  });
+
+  it("TDialog suppresses click after pointerup confirms a footer button", async () => {
+    const open = ref(true);
+    const onConfirm = vi.fn();
+    const mounted = await mountTerminal(
+      () =>
+        h(
+          TDialog as any,
+          {
+            modelValue: open.value,
+            "onUpdate:modelValue": (v: boolean) => (open.value = v),
+            w: 24,
+            h: 7,
+            title: "Confirm",
+            placement: "center",
+            teleport: true,
+            closeOnConfirm: false,
+            buttons: [{ label: "OK", value: "ok", default: true }],
+            onConfirm,
+          },
+          () => h(TText, { x: 0, y: 0, w: 20, value: "Hi" }),
+        ),
+      40,
+      12,
+    );
+
+    const container = mounted.container()!;
+    await nextTick();
+    await nextTick();
+
+    const lines = mounted.terminal.snapshot().lines;
+    const buttonY = lines.findIndex((line) => line.includes("[ OK ]"));
+    const okX = lines[buttonY]!.indexOf("[ OK ]") + 2;
+
+    container.dispatchEvent(
+      new MouseEvent("pointerdown", { clientX: okX, clientY: buttonY, bubbles: true }),
+    );
+    container.dispatchEvent(
+      new MouseEvent("pointerup", { clientX: okX, clientY: buttonY, bubbles: true }),
+    );
+    container.dispatchEvent(
+      new MouseEvent("click", { clientX: okX, clientY: buttonY, bubbles: true }),
+    );
+    await nextTick();
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenLastCalledWith({
+      label: "OK",
+      value: "ok",
+      default: true,
+      index: 0,
+    });
+    mounted.unmount();
+  });
+
+  it("TDialog pointerup on another footer button cell waits for click confirmation", async () => {
+    const open = ref(true);
+    const onConfirm = vi.fn();
+    const mounted = await mountTerminal(
+      () =>
+        h(
+          TDialog as any,
+          {
+            modelValue: open.value,
+            "onUpdate:modelValue": (v: boolean) => (open.value = v),
+            w: 24,
+            h: 7,
+            title: "Confirm",
+            placement: "center",
+            teleport: true,
+            closeOnConfirm: false,
+            buttons: [{ label: "OK", value: "ok", default: true }],
+            onConfirm,
+          },
+          () => h(TText, { x: 0, y: 0, w: 20, value: "Hi" }),
+        ),
+      40,
+      12,
+    );
+
+    const container = mounted.container()!;
+    await nextTick();
+    await nextTick();
+
+    const lines = mounted.terminal.snapshot().lines;
+    const buttonY = lines.findIndex((line) => line.includes("[ OK ]"));
+    const okX = lines[buttonY]!.indexOf("[ OK ]") + 2;
+    const otherOkCellX = okX + 1;
+
+    container.dispatchEvent(
+      new MouseEvent("pointerdown", { clientX: okX, clientY: buttonY, bubbles: true }),
+    );
+    container.dispatchEvent(
+      new MouseEvent("pointerup", { clientX: otherOkCellX, clientY: buttonY, bubbles: true }),
+    );
+    await nextTick();
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    container.dispatchEvent(
+      new MouseEvent("click", { clientX: otherOkCellX, clientY: buttonY, bubbles: true }),
+    );
+    await nextTick();
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    mounted.unmount();
+  });
+
+  it("TDialog Enter still confirms after a suppressed pointer click", async () => {
+    const open = ref(true);
+    const onConfirm = vi.fn();
+    const mounted = await mountTerminal(
+      () =>
+        h(
+          TDialog as any,
+          {
+            modelValue: open.value,
+            "onUpdate:modelValue": (v: boolean) => (open.value = v),
+            w: 24,
+            h: 7,
+            title: "Confirm",
+            placement: "center",
+            teleport: true,
+            closeOnConfirm: false,
+            buttons: [{ label: "OK", value: "ok", default: true }],
+            onConfirm,
+          },
+          () => h(TText, { x: 0, y: 0, w: 20, value: "Hi" }),
+        ),
+      40,
+      12,
+    );
+
+    const container = mounted.container()!;
+    await nextTick();
+    await nextTick();
+
+    const lines = mounted.terminal.snapshot().lines;
+    const buttonY = lines.findIndex((line) => line.includes("[ OK ]"));
+    const okX = lines[buttonY]!.indexOf("[ OK ]") + 2;
+
+    container.dispatchEvent(
+      new MouseEvent("pointerdown", { clientX: okX, clientY: buttonY, bubbles: true }),
+    );
+    container.dispatchEvent(
+      new MouseEvent("pointerup", { clientX: okX, clientY: buttonY, bubbles: true }),
+    );
+    container.dispatchEvent(
+      new MouseEvent("click", { clientX: okX, clientY: buttonY, bubbles: true }),
+    );
+    await nextTick();
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+
+    container.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", code: "Enter", bubbles: true }),
+    );
+    await nextTick();
+    expect(onConfirm).toHaveBeenCalledTimes(2);
     mounted.unmount();
   });
 

--- a/test/ui-regressions-event-manager.test.ts
+++ b/test/ui-regressions-event-manager.test.ts
@@ -227,6 +227,65 @@ describe("ui regressions event manager", () => {
     events.dispose();
   });
 
+  it("EventManager does not bubble through equal hitboxes from stale remount nodes", async () => {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    const events = createEventManager(el, { cellWidth: 1, cellHeight: 1 });
+    const calls: string[] = [];
+
+    events.register({
+      rect: { x: 0, y: 0, w: 10, h: 1 },
+      zIndex: 10,
+      focusable: true,
+      handlers: {
+        pointerup: () => calls.push("stale"),
+      },
+    });
+    events.register({
+      rect: { x: 0, y: 0, w: 10, h: 1 },
+      zIndex: 10,
+      focusable: true,
+      handlers: {
+        pointerup: () => calls.push("current"),
+      },
+    });
+
+    el.dispatchEvent(new MouseEvent("pointerdown", { clientX: 0, clientY: 0, bubbles: true }));
+    el.dispatchEvent(new MouseEvent("pointerup", { clientX: 0, clientY: 0, bubbles: true }));
+
+    expect(calls).toEqual(["current"]);
+    events.dispose();
+    el.remove();
+  });
+
+  it("CliEventManager does not bubble through equal hitboxes from stale remount nodes", async () => {
+    const events = createCliEventManager();
+    const calls: string[] = [];
+
+    events.register({
+      rect: { x: 0, y: 0, w: 10, h: 1 },
+      zIndex: 10,
+      focusable: true,
+      handlers: {
+        pointerup: () => calls.push("stale"),
+      },
+    });
+    events.register({
+      rect: { x: 0, y: 0, w: 10, h: 1 },
+      zIndex: 10,
+      focusable: true,
+      handlers: {
+        pointerup: () => calls.push("current"),
+      },
+    });
+
+    events.dispatch({ type: "pointerdown", cellX: 0, cellY: 0, button: 0 });
+    events.dispatch({ type: "pointerup", cellX: 0, cellY: 0, button: 0 });
+
+    expect(calls).toEqual(["current"]);
+    events.dispose();
+  });
+
   it("EventManager prevents click-through via bubble ordering across zIndex", async () => {
     const el = document.createElement("div");
     document.body.appendChild(el);


### PR DESCRIPTION
## Problem

When a component remounts (e.g. TDialog reopening, teleport re-registration) and registers a new node with the same rect and zIndex, the old (stale) node was still included in the event propagation path. This caused events to fire on stale handlers before reaching the current one, leading to duplicate firing and click-through bugs.

## Changes

### Core fix (both event-manager.ts and cli-event-manager.ts)

1. Add sameRect helper - compares two Rect objects for equality
2. Fix target selection tie-breaking - change area(n.rect) < area(target.rect) to <= so later-registered nodes win ties, matching the remount expectation
3. Filter stale nodes from propagation path - in pathOuterToInner, when multiple focusable nodes share the same zIndex and rect, only the latest (target) node is kept; earlier registrations are excluded from the event path

### Tests

- EventManager + CliEventManager: verify only the latest registration receives the event when two nodes share the same hitbox
- TDialog: 3 regression tests covering click suppression after pointerup confirms a footer button, pointerup on another cell waiting for click, and Enter still working after a suppressed click