### PR TITLE
test: expand coverage for rowKey prepass, palette color modes, dialog dispatch, and event manager

### DIFF
--- a/test/bench-smoke.test.ts
+++ b/test/bench-smoke.test.ts
@@ -1,0 +1,39 @@
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+function runTsx(script: string): string {
+  return execFileSync(process.execPath, ["node_modules/tsx/dist/cli.mjs", script], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    maxBuffer: 20 * 1024 * 1024,
+    timeout: 30_000,
+  });
+}
+
+function parseJsonObject(output: string): any {
+  const start = output.indexOf("{");
+  expect(start).toBeGreaterThanOrEqual(0);
+  return JSON.parse(output.slice(start));
+}
+
+describe("bench smoke", () => {
+  it("bench:dom-renderer emits mixed rowKey prepass results", () => {
+    const output = runTsx("scripts/bench-dom-renderer.ts");
+    const results = JSON.parse(output);
+
+    expect(results.mixedRowKeyPrepass).toBeDefined();
+    expect(results.mixedRowKeyPrepass.default.secondFlush.rowKeyPrepassChecks).toBe(0);
+    expect(results.mixedRowKeyPrepass.prepass.secondFlush.rowKeyPrepassChecks).toBeGreaterThan(0);
+    expect(results.cacheHitPlain.default).toBeDefined();
+    expect(results.cacheHitPlain.prepass).toBeDefined();
+  });
+
+  it("bench:scroll-mailbox still passes and emits scenarios", () => {
+    const output = runTsx("scripts/bench-scroll-mailbox.ts");
+    expect(output).toContain("[bench:scroll-mailbox] passed");
+
+    const results = parseJsonObject(output);
+    expect(results.scenarios.length).toBeGreaterThan(0);
+    expect(results.guards).toBeDefined();
+  });
+});

--- a/test/dom-renderer.test.ts
+++ b/test/dom-renderer.test.ts
@@ -672,6 +672,9 @@ describe("DomRenderer row rendering", () => {
       expect(lastRowStats(renderer)).toMatchObject({
         rows: 1,
         cacheHits: 1,
+        rowKeyPrepassChecks: 1,
+        rowKeyPrepassHits: 1,
+        rowKeyPrepassMisses: 0,
         singleStyledRows: 0,
         fragmentRows: 0,
         spansCreated: 0,
@@ -705,11 +708,43 @@ describe("DomRenderer row rendering", () => {
       expect(lastRowStats(renderer)).toMatchObject({
         rows: 1,
         cacheHits: 1,
+        rowKeyPrepassChecks: 1,
+        rowKeyPrepassHits: 1,
+        rowKeyPrepassMisses: 0,
         segmentReuseRows: 0,
         fragmentRows: 0,
         spansCreated: 0,
         spansReused: 0,
         replaceChildren: 0,
+      });
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("invalidates the opt-in row prepass when a single styled row changes", () => {
+    const { terminal, container, renderer } = setup(3, 1, { enableRowKeyPrepass: true });
+
+    try {
+      terminal.fill(0, 0, 3, 1, "A", { fg: "red" });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      const span = lineEl(container).firstChild as HTMLSpanElement;
+
+      terminal.fill(0, 0, 3, 1, "A", { fg: "blue" });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      expect(lineEl(container).firstChild).toBe(span);
+      expect(span.style.color).toBe("var(--vt-color-blue)");
+      expect(lastRowStats(renderer)).toMatchObject({
+        rows: 1,
+        cacheHits: 0,
+        rowKeyPrepassChecks: 1,
+        rowKeyPrepassHits: 0,
+        rowKeyPrepassMisses: 1,
+        singleStyledRows: 1,
+        spansReused: 1,
       });
     } finally {
       renderer.dispose();
@@ -735,6 +770,9 @@ describe("DomRenderer row rendering", () => {
       expect(lastRowStats(renderer)).toMatchObject({
         rows: 1,
         cacheHits: 0,
+        rowKeyPrepassChecks: 1,
+        rowKeyPrepassHits: 0,
+        rowKeyPrepassMisses: 1,
         segmentReuseRows: 1,
       });
     } finally {
@@ -774,8 +812,33 @@ describe("DomRenderer row rendering", () => {
     }
   });
 
+  it("invalidates the opt-in row prepass when href changes", () => {
+    const { terminal, container, renderer } = setup(3, 1, { enableRowKeyPrepass: true });
+
+    try {
+      terminal.fill(0, 0, 3, 1, "A", { href: "https://example.com/a" });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      terminal.fill(0, 0, 3, 1, "A", { href: "https://example.com/b" });
+      terminal.commit({ planes: ["default"], sync: true });
+
+      expect(lineEl(container).textContent).toBe("AAA");
+      expect(lastRowStats(renderer)).toMatchObject({
+        rows: 1,
+        cacheHits: 0,
+        rowKeyPrepassChecks: 1,
+        rowKeyPrepassHits: 0,
+        rowKeyPrepassMisses: 1,
+        fragmentRows: 1,
+      });
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
   it("invalidates the row cache when a plain row becomes wide", () => {
-    const { terminal, container, renderer } = setup(2);
+    const { terminal, container, renderer } = setup(2, 1, { enableRowKeyPrepass: true });
 
     try {
       terminal.fill(0, 0, 2, 1, "A");
@@ -790,6 +853,9 @@ describe("DomRenderer row rendering", () => {
       expect(lastRowStats(renderer)).toMatchObject({
         rows: 1,
         cacheHits: 0,
+        rowKeyPrepassChecks: 1,
+        rowKeyPrepassHits: 0,
+        rowKeyPrepassMisses: 1,
         fragmentRows: 1,
       });
     } finally {

--- a/test/stdout-renderer-color-mode.test.ts
+++ b/test/stdout-renderer-color-mode.test.ts
@@ -3,6 +3,7 @@ import {
   createStdoutRenderer,
   createTerminal,
   detectTerminalColorCapability,
+  rgbToAnsi256,
 } from "../src/index.js";
 
 const getFrameDelayMs = () => ("GHOSTTY_RESOURCES_DIR" in process.env ? 24 : 16);
@@ -166,6 +167,77 @@ describe("stdoutRenderer color mode", () => {
     expect(out).toContain("\u001B[48;2;68;85;102m");
   });
 
+  it("uses custom palettes for ansi names in ansi256 output", () => {
+    const terminal = createTerminal({ cols: 3, rows: 1 });
+    const cap = createCapture(false);
+    createStdoutRenderer(terminal, {
+      output: cap.output,
+      clear: false,
+      hideCursor: false,
+      altScreen: false,
+      colorMode: "ansi256",
+      palette: {
+        red: "#112233",
+        blue: "#445566",
+      },
+    });
+
+    terminal.put(0, 0, "X", { fg: "red", bg: "blue" });
+    terminal.commit();
+
+    const out = cap.getOut();
+    expect(out).toContain(`\u001B[38;5;${rgbToAnsi256({ r: 17, g: 34, b: 51 })}m`);
+    expect(out).toContain(`\u001B[48;5;${rgbToAnsi256({ r: 68, g: 85, b: 102 })}m`);
+    expect(out).not.toContain("\u001B[38;2;");
+    expect(out).not.toContain("\u001B[48;2;");
+  });
+
+  it("keeps ansi16 and ansi8 named-color output independent from custom palettes", () => {
+    const cases = [
+      {
+        colorMode: "ansi16" as const,
+        fg: "redBright",
+        bg: "blueBright",
+        fgOpen: "\u001B[91m",
+        bgOpen: "\u001B[104m",
+      },
+      {
+        colorMode: "ansi8" as const,
+        fg: "redBright",
+        bg: "blueBright",
+        fgOpen: "\u001B[31m",
+        bgOpen: "\u001B[44m",
+      },
+    ];
+
+    for (const c of cases) {
+      const terminal = createTerminal({ cols: 3, rows: 1 });
+      const cap = createCapture(false);
+      createStdoutRenderer(terminal, {
+        output: cap.output,
+        clear: false,
+        hideCursor: false,
+        altScreen: false,
+        colorMode: c.colorMode,
+        palette: {
+          redBright: "#112233",
+          blueBright: "#445566",
+        },
+      });
+
+      terminal.put(0, 0, "X", { fg: c.fg, bg: c.bg });
+      terminal.commit();
+
+      const out = cap.getOut();
+      expect(out).toContain(c.fgOpen);
+      expect(out).toContain(c.bgOpen);
+      expect(out).not.toContain("\u001B[38;2;");
+      expect(out).not.toContain("\u001B[48;2;");
+      expect(out).not.toContain("\u001B[38;5;");
+      expect(out).not.toContain("\u001B[48;5;");
+    }
+  });
+
   it("updates custom palettes without recreating the stdout renderer", () => {
     const terminal = createTerminal({ cols: 3, rows: 1 });
     const cap = createCapture(false);
@@ -191,6 +263,76 @@ describe("stdoutRenderer color mode", () => {
     });
 
     expect(cap.getOut()).toContain("\u001B[38;2;1;2;3m");
+    renderer.dispose();
+  });
+
+  it("resets to the built-in palette when updateTheme receives undefined palette", () => {
+    const terminal = createTerminal({ cols: 3, rows: 1 });
+    const cap = createCapture(false);
+    const renderer = createStdoutRenderer(terminal, {
+      output: cap.output,
+      clear: false,
+      hideCursor: false,
+      altScreen: false,
+      colorMode: "truecolor",
+      palette: {
+        red: "#112233",
+      },
+    });
+
+    terminal.put(0, 0, "X", { fg: "red" });
+    terminal.commit();
+    expect(cap.getOut()).toContain("\u001B[38;2;17;34;51m");
+
+    const beforeResetLength = cap.getOut().length;
+    renderer.updateTheme?.({ palette: undefined });
+    const resetOut = cap.getOut().slice(beforeResetLength);
+    expect(resetOut).toContain("\u001B[38;2;201;27;0m");
+    renderer.dispose();
+  });
+
+  it("falls back to default output for unknown color names", () => {
+    const terminal = createTerminal({ cols: 3, rows: 1 });
+    const cap = createCapture(false);
+    createStdoutRenderer(terminal, {
+      output: cap.output,
+      clear: false,
+      hideCursor: false,
+      altScreen: false,
+      colorMode: "truecolor",
+    });
+
+    terminal.put(0, 0, "X", { fg: "unknown" as any });
+    terminal.commit();
+
+    const out = cap.getOut();
+    expect(out).toContain("X");
+    expect(out).not.toContain("\u001B[38;2;");
+    expect(out).not.toContain("\u001B[38;5;");
+  });
+
+  it("does not mutate caller palette objects", () => {
+    const terminal = createTerminal({ cols: 3, rows: 1 });
+    const cap = createCapture(false);
+    const palette = {
+      red: "#112233",
+      blue: "#445566",
+    };
+    const snapshot = { ...palette };
+    const renderer = createStdoutRenderer(terminal, {
+      output: cap.output,
+      clear: false,
+      hideCursor: false,
+      altScreen: false,
+      colorMode: "truecolor",
+      palette,
+    });
+
+    terminal.put(0, 0, "X", { fg: "red", bg: "blue" });
+    terminal.commit();
+    renderer.updateTheme?.({ palette });
+
+    expect(palette).toEqual(snapshot);
     renderer.dispose();
   });
 

--- a/test/ui-regressions-dialog.test.ts
+++ b/test/ui-regressions-dialog.test.ts
@@ -748,6 +748,132 @@ describe("ui regressions dialog", () => {
     mounted.unmount();
   });
 
+  it("TDialog click, Enter, and Escape paths dispatch once per action", async () => {
+    const open = ref(true);
+    const onConfirm = vi.fn();
+    const onClose = vi.fn();
+    const onUpdateModelValue = vi.fn((v: boolean) => {
+      open.value = v;
+    });
+    const mounted = await mountTerminal(
+      () =>
+        h(
+          TDialog as any,
+          {
+            modelValue: open.value,
+            "onUpdate:modelValue": onUpdateModelValue,
+            w: 24,
+            h: 7,
+            title: "Confirm",
+            placement: "center",
+            teleport: true,
+            closeOnConfirm: false,
+            buttons: [{ label: "OK", value: "ok", default: true }],
+            onConfirm,
+            onClose,
+          },
+          () => h(TText, { x: 0, y: 0, w: 20, value: "Hi" }),
+        ),
+      40,
+      12,
+    );
+
+    const container = mounted.container()!;
+    await nextTick();
+    await nextTick();
+
+    const lines = mounted.terminal.snapshot().lines;
+    const buttonY = lines.findIndex((line) => line.includes("[ OK ]"));
+    const okX = lines[buttonY]!.indexOf("[ OK ]") + 2;
+
+    container.dispatchEvent(
+      new MouseEvent("click", { clientX: okX, clientY: buttonY, bubbles: true }),
+    );
+    await nextTick();
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+
+    container.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", code: "Enter", bubbles: true }),
+    );
+    await nextTick();
+    expect(onConfirm).toHaveBeenCalledTimes(2);
+
+    container.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", code: "Escape", bubbles: true }),
+    );
+    await nextTick();
+    container.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", code: "Escape", bubbles: true }),
+    );
+    await nextTick();
+
+    expect(onUpdateModelValue).toHaveBeenCalledTimes(1);
+    expect(onUpdateModelValue).toHaveBeenLastCalledWith(false);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    mounted.unmount();
+  });
+
+  it("TDialog reopen does not leave stale footer handlers", async () => {
+    const open = ref(true);
+    const onConfirm = vi.fn();
+    const mounted = await mountTerminal(
+      () =>
+        h(
+          TDialog as any,
+          {
+            modelValue: open.value,
+            "onUpdate:modelValue": (v: boolean) => (open.value = v),
+            w: 24,
+            h: 7,
+            title: "Confirm",
+            placement: "center",
+            teleport: true,
+            buttons: [{ label: "OK", value: "ok", default: true }],
+            onConfirm,
+          },
+          () => h(TText, { x: 0, y: 0, w: 20, value: "Hi" }),
+        ),
+      40,
+      12,
+    );
+
+    const container = mounted.container()!;
+    await nextTick();
+    await nextTick();
+
+    let lines = mounted.terminal.snapshot().lines;
+    let buttonY = lines.findIndex((line) => line.includes("[ OK ]"));
+    let okX = lines[buttonY]!.indexOf("[ OK ]") + 2;
+
+    container.dispatchEvent(
+      new MouseEvent("click", { clientX: okX, clientY: buttonY, bubbles: true }),
+    );
+    await nextTick();
+    expect(open.value).toBe(false);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+
+    container.dispatchEvent(
+      new MouseEvent("click", { clientX: okX, clientY: buttonY, bubbles: true }),
+    );
+    await nextTick();
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+
+    open.value = true;
+    await nextTick();
+    await nextTick();
+
+    lines = mounted.terminal.snapshot().lines;
+    buttonY = lines.findIndex((line) => line.includes("[ OK ]"));
+    okX = lines[buttonY]!.indexOf("[ OK ]") + 2;
+
+    container.dispatchEvent(
+      new MouseEvent("click", { clientX: okX, clientY: buttonY, bubbles: true }),
+    );
+    await nextTick();
+    expect(onConfirm).toHaveBeenCalledTimes(2);
+    mounted.unmount();
+  });
+
   it("TDialog keeps Tab order in sync after ArrowLeft/Right button navigation", async () => {
     const open = ref(true);
     const confirmed = ref("");

--- a/test/ui-regressions-event-manager.test.ts
+++ b/test/ui-regressions-event-manager.test.ts
@@ -595,6 +595,78 @@ describe("ui regressions event manager", () => {
     events.dispose();
   });
 
+  it("EventManager replaces stale same-rect focus before key dispatch", async () => {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    const events = createEventManager(el, { cellWidth: 1, cellHeight: 1 });
+    const calls: string[] = [];
+
+    const stale = events.register({
+      rect: { x: 0, y: 0, w: 10, h: 1 },
+      zIndex: 10,
+      focusable: true,
+      handlers: {
+        keydown: () => calls.push("stale"),
+      },
+    });
+    events.focus(stale.id);
+    events.register({
+      rect: { x: 0, y: 0, w: 10, h: 1 },
+      zIndex: 10,
+      focusable: true,
+      handlers: {
+        pointerdown: () => calls.push("current-pointerdown"),
+        keydown: () => calls.push("current-keydown"),
+      },
+    });
+
+    el.dispatchEvent(new MouseEvent("pointerdown", { clientX: 0, clientY: 0, bubbles: true }));
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", code: "Enter", bubbles: true }));
+
+    expect(calls).toEqual(["current-pointerdown", "current-keydown"]);
+    events.dispose();
+    el.remove();
+  });
+
+  it("CliEventManager replaces stale same-rect focus before key dispatch", async () => {
+    const events = createCliEventManager();
+    const calls: string[] = [];
+
+    const stale = events.register({
+      rect: { x: 0, y: 0, w: 10, h: 1 },
+      zIndex: 10,
+      focusable: true,
+      handlers: {
+        keydown: () => calls.push("stale"),
+      },
+    });
+    events.focus(stale.id);
+    events.register({
+      rect: { x: 0, y: 0, w: 10, h: 1 },
+      zIndex: 10,
+      focusable: true,
+      handlers: {
+        pointerdown: () => calls.push("current-pointerdown"),
+        keydown: () => calls.push("current-keydown"),
+      },
+    });
+
+    events.dispatch({ type: "pointerdown", cellX: 0, cellY: 0, button: 0 });
+    events.dispatch({
+      type: "keydown",
+      key: "Enter",
+      code: "Enter",
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      metaKey: false,
+      repeat: false,
+    });
+
+    expect(calls).toEqual(["current-pointerdown", "current-keydown"]);
+    events.dispose();
+  });
+
   it("EventManager prevents click-through via bubble ordering across zIndex", async () => {
     const el = document.createElement("div");
     document.body.appendChild(el);


### PR DESCRIPTION
## Summary

Expand test coverage across several subsystems:

### dom-renderer
- Add tests for rowKey prepass invalidation when single styled row changes, href changes, and plain row becomes wide
- Include `rowKeyPrepassChecks`/`rowKeyPrepassHits`/`rowKeyPrepassMisses` in existing assertions

### stdout-renderer-color-mode
- Custom palettes applied in `ansi256` mode via `rgbToAnsi256` conversion
- `ansi16` and `ansi8` named-color output remains independent from custom palettes
- Palette reset to built-in when `updateTheme` receives `undefined` palette
- Unknown color name fallback (no escape emitted)
- Caller palette objects are not mutated

### ui-regressions-dialog
- Click, Enter, and Escape each dispatch exactly once per action
- Reopening a closed dialog does not leave stale footer event handlers

### ui-regressions-event-manager
- EventManager and CliEventManager replace stale same-rect focus before key dispatch

### bench-smoke (new)
- Smoke tests for `bench-dom-renderer` and `bench-scroll-mailbox` scripts

## Test plan

- [x] `bun run test` passes with all new tests
- [x] Existing tests remain green