### PR TITLE
feat: advance renderer streaming roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,127 +1,173 @@
-# Vue Terminal
+# Vue TUI
 
-用 Vue 组件语法绘制和交互的终端渲染框架。目标是让 “终端” 具备：
+Vue TUI is a Vue 3 terminal UI toolkit. It lets you render the same component model to a browser DOM surface or to a real terminal through stdout.
 
-- 类终端的写入/删除/更新/尺寸调整能力
-- ANSI 样式渲染（颜色、加粗、下划线等）
-- 事件机制（点击、移动、滚动、拖拽）
-- Vue 组件 + 响应式数据驱动终端界面更新
+The package is useful for:
 
-## 快速开始
+- browser-hosted terminal interfaces and playgrounds
+- CLI apps that want Vue component composition
+- high-throughput views such as virtual lists, streaming logs, and markdown transcripts
+- renderer and terminal experiments that need deterministic tests
 
-## 运行环境
+## Installation
 
-- `@simon_he/vue-tui` 本身不再强制 Node 18 基线。
-- `@simon_he/vue-tui/markdown` 依赖 `stream-markdown-parser` / `markdown-it-ts` 链路；其上游包当前仍声明 `node >= 18`，因此如果你使用 Markdown 子入口，请按该依赖链的运行时要求评估。
+```bash
+pnpm add @simon_he/vue-tui vue
+```
 
-### 浏览器渲染
+Vue is a peer dependency. The published package supports Vue `>=3.3.0 <4`.
+
+## Entry Points
+
+| Import                           | Stability         | Main exports                                                                                                                                                                    |
+| -------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@simon_he/vue-tui`              | Stable            | `TerminalProvider`, `TText`, `TBox`, `TInput`, `createTerminal`, `createDomRenderer`, `createStdoutRenderer`, `createTerminalApp`, event managers, runtime/router/input helpers |
+| `@simon_he/vue-tui/markdown`     | Focused sub-entry | `TMarkdownText`, `TVirtualMarkdown`, markdown parser and layout helpers                                                                                                         |
+| `@simon_he/vue-tui/experimental` | Experimental      | `TVirtualList`, `TLogView`, log search/link/minimap components, append-only log store, TLog plugins                                                                             |
+
+High-throughput log and virtualized APIs are intentionally kept out of the root entrypoint until their API surface settles.
+
+## Browser Usage
 
 ```vue
 <script setup lang="ts">
-import { computed, ref } from "vue";
-import { TerminalProvider, TBox, TInput, TText, useLayout } from "@simon_he/vue-tui";
+import { ref } from "vue";
+import { TerminalProvider, TBox, TInput, TText } from "@simon_he/vue-tui";
 
-const layout = useLayout();
-const cols = computed(() => layout.clipRect?.w ?? 80);
-const rows = computed(() => layout.clipRect?.h ?? 24);
 const input = ref("");
 </script>
 
 <template>
   <TerminalProvider :cols="80" :rows="24" :default-style="{ fg: 'whiteBright' }">
-    <TBox
-      :x="0"
-      :y="0"
-      :w="80"
-      :h="24"
-      border
-      title="Demo"
-      :padding="1"
-      :style="{ fg: 'blueBright' }"
-    >
-      <TText :x="0" :y="0" :w="78" :value="`cols=${cols} rows=${rows}`" />
+    <TBox :x="0" :y="0" :w="80" :h="24" border title="Demo" :padding="1">
+      <TText :x="0" :y="0" :w="78" value="Vue TUI is running" />
       <TInput :x="0" :y="20" :w="78" v-model="input" placeholder="Type..." />
     </TBox>
   </TerminalProvider>
 </template>
 ```
 
-## 组件文档与验收标准
+## Terminal Usage
 
-- VitePress 文档站点（本地）：`bun run --filter '@simon_he/vue-tui' docs:dev`（入口 `docs/index.md`）
-- 组件使用文档：`docs/components.md`
-- 组件 Props/Events（自动生成）：`docs/generated/components-api.md`（脚本：`scripts/generate-component-api-docs.ts`）
-- 组件验收标准（可信赖组件定义 + 测试范围）：`docs/components-acceptance.md`
-- Terminal 兼容性与颜色一致性：`docs/terminal-compatibility.md`
-- 性能关注点与回归策略：`docs/performance.md`
+For a real terminal, mount a headless Vue app and attach stdout/stdin:
 
-### 终端（真实 CLI）渲染
+```ts
+import { createStdinDriver, createStdoutRenderer, createTerminalApp } from "@simon_he/vue-tui";
+import App from "./App.vue";
 
-内置 `vue-terminal run`，直接在真实终端中跑 UI（stdout renderer + stdin driver）：
+const app = createTerminalApp({
+  cols: process.stdout.columns || 80,
+  rows: process.stdout.rows || 24,
+  component: App as any,
+  defaultStyle: { fg: "whiteBright" },
+});
+
+app.mount();
+
+const renderer = createStdoutRenderer(app.terminal, {
+  output: process.stdout,
+  hideCursor: true,
+  colorMode: "auto",
+});
+
+app.scheduler.flush();
+
+const driver = createStdinDriver({
+  dispatch(event) {
+    const prevented = app.events.dispatch(event);
+    app.scheduler.flush();
+    return prevented;
+  },
+  enableMouse: true,
+  onExit() {
+    driver.dispose();
+    renderer.dispose();
+    app.dispose();
+    process.exit(0);
+  },
+});
+```
+
+## Core Concepts
+
+- `createTerminal({ cols, rows })` creates the cell buffer, cursor, planes, scrollback, and commit events.
+- `createDomRenderer(terminal, container)` renders terminal cells to DOM with row caching and optional DOM scroll operations.
+- `createStdoutRenderer(terminal, options)` emits ANSI output for real terminal UIs.
+- `TerminalProvider` wires terminal, renderer, events, scheduler, runtime, layout, and input plugins for browser Vue usage.
+- `createTerminalApp()` provides the same runtime wiring without a DOM renderer, for CLI apps and tests.
+- `TRenderPlane` separates transcript, chrome, and overlay surfaces so small UI updates do not repaint large content panes.
+
+## API Surface
+
+### Root Components
+
+| Component                                                                 | Purpose                                          |
+| ------------------------------------------------------------------------- | ------------------------------------------------ |
+| `TerminalProvider`                                                        | Browser terminal runtime provider                |
+| `TText`                                                                   | Fixed-position text drawing                      |
+| `TBox`                                                                    | Border, title, padding, and clipped content area |
+| `TView`, `TAnchor`, `TFlow`                                               | Layout containers                                |
+| `TInput`, `TInputBox`, `TSelect`, `TDialog`, `TPathPicker`, `TJsonEditor` | Interactive terminal widgets                     |
+| `TRenderPlane`, `TRenderLayer`                                            | Plane/layer routing                              |
+| `TTransition`                                                             | Time-based mount/unmount transitions             |
+
+### Core And Renderer APIs
+
+| API                                           | Purpose                                     |
+| --------------------------------------------- | ------------------------------------------- |
+| `createTerminal`                              | In-memory terminal and planes               |
+| `createDomRenderer`                           | Browser DOM renderer                        |
+| `createStdoutRenderer`                        | CLI/stdout renderer                         |
+| `createEventManager`, `createCliEventManager` | Pointer/keyboard dispatch to terminal nodes |
+| `createTerminalApp`                           | Headless Vue app for CLI/tests              |
+| `createRuntime`                               | Imperative component mounting               |
+| `createTerminalRouter`                        | Terminal route state                        |
+
+### Markdown Entry
+
+| API                                                                      | Purpose                                                  |
+| ------------------------------------------------------------------------ | -------------------------------------------------------- |
+| `TMarkdownText`                                                          | Markdown text block                                      |
+| `TVirtualMarkdown`                                                       | Virtualized markdown viewport for long/streaming content |
+| `createTuiMarkdownParser`                                                | Parser wrapper around `stream-markdown-parser`           |
+| `buildMarkdownBlocks`, `buildMarkdownVisualRows`, `layoutMarkdownBlocks` | Markdown pipeline helpers                                |
+
+### Experimental Entry
+
+| API                                                                                 | Purpose                                              |
+| ----------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `TVirtualList`                                                                      | Virtual list with dirty-row and scroll optimizations |
+| `TLogView`                                                                          | Append-only / retained-window log viewport           |
+| `createAppendOnlyLogStore`                                                          | Streaming log source for `TLogView`                  |
+| `TLogSearchBar`, `TLogSearchResults`, `TLogVirtualSearchResults`, `TLogSearchPager` | Log search UI                                        |
+| `TLogLinksPanel`, `TLogVirtualLinksPanel`                                           | Link navigation UI                                   |
+| `TLogScrollbar`, `TLogMinimap`                                                      | Log navigation affordances                           |
+
+## Performance Guide
+
+Use the renderer features that match the workload:
+
+- Split large transcript content and frequently changing chrome into different `TRenderPlane`s.
+- Use `TVirtualList` for large lists rather than rendering all rows as components.
+- Use `TLogView` with `createAppendOnlyLogStore({ maxLines })` for streaming logs.
+- Provide stable line keys for custom `TLogView` sources; mutable tail rows should get changing keys.
+- For DOM rendering, row-key prepass defaults to `"auto"` and enables itself only when cached-row hit ratio is useful.
+- For stdout rendering, set `colorMode` or `DIMCODE_COLOR_MODE` when the terminal color capability is known.
+- Reuse style objects on hot paths instead of creating new object literals every frame.
+
+Useful checks:
 
 ```bash
-pnpm build
-node cli.mjs --app basic
+pnpm run bench:dom-renderer
+pnpm run bench:scroll-mailbox
+pnpm run bench:phase2
 ```
 
-## 示例工程
+More detail: [docs/performance.md](./docs/performance.md) and [docs/high-throughput-rendering.md](./docs/high-throughput-rendering.md).
 
-```bash
-# 浏览器示例（交互测试）
-pnpm -C examples/basic dev
+## Colors And Themes
 
-# 打包 browser
-pnpm build:examples
-
-# 打包成 terminal 产物并运行
-pnpm build:examples:terminal
-pnpm run:basic:terminal
-
-# 运行完整 experimental TLogView Lab
-pnpm run example:tlog-view-lab
-
-# 交互运行 TLogView Lab
-pnpm run run:tlog-view-lab
-```
-
-terminal 构建产物会生成 `dist-terminal/terminal.js`，可以直接作为 `bin` 入口使用。
-
-## 核心概念
-
-- Buffer: 以 Cell 网格存储字符与样式，负责最小化更新
-- Renderer: 将 Buffer diff 渲染为 DOM（后续可扩展 canvas）
-- EventManager: DOM 事件 -> cell 坐标 -> 命中测试 -> 派发给组件
-- Vue Layer: 提供 `TerminalProvider` 与内置组件 (TText/TBox/TView)
-- UI Layer: 通用组件与指令（`select`, `v-if`, `v-show` 等）
-- Vue3 对齐: 事件名称/修饰符/行为尽量与浏览器 Vue3 保持一致
-
-## 模块分层（建议结构）
-
-```
-src/
-  core/
-    buffer/       # Cell 网格、dirty 标记、宽字符
-    terminal/     # Terminal API（write/clear/resize/batch/commit）
-    ansi/         # ANSI 解析 -> Style
-  renderer/
-    dom/          # 行/Span 渲染、diff 更新
-  events/
-    manager/      # 坐标映射、hit test、事件派发
-  vue/
-    components/   # TerminalProvider, TText, TBox, TView
-    composables/  # useTerminal, useTerminalNode
-    directives/   # v-if, v-show, v-model, v-focus 等
-    runtime/      # 动态插入、组件工厂、命令式渲染
-```
-
-## 数据流
-
-```
-Vue 组件 -> Terminal API -> Buffer -> Diff -> Renderer -> DOM
-DOM 事件 -> EventManager -> HitTest -> Vue 组件事件回调
-```
-
-## 核心数据结构（设计草案）
+Styles support ANSI color names, hex colors, and terminal text attributes:
 
 ```ts
 type Style = {
@@ -132,392 +178,55 @@ type Style = {
   italic?: boolean;
   underline?: boolean;
   inverse?: boolean;
-};
-
-type Cell = {
-  ch: string;
-  style: Style;
-  width: 1 | 2; // 宽字符支持
-};
-
-type Buffer = {
-  rows: Cell[][];
-  cols: number;
-  rowsCount: number;
-  dirtyRows: boolean[];
+  href?: string;
 };
 ```
 
-## 终端语义范围（初版约束）
+DOM and stdout renderers share the same ANSI palette resolver. `createDomRenderer` exposes palette values as CSS variables, while `createStdoutRenderer` maps them to truecolor or downgraded ANSI sequences depending on `colorMode`.
 
-- `write()` 默认不解析 ANSI，仅做“就地写入”，越界裁剪
-- `writeAnsi()` 解析 ANSI 样式与基础控制序列
-- 光标与换行：`write()` 未提供 `x/y` 时使用内部 cursor，带 `x/y` 不更新全局 cursor
-- `scroll()` 仅滚动可视区域（是否保留 scrollback 由实现决定）
+## Package And Release Notes
 
-## Viewport 与 Scrollback（建议）
+- The published package ships `dist` only. Export targets point to built ESM/CJS/types files.
+- Root, markdown, and experimental entrypoints are available as both ESM and CJS after build.
+- The package does not declare a Node engine for the root browser/core API. CLI usage requires a Node-like process/stdout/stdin environment.
+- The markdown sub-entry depends on `stream-markdown-parser`; check that dependency chain if your runtime has strict engine policies.
+- Experimental APIs can change before the next stable release. Keep imports from `/experimental` isolated in application code.
 
-- Buffer 区分 viewport（可视区域）与 scrollback（历史区域）
-- cursor 驱动写入在底部时超出触发滚动
-- `scroll(lines)` 只移动 viewport，不影响 buffer 内容
-- 支持 `scrollTo()` 与 scrollback 上限（内存可控）
+## Known Limitations
 
-## Terminal API（设计草案）
+- `TVirtualMarkdown` reuses block-level layout during streaming, but parsing still starts from the current full markdown string because the parser dependency exposes full-buffer parsing.
+- `TLogView` is optimized for append-only and retained-window sources; arbitrary random mutation workloads should provide explicit stable keys and should be tested with the target renderer.
+- Terminal emoji and East Asian width behavior still depends on the user terminal and font.
+- ANSI16 colors follow the terminal theme; use truecolor or ansi256 for more deterministic color output.
+- No canvas renderer is currently shipped.
 
-```ts
-interface Terminal {
-  resize(cols: number, rows: number): void;
-  clear(x?: number, y?: number, w?: number, h?: number): void;
-  write(text: string, opts?: { x?: number; y?: number; style?: Style }): void;
-  writeAnsi(text: string, opts?: { x?: number; y?: number }): void;
-  put(x: number, y: number, ch: string, style?: Style): void;
-  fill(x: number, y: number, w: number, h: number, ch?: string, style?: Style): void;
-  scroll(lines: number): void;
-  setCursor(x: number, y: number, visible?: boolean): void;
-  batch(fn: () => void): void;
-  commit(): void;
-  on(event: TerminalEvent, cb: (e: TerminalEventPayload) => void): () => void;
-  dispose(): void;
-}
+## Development
+
+```bash
+pnpm install
+pnpm run typecheck
+pnpm run lint
+pnpm run test
+pnpm run build
 ```
 
-## 事件模型（设计草案）
+Examples:
 
-- 事件名称与 Vue3 DOM 事件对齐（`@click`, `@keydown`, `@input` 等）
-- DOM 事件转换为 cell 坐标 (cellX/cellY)
-- hit test 查找当前坐标命中的节点 (支持 zIndex)
-
-```ts
-type TerminalEvent =
-  | "click"
-  | "dblclick"
-  | "contextmenu"
-  | "pointerdown"
-  | "pointerup"
-  | "pointermove"
-  | "pointerenter"
-  | "pointerleave"
-  | "mousedown"
-  | "mouseup"
-  | "mousemove"
-  | "mouseenter"
-  | "mouseleave"
-  | "wheel"
-  | "keydown"
-  | "keyup"
-  | "input"
-  | "change"
-  | "compositionstart"
-  | "compositionupdate"
-  | "compositionend"
-  | "focus"
-  | "blur"
-  | "drag";
-
-type TerminalBaseEvent = {
-  type: TerminalEvent;
-  target: TerminalNode | null;
-  currentTarget: TerminalNode | null;
-  bubbles: boolean;
-  cancelable: boolean;
-  defaultPrevented: boolean;
-  timeStamp: number;
-  stopPropagation(): void;
-  preventDefault(): void;
-  nativeEvent?: Event;
-};
-
-type TerminalPointerEvent = TerminalBaseEvent & {
-  clientX: number;
-  clientY: number;
-  cellX: number;
-  cellY: number;
-  button?: number;
-  buttons?: number;
-  ctrlKey?: boolean;
-  shiftKey?: boolean;
-  altKey?: boolean;
-  metaKey?: boolean;
-  deltaY?: number;
-};
-
-type TerminalKeyboardEvent = TerminalBaseEvent & {
-  key: string;
-  code: string;
-  ctrlKey?: boolean;
-  shiftKey?: boolean;
-  altKey?: boolean;
-  metaKey?: boolean;
-  repeat?: boolean;
-};
+```bash
+pnpm -C examples/basic dev
+pnpm run build:examples
+pnpm run build:examples:terminal
+pnpm run run:basic:terminal
+pnpm run example:tlog-view-lab
 ```
 
-## 事件派发与冒泡（建议）
+Docs:
 
-- 默认冒泡，支持 `stopPropagation()`/`preventDefault()`，语义与 DOM 一致
-- 支持捕获阶段（可选），用于全局拦截（与 `.capture` 对齐）
-- 拖拽使用 pointer capture，保证按下后持续命中
-- 支持 `contextmenu` 事件（右键菜单）
-
-## 事件桥接（建议）
-
-- Terminal 事件与 Vue 组件事件做统一归一化
-- 事件路径包含命中节点链，便于冒泡与拦截
-- `pointer` 事件优先于 `mouse`，便于兼容触控
-
-## Vue3 浏览器事件对齐（约定）
-
-- 事件名称：与浏览器 DOM 事件一致（`click`, `keydown`, `input`, `focus` 等）
-- 事件修饰符：支持 `.stop` `.prevent` `.capture` `.once` `.passive` `.self` `.exact`
-- 键盘修饰符：`.ctrl` `.shift` `.alt` `.meta` `.enter` `.esc` 等与 Vue3 行为一致
-- 指针/鼠标：`pointer*` 优先，`mouse*` 兼容；`clientX/clientY` 保留
-- 事件对象：保留原生字段，并额外提供 `cellX/cellY` 与 `nativeEvent`
-- `v-model`：保持 `modelValue` + `update:modelValue` 的 Vue3 约定
-
-## 事件映射表（核心字段）
-
+```bash
+pnpm run docs:gen
+pnpm run docs:dev
+pnpm run docs:build
 ```
-DOM Mouse/Pointer Event -> TerminalPointerEvent
-- clientX/clientY 保留，额外提供 cellX/cellY
-- button/buttons/ctrlKey/shiftKey/altKey/metaKey 保留
-DOM Keyboard Event -> TerminalKeyboardEvent
-- key/code/repeat/ctrlKey/shiftKey/altKey/metaKey 保留
-DOM Input/Composition Event -> TerminalBaseEvent
-- inputType/data 通过 nativeEvent 获取
-```
-
-## `@input` / `@change` 触发规则（建议）
-
-- `TInput` 输入过程中触发 `input`，提交时触发 `change`
-- `compositionstart/update/end` 与浏览器一致，结束后触发一次 `input`
-- `v-model` 绑定：`input` 时更新 `modelValue`，`change` 作为提交确认
-
-## Pointer Capture / Focus / Blur 规则（建议）
-
-- `pointerdown` 后启用捕获，直到 `pointerup` 释放
-- `focus` 由点击或 `v-focus` 触发，`blur` 由切换焦点或卸载触发
-- `focusin/focusout` 可选支持，用于冒泡式焦点事件
-
-## Vue 组件层（设计草案）
-
-```vue
-<TerminalProvider :cols="80" :rows="24">
-  <TView :x="2" :y="2" :w="20" :h="5" @click="onClick">
-    <TText :value="title" :style="{ fg: 'green' }" />
-    <TBox border />
-  </TView>
-</TerminalProvider>
-```
-
-- `TerminalProvider`: 创建 terminal、绑定 renderer 和 event manager
-- `TView`: 提供局部坐标系、事件区域、zIndex
-- `TText`: 响应式写入文字
-- `TBox`: 绘制边框、标题
-
-## 通用组件与指令
-
-- 通用组件：`TSelect`, `TInput`, `TList`, `TTable`, `TDialog`
-- 指令：
-  - `v-if`: 条件渲染/卸载组件，释放 buffer 区域
-  - `v-show`: 仅隐藏展示，保持节点存在以保留事件与状态
-  - `v-model`: 绑定 `TInput` 文本与光标状态
-  - `v-focus`: 让组件获得焦点（键盘输入）
-
-## 动态插入组件（命令式）
-
-支持在事件回调中插入组件，例如监听 `input` 后插入 `TSelect`。
-通过 `useTerminalRuntime()` 或 `createPortal()` 提供命令式入口。
-
-```ts
-const { mount } = useTerminalRuntime();
-
-function onInputCommit(value: string) {
-  if (value.startsWith("/")) {
-    mount(TSelect, {
-      x: 2,
-      y: 10,
-      w: 20,
-      h: 6,
-      options: ["a", "b", "c"],
-      onSelect: (v) => console.log(v),
-    });
-  }
-}
-```
-
-约束：
-
-- 动态插入的组件必须显式提供布局 (x/y/w/h) 或依赖父容器布局
-- 插入/卸载会触发局部重绘，不影响其它区域
-
-## 命令式渲染协议（建议）
-
-- `mount()` 返回 handle，包含 `update()` / `unmount()` / `move()` 等操作
-- 允许传入 `key` 复用实例，避免频繁销毁
-- `TerminalProvider` 卸载时自动清理所有命令式节点
-
-```ts
-type TerminalHandle = {
-  update: (props: Record<string, unknown>) => void;
-  move: (x: number, y: number) => void;
-  unmount: () => void;
-};
-```
-
-## 组件生命周期与资源管理（建议）
-
-- 挂载：注册事件节点、占用 buffer 区域、写入初始内容
-- 更新：清理旧区域 + 写入新内容，保持最小 dirty 范围
-- 卸载：释放事件节点、清理 buffer 区域、移除焦点/输入绑定
-
-对 `v-if`/`v-show` 的行为约定：
-
-- `v-if`: 触发卸载与资源释放（清 buffer、解绑事件）
-- `v-show`: 仅隐藏渲染，保留节点与状态（不解绑事件）
-
-## 焦点与输入协议（建议）
-
-- 引入 focus manager，维护当前焦点组件
-- `v-focus`/`focus()` 触发焦点切换，自动更新光标样式
-- 键盘事件仅派发给焦点组件
-- `TInput` 需要处理：
-  - 文本插入、删除、移动光标
-  - 组合输入（IME）阶段的暂存显示
-  - Enter/Escape 行为（提交/取消）
-
-## 键盘与快捷键（建议）
-
-- 统一规范化键名（如 `Enter`/`Esc`/`ArrowUp`）
-- 仅焦点组件接收输入，支持全局快捷键注册
-- 支持组合键与平台差异（macOS/Windows/Linux）
-
-## 常见组件交互约定（示例）
-
-- `TSelect`:
-  - 上下键切换选项，Enter 确认，Esc 取消
-  - `onOpen`/`onClose` 用于显示/隐藏下拉
-- `TList`:
-  - 支持滚动、虚拟化（列表过长时）
-- `TDialog`:
-  - 居中布局、遮罩区域、阻止底层事件
-
-## 0.0.x 迁移提示
-
-`TList` 的滚轮滚动只移动 viewport，不再同步移动选中项，也不再触发
-`update:modelValue`。如果旧代码依赖滚轮更新选中项，请改为分别监听
-`@scroll` 和 `@update:modelValue`：
-
-```vue
-<TList
-  :items="items"
-  :model-value="selectedIndex"
-  @update:model-value="selectedIndex = $event"
-  @scroll="viewportTop = $event"
-  @change="confirmItem"
-/>
-```
-
-`TRenderPlane.plane` mount 后不再动态迁移子树；需要换 plane 时给
-`TRenderPlane` 加 key 触发重挂载：
-
-```vue
-<TRenderPlane :key="activePlane" :plane="activePlane">
-  <PaneBody />
-</TRenderPlane>
-```
-
-`scheduler.queueFrameTask()` 返回 `false` 表示任务被拒绝，producer 应清理本地
-pending 状态；返回 `true` 或旧实现的 `undefined` 都表示已接受。
-
-## 响应式与尺寸变化（建议）
-
-- `TerminalProvider` 监听容器尺寸变化，触发 `resize(cols, rows)` 并广播 `resize` 事件
-- 组件接收 `onResize` 或 `useTerminalSize()` 响应尺寸变化
-- 布局建议：
-  - `TView` 支持 `w/h` 为百分比或 `auto`（依赖父容器）
-  - resize 时触发局部重排，避免全量重绘
-
-## 布局与坐标系统（建议）
-
-- 坐标系基于 cell 网格，所有位置/尺寸以整数为主
-- 布局模式：
-  - `absolute`: `x/y/w/h` 明确指定
-  - `flow`: 垂直/水平流布局（简化版）
-  - `anchor`: 支持 `left/right/top/bottom` 锚定
-- 约束：`minW/maxW/minH/maxH`，超出时裁剪
-- 容器提供 `padding` 与 `clip`，子组件默认裁剪到内容区域
-
-## 布局计算（简版规则）
-
-- 先计算父容器 contentRect，再计算子组件布局
-- `absolute` 优先：有明确 `x/y/w/h` 时直接裁剪
-- `anchor` 次之：根据边距计算剩余空间
-- `flow` 最后：按方向累积尺寸，支持 `gap` 与 `wrap`
-- `auto` 尺寸：基于内容测量（文本/子组件）得到
-
-## 带边框 Box 的内容保护
-
-当 `TBox` 带边框时，需要保护内容区域不被破坏：
-
-- 外框占 1 cell 边距，内容区域为 `(x+1, y+1, w-2, h-2)`
-- 内容写入必须裁剪到内容区域，避免覆盖边框
-- 当内容超出时，支持 `overflow: clip | scroll`
-- 建议 `TBox` 内部提供 `padding` 与 `contentRect`，子组件写入基于 `contentRect`
-
-## 渲染策略（初版）
-
-- 以行 (row) 为单位进行 dirty 标记
-- 每行合并相同样式为 span，减少 DOM 节点数
-- `batch()` + `commit()` 合并更新
-
-## 渲染调度（建议）
-
-- 所有写入走调度器聚合到下一帧（`requestAnimationFrame`）
-- `batch()` 在同一帧内合并多个写入，减少 diff 次数
-- 支持 `flush()` 立即渲染（用于调试或关键交互）
-
-## 字体度量与像素映射（建议）
-
-- 统一使用等宽字体，测量 `cellWidth`/`cellHeight`
-- 设备像素比变化时重新测量并触发重排
-- 支持固定 `cellSize` 覆盖测量结果（用于稳定布局）
-
-## ANSI 支持
-
-- `writeAnsi()` 接受 ANSI 字符串，解析后写入 Buffer
-- 可先实现轻量解析器，后续切换到更完整的 ANSI 样式库（如 `ansis`）
-
-## 文本分段与宽字符策略（建议）
-
-- 使用 grapheme 分段，避免组合字符被拆分
-- 宽字符占用 2 cell，后续 cell 标记为 continuation
-- 无法渲染的字符使用占位符（如 `?`）并记录告警
-
-## 主题与样式系统（建议）
-
-- 提供 `Theme` 对象（默认 fg/bg、16/256 色板、字体设置）
-- ANSI 颜色映射依赖主题，可热更新
-- 允许组件局部覆盖主题（如 `TDialog`）
-
-## 光标、选择与剪贴板（建议）
-
-- 光标形态：`block`/`underline`/`bar`，支持闪烁
-- 选择：鼠标拖拽选区，支持跨行
-- 剪贴板：复制/粘贴基于 Buffer 内容而非 DOM 文本
-
-## 设计注意事项
-
-- 文本宽度：需支持 grapheme + wcwidth，避免 emoji/组合字符错位
-- 组合模型：建议引入容器裁剪与 zIndex，避免组件相互覆盖
-- 调度机制：统一 batch/commit，避免组件更新引发频繁重绘
-- 事件映射：需基于字体度量映射 cell 坐标，resize 时重算
-- 滚动与 resize：需要明确 scrollback 与重排策略
-
-## 后续计划（草案）
-
-- 基础组件库完善 (TList/TInput/TTable)
-- Canvas 渲染器
-- 虚拟滚动和大 buffer 支持
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -30,19 +30,16 @@
   },
   "exports": {
     ".": {
-      "bun": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
     "./markdown": {
-      "bun": "./src/markdown.ts",
       "types": "./dist/markdown.d.ts",
       "import": "./dist/markdown.js",
       "require": "./dist/markdown.cjs"
     },
     "./experimental": {
-      "bun": "./src/experimental.ts",
       "types": "./dist/experimental.d.ts",
       "import": "./dist/experimental.js",
       "require": "./dist/experimental.cjs"
@@ -105,7 +102,7 @@
     "vue": "^3.5.33"
   },
   "peerDependencies": {
-    "vue": "^3.5.27"
+    "vue": ">=3.3.0 <4"
   },
   "lint-staged": {
     "*": "oxfmt --write",

--- a/scripts/bench-dom-renderer.ts
+++ b/scripts/bench-dom-renderer.ts
@@ -57,7 +57,7 @@ type Scenario = Readonly<{
 }>;
 
 type PrepassOptions = Readonly<{
-  enableRowKeyPrepass: boolean;
+  enableRowKeyPrepass: boolean | "auto";
 }>;
 
 function createScenario(options: Parameters<typeof createDomRenderer>[2] = {}): Scenario {
@@ -180,12 +180,14 @@ function runScenario<T>(
   }
 }
 
-function runPrepassModes<T>(run: (enableRowKeyPrepass: boolean) => T): {
+function runPrepassModes<T>(run: (enableRowKeyPrepass: boolean | "auto") => T): {
+  off: T;
   default: T;
   prepass: T;
 } {
   return {
-    default: run(false),
+    off: run(false),
+    default: run("auto"),
     prepass: run(true),
   };
 }
@@ -197,9 +199,10 @@ function assertRowKeyPrepassStats(
   enabledHits: number,
   enabledMisses: number,
 ): void {
-  assert.equal(stats.rowKeyPrepassChecks, options.enableRowKeyPrepass ? enabledChecks : 0);
-  assert.equal(stats.rowKeyPrepassHits, options.enableRowKeyPrepass ? enabledHits : 0);
-  assert.equal(stats.rowKeyPrepassMisses, options.enableRowKeyPrepass ? enabledMisses : 0);
+  const expectPrepass = options.enableRowKeyPrepass !== false;
+  assert.equal(stats.rowKeyPrepassChecks, expectPrepass ? enabledChecks : 0);
+  assert.equal(stats.rowKeyPrepassHits, expectPrepass ? enabledHits : 0);
+  assert.equal(stats.rowKeyPrepassMisses, expectPrepass ? enabledMisses : 0);
 }
 
 function benchPlainRows(): RowRenderSnapshot {
@@ -322,7 +325,7 @@ function benchMixedRowKeyPrepass(options: PrepassOptions): RoundSnapshot {
     });
     const secondFlush = measured.value;
 
-    if (options.enableRowKeyPrepass) {
+    if (options.enableRowKeyPrepass !== false) {
       assert.ok(secondFlush.rowKeyPrepassChecks > 0);
       assert.ok(secondFlush.rowKeyPrepassHits > 0);
       assert.ok(secondFlush.rowKeyPrepassMisses > 0);

--- a/src/core/ansi-palette.ts
+++ b/src/core/ansi-palette.ts
@@ -1,6 +1,7 @@
 import type { AnsiColorName } from "./types.js";
 
 export type AnsiRgb = Readonly<{ r: number; g: number; b: number }>;
+export type ThemePalette = Partial<Record<AnsiColorName, string>>;
 
 export const ANSI_PALETTE_HEX: Readonly<Record<AnsiColorName, string>> = Object.freeze({
   black: "#000000",
@@ -37,13 +38,21 @@ const ANSI_PALETTE_RGB: Readonly<Record<AnsiColorName, AnsiRgb>> = Object.freeze
   ) as any,
 );
 
-export function ansiColorHex(name?: AnsiColorName): string | undefined {
-  if (!name) return undefined;
+export function isAnsiColorName(name: string | undefined): name is AnsiColorName {
+  return typeof name === "string" && Object.prototype.hasOwnProperty.call(ANSI_PALETTE_HEX, name);
+}
+
+export function ansiColorHex(name?: string, palette?: ThemePalette | null): string | undefined {
+  if (!isAnsiColorName(name)) return undefined;
+  const custom = palette?.[name];
+  if (custom && ansiHexToRgb(custom)) return custom;
   return ANSI_PALETTE_HEX[name];
 }
 
-export function ansiColorRgb(name?: AnsiColorName): AnsiRgb | undefined {
-  if (!name) return undefined;
+export function ansiColorRgb(name?: string, palette?: ThemePalette | null): AnsiRgb | undefined {
+  if (!isAnsiColorName(name)) return undefined;
+  const custom = palette?.[name];
+  if (custom) return ansiHexToRgb(custom) ?? ANSI_PALETTE_RGB[name];
   return ANSI_PALETTE_RGB[name];
 }
 
@@ -51,7 +60,10 @@ export function ansiCssVar(name: AnsiColorName): string {
   return `var(--vt-color-${name})`;
 }
 
-export function installAnsiPaletteCssVars(container: HTMLElement): void {
+export function installAnsiPaletteCssVars(
+  container: HTMLElement,
+  palette?: ThemePalette | null,
+): void {
   for (const [name, hex] of Object.entries(ANSI_PALETTE_HEX))
-    container.style.setProperty(`--vt-color-${name}`, hex);
+    container.style.setProperty(`--vt-color-${name}`, ansiColorHex(name, palette) ?? hex);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ export {
   detectTerminalColorCapability,
   type TerminalColorCapability,
 } from "./core/ansi/capability.js";
+export type { ThemePalette } from "./core/ansi-palette.js";
 export { parseAnsiSgr } from "./core/ansi/sgr.js";
 export { charCellWidth } from "./core/buffer/width.js";
 export type {
@@ -92,6 +93,9 @@ export type {
   DomRendererFlushSample,
   DomRendererFlushStats,
   DomRendererOptions,
+  DomRendererRowKeyPrepassDebugStats,
+  DomRendererRowKeyPrepassDecision,
+  DomRendererRowKeyPrepassMode,
   DomRendererRowRenderDebugStats,
   DomRendererRowRenderStats,
   DomRendererSyncFlushDecision,

--- a/src/renderer/cli/stdout-renderer.ts
+++ b/src/renderer/cli/stdout-renderer.ts
@@ -7,7 +7,8 @@ import type {
 } from "../../core/types.js";
 import { Buffer } from "node:buffer";
 import process from "node:process";
-import { ansiColorRgb, ansiHexToRgb } from "../../core/ansi-palette.js";
+import type { ThemePalette } from "../../core/ansi-palette.js";
+import { ansiColorRgb, ansiHexToRgb, isAnsiColorName } from "../../core/ansi-palette.js";
 import { detectTerminalColorCapability } from "../../core/ansi/capability.js";
 import {
   ansi8BgOpen,
@@ -88,7 +89,7 @@ export type StdoutRenderer = Readonly<{
 }>;
 
 export type StdoutColorMode = "auto" | "truecolor" | "ansi256" | "ansi16" | "ansi8";
-export type ThemePalette = Partial<Record<AnsiColorName, string>>;
+export type { ThemePalette } from "../../core/ansi-palette.js";
 
 export function createStdoutRenderer(
   terminal: Terminal,
@@ -354,10 +355,8 @@ export function createStdoutRenderer(
     return typeof value === "string" && value ? value : null;
   }
 
-  function resolveAnsiColorRgb(name: AnsiColorName) {
-    const hex = palette?.[name];
-    if (hex) return ansiHexToRgb(hex) ?? ansiColorRgb(name);
-    return ansiColorRgb(name);
+  function resolveAnsiColorRgb(name: string) {
+    return ansiColorRgb(name, palette);
   }
 
   function openColor(fg?: string): string {
@@ -374,9 +373,10 @@ export function createStdoutRenderer(
       return truecolorFgOpen(rgb);
     }
     // AnsiColorName path (fallback layer + legacy themes)
+    if (!isAnsiColorName(fg)) return "";
     if (colorMode === "ansi8") return ansi8FgOpen(fg as AnsiColorName);
     if (colorMode === "ansi16") return ansi16FgOpen(fg as AnsiColorName);
-    const rgb = resolveAnsiColorRgb(fg as AnsiColorName);
+    const rgb = resolveAnsiColorRgb(fg);
     if (!rgb) return "";
     if (colorMode === "ansi256") return ansi256FgOpen(rgbToAnsi256(rgb));
     return truecolorFgOpen(rgb);
@@ -396,9 +396,10 @@ export function createStdoutRenderer(
       return truecolorBgOpen(rgb);
     }
     // AnsiColorName path (fallback layer + legacy themes)
+    if (!isAnsiColorName(bg)) return "";
     if (colorMode === "ansi8") return ansi8BgOpen(bg as AnsiColorName);
     if (colorMode === "ansi16") return ansi16BgOpen(bg as AnsiColorName);
-    const rgb = resolveAnsiColorRgb(bg as AnsiColorName);
+    const rgb = resolveAnsiColorRgb(bg);
     if (!rgb) return "";
     if (colorMode === "ansi256") return ansi256BgOpen(rgbToAnsi256(rgb));
     return truecolorBgOpen(rgb);

--- a/src/renderer/dom/dom-renderer.ts
+++ b/src/renderer/dom/dom-renderer.ts
@@ -1,7 +1,13 @@
 import type { TerminalRenderPlane } from "../../core/render-plane.js";
 import type { Cell, Style, Terminal, TerminalScrollOperation } from "../../core/types.js";
 import type { RendererCapabilities } from "../capabilities.js";
-import { ansiColorHex, ansiCssVar, installAnsiPaletteCssVars } from "../../core/ansi-palette.js";
+import type { ThemePalette } from "../../core/ansi-palette.js";
+import {
+  ansiColorHex,
+  ansiCssVar,
+  installAnsiPaletteCssVars,
+  isAnsiColorName,
+} from "../../core/ansi-palette.js";
 import { TERMINAL_RENDER_PLANES } from "../../core/render-plane.js";
 import { getPlaneTerminal } from "../../core/terminal/create-terminal.js";
 import { DOM_RENDERER_CAPABILITIES } from "../capabilities.js";
@@ -60,10 +66,31 @@ export type DomRendererRowRenderDebugStats = Readonly<{
   lastFlush: DomRendererRowRenderStats | null;
 }>;
 
+export type DomRendererRowKeyPrepassMode = boolean | "auto";
+
+export type DomRendererRowKeyPrepassDecision =
+  | "forced-enabled"
+  | "forced-disabled"
+  | "sampling"
+  | "enabled"
+  | "disabled";
+
+export type DomRendererRowKeyPrepassDebugStats = Readonly<{
+  mode: DomRendererRowKeyPrepassMode;
+  decision: DomRendererRowKeyPrepassDecision;
+  sampleRows: number;
+  sampleHits: number;
+  sampleMisses: number;
+  sampleHitRatio: number | null;
+  lastSampleRows: number;
+  lastSampleHitRatio: number | null;
+}>;
+
 export type DomRendererDebugStats = Readonly<{
   syncFlush: DomRendererSyncFlushStats;
   flush: DomRendererFlushStats;
   rowRender: DomRendererRowRenderDebugStats;
+  rowKeyPrepass: DomRendererRowKeyPrepassDebugStats;
 }>;
 
 export interface DomRenderer {
@@ -73,6 +100,11 @@ export interface DomRenderer {
   readonly metrics: CellMetrics;
   dispose: () => void;
   refresh: () => void;
+  updateTheme: (
+    next: Readonly<{
+      palette?: ThemePalette | null;
+    }>,
+  ) => void;
   setPlaneOffset: (plane: TerminalRenderPlane, offsetPx: number) => void;
   setPlaneViewport: (
     plane: TerminalRenderPlane,
@@ -94,11 +126,15 @@ export interface DomRendererOptions {
    * Enables DOM line-node shifting for terminal scrollOperations.
    */
   enableScrollOperations?: boolean;
+  /** Optional ANSI-name palette exposed as DOM CSS variables. */
+  palette?: ThemePalette | null;
   /**
-   * Enables a key-only early bailout before row segment allocation.
+   * Controls a key-only early bailout before row segment allocation.
    * The normal row cache remains enabled regardless of this option.
+   * Defaults to "auto": sample cached-row hit ratio and keep prepass enabled only
+   * when it pays for itself.
    */
-  enableRowKeyPrepass?: boolean;
+  enableRowKeyPrepass?: DomRendererRowKeyPrepassMode;
 }
 
 interface PlaneLayer {
@@ -126,6 +162,9 @@ const DEFAULT_FONT_FAMILY = [
 ].join(", ");
 const DEFAULT_SYNC_FLUSH_MAX_ROWS = 32;
 const DEFAULT_SYNC_FLUSH_CELL_BUDGET = 4096;
+const PREPASS_SAMPLE_ROWS = 512;
+const PREPASS_ENABLE_HIT_RATIO = 0.5;
+const PREPASS_DISABLE_HIT_RATIO = 0.25;
 
 const styleKeyCache = new WeakMap<object, string>();
 
@@ -190,23 +229,27 @@ function styleKey(style: Style): string {
   return key;
 }
 
-function resolveColorHex(color: string | undefined): string | undefined {
+function resolveColorHex(
+  color: string | undefined,
+  palette?: ThemePalette | null,
+): string | undefined {
   if (!color) return undefined;
   if (color === "transparent") return undefined;
   if (color.startsWith("#")) return color;
-  return ansiColorHex(color as any);
+  return ansiColorHex(color, palette);
 }
 
 function resolveColorCss(color: string | undefined): string | undefined {
   if (!color) return undefined;
   if (color === "transparent") return undefined;
   if (color.startsWith("#")) return color;
-  return ansiCssVar(color as any);
+  if (!isAnsiColorName(color)) return undefined;
+  return ansiCssVar(color);
 }
 
-function applyStyle(span: HTMLSpanElement, style: Style): void {
-  const fgHex = resolveColorHex(style.fg);
-  const bgHex = resolveColorHex(style.bg);
+function applyStyle(span: HTMLSpanElement, style: Style, palette?: ThemePalette | null): void {
+  const fgHex = resolveColorHex(style.fg, palette);
+  const bgHex = resolveColorHex(style.bg, palette);
   const fgCss = resolveColorCss(style.fg);
   const bgCss = resolveColorCss(style.bg);
 
@@ -527,6 +570,7 @@ function tryUpdateSegmentSpans(
   lineEl: HTMLElement,
   segments: readonly RowSegment[],
   metrics: CellMetrics,
+  palette: ThemePalette | null,
 ): boolean {
   if (lineEl.childNodes.length !== segments.length) return false;
 
@@ -543,7 +587,7 @@ function tryUpdateSegmentSpans(
     span.textContent = seg.text;
     resetSpanStyle(span);
     span.style.cssText = `display:inline-block;width:${seg.cols * metrics.cellWidth}px;height:${metrics.cellHeight}px;overflow:hidden;white-space:pre;vertical-align:top`;
-    applyStyle(span, seg.style);
+    applyStyle(span, seg.style, palette);
   }
 
   return true;
@@ -557,6 +601,7 @@ function renderRow(
   lineEl: HTMLElement,
   stats: RowRenderMutableStats,
   enableRowKeyPrepass: boolean,
+  palette: ThemePalette | null,
 ): void {
   stats.rows++;
   const cachedKey = rowCache.get(lineEl);
@@ -624,12 +669,12 @@ function renderRow(
     span.textContent = seg.text;
     resetSpanStyle(span);
     span.style.cssText = `display:inline-block;width:${seg.cols * metrics.cellWidth}px;height:${metrics.cellHeight}px;overflow:hidden;white-space:pre;vertical-align:top`;
-    applyStyle(span, seg.style);
+    applyStyle(span, seg.style, palette);
     return;
   }
 
   const canReuseSpans = canReuseSegmentSpans(segments);
-  if (canReuseSpans && tryUpdateSegmentSpans(lineEl, segments, metrics)) {
+  if (canReuseSpans && tryUpdateSegmentSpans(lineEl, segments, metrics, palette)) {
     stats.segmentReuseRows++;
     stats.spansReused += segments.length;
     return;
@@ -658,7 +703,7 @@ function renderRow(
       span.textContent = seg.text;
     }
     span.style.cssText = `display:inline-block;width:${seg.cols * metrics.cellWidth}px;height:${metrics.cellHeight}px;overflow:hidden;white-space:pre;vertical-align:top`;
-    applyStyle(span, seg.style);
+    applyStyle(span, seg.style, palette);
     fragment.appendChild(span);
   }
 
@@ -683,7 +728,8 @@ export function createDomRenderer(
   // Prevent layout shifts during updates
   container.style.contain = "layout style";
   container.tabIndex = 0;
-  installAnsiPaletteCssVars(container);
+  let palette: ThemePalette | null = options.palette ?? null;
+  installAnsiPaletteCssVars(container, palette);
 
   let metrics = measureCell(container);
   let wideScaleX = 1;
@@ -699,7 +745,7 @@ export function createDomRenderer(
     0,
     Math.floor(options.syncFlushCellBudget ?? DEFAULT_SYNC_FLUSH_CELL_BUDGET),
   );
-  const enableRowKeyPrepass = options.enableRowKeyPrepass === true;
+  const rowKeyPrepassMode = options.enableRowKeyPrepass ?? "auto";
   const capabilities: RendererCapabilities = Object.freeze({
     ...DOM_RENDERER_CAPABILITIES,
     scrollOperations: options.enableScrollOperations !== false,
@@ -712,6 +758,23 @@ export function createDomRenderer(
   let lastDomFlush: DomRendererFlushSample | null = null;
   const rowRenderTotal = createEmptyRowStats();
   let lastRowRenderStats: DomRendererRowRenderStats | null = null;
+  let rowKeyPrepassAutoReady = false;
+  let rowKeyPrepassAutoDecision: Extract<
+    DomRendererRowKeyPrepassDecision,
+    "sampling" | "enabled" | "disabled"
+  > = "sampling";
+  let rowKeyPrepassSampleRows = 0;
+  let rowKeyPrepassSampleHits = 0;
+  let rowKeyPrepassSampleMisses = 0;
+  let rowKeyPrepassLastSampleRows = 0;
+  let rowKeyPrepassLastSampleHitRatio: number | null = null;
+
+  function rowKeyPrepassDecision(): DomRendererRowKeyPrepassDecision {
+    if (rowKeyPrepassMode === true) return "forced-enabled";
+    if (rowKeyPrepassMode === false) return "forced-disabled";
+    return rowKeyPrepassAutoDecision;
+  }
+
   const debugStats: DomRendererDebugStats = {
     get syncFlush() {
       return {
@@ -733,7 +796,54 @@ export function createDomRenderer(
         lastFlush: lastRowRenderStats,
       };
     },
+    get rowKeyPrepass() {
+      const sampleHitRatio =
+        rowKeyPrepassSampleRows > 0 ? rowKeyPrepassSampleHits / rowKeyPrepassSampleRows : null;
+      return {
+        mode: rowKeyPrepassMode,
+        decision: rowKeyPrepassDecision(),
+        sampleRows: rowKeyPrepassSampleRows,
+        sampleHits: rowKeyPrepassSampleHits,
+        sampleMisses: rowKeyPrepassSampleMisses,
+        sampleHitRatio,
+        lastSampleRows: rowKeyPrepassLastSampleRows,
+        lastSampleHitRatio: rowKeyPrepassLastSampleHitRatio,
+      };
+    },
   };
+
+  function shouldUseRowKeyPrepass(): boolean {
+    if (rowKeyPrepassMode === true) return true;
+    if (rowKeyPrepassMode === false) return false;
+    return rowKeyPrepassAutoReady && rowKeyPrepassAutoDecision !== "disabled";
+  }
+
+  function recordRowKeyPrepassAutoStats(stats: RowRenderMutableStats): void {
+    if (rowKeyPrepassMode !== "auto") return;
+    if (stats.rowKeyPrepassChecks === 0) return;
+
+    rowKeyPrepassSampleRows += stats.rowKeyPrepassChecks;
+    rowKeyPrepassSampleHits += stats.rowKeyPrepassHits;
+    rowKeyPrepassSampleMisses += stats.rowKeyPrepassMisses;
+
+    if (rowKeyPrepassSampleRows < PREPASS_SAMPLE_ROWS) return;
+
+    const hitRatio = rowKeyPrepassSampleHits / rowKeyPrepassSampleRows;
+    rowKeyPrepassLastSampleRows = rowKeyPrepassSampleRows;
+    rowKeyPrepassLastSampleHitRatio = hitRatio;
+
+    if (rowKeyPrepassAutoDecision === "enabled") {
+      if (hitRatio < PREPASS_DISABLE_HIT_RATIO) rowKeyPrepassAutoDecision = "disabled";
+    } else if (hitRatio >= PREPASS_ENABLE_HIT_RATIO) {
+      rowKeyPrepassAutoDecision = "enabled";
+    } else {
+      rowKeyPrepassAutoDecision = "disabled";
+    }
+
+    rowKeyPrepassSampleRows = 0;
+    rowKeyPrepassSampleHits = 0;
+    rowKeyPrepassSampleMisses = 0;
+  }
 
   function recordRowRenderStats(stats: RowRenderMutableStats): void {
     if (stats.rows === 0) return;
@@ -863,9 +973,11 @@ export function createDomRenderer(
           y,
           layer.lines[y]!,
           rowStats,
-          enableRowKeyPrepass,
+          shouldUseRowKeyPrepass(),
+          palette,
         );
     }
+    recordRowKeyPrepassAutoStats(rowStats);
     recordRowRenderStats(rowStats);
   }
 
@@ -1151,6 +1263,7 @@ export function createDomRenderer(
     const planesToFlush = scope?.planes ?? TERMINAL_RENDER_PLANES;
     let flushedRows = 0;
     const rowStats = createEmptyRowStats();
+    const useRowKeyPrepass = shouldUseRowKeyPrepass();
 
     for (const plane of planesToFlush) {
       const layer = planeLayers.get(plane);
@@ -1161,7 +1274,16 @@ export function createDomRenderer(
         if (!rows.has(y)) return;
         const line = layer.lines[y];
         if (line)
-          renderRow(layer.terminal, metrics, wideScaleX, y, line, rowStats, enableRowKeyPrepass);
+          renderRow(
+            layer.terminal,
+            metrics,
+            wideScaleX,
+            y,
+            line,
+            rowStats,
+            useRowKeyPrepass,
+            palette,
+          );
         deletePendingRow(plane, rows, y);
         flushedRows++;
       };
@@ -1176,7 +1298,9 @@ export function createDomRenderer(
     }
 
     if (flushedRows > 0) {
+      recordRowKeyPrepassAutoStats(rowStats);
       recordRowRenderStats(rowStats);
+      rowKeyPrepassAutoReady = true;
       domFlushCount++;
       lastDomFlush = {
         mode: options?.mode ?? "deferred",
@@ -1269,6 +1393,18 @@ export function createDomRenderer(
     refresh();
   });
 
+  function updateTheme(
+    next: Readonly<{
+      palette?: ThemePalette | null;
+    }>,
+  ): void {
+    if (disposed) return;
+    if ("palette" in next) {
+      palette = next.palette ?? null;
+      installAnsiPaletteCssVars(container, palette);
+    }
+  }
+
   refresh();
   // Clear initial dirty flags.
   terminal.commit();
@@ -1281,6 +1417,7 @@ export function createDomRenderer(
       return metrics;
     },
     refresh,
+    updateTheme,
     dispose() {
       disposed = true;
       offCommit();

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -1,4 +1,4 @@
-export type { StdoutRenderer } from "./cli/stdout-renderer.js";
+export type { StdoutRenderer, ThemePalette } from "./cli/stdout-renderer.js";
 export { createStdoutRenderer } from "./cli/stdout-renderer.js";
 export type { RendererCapabilities, TerminalRendererLike } from "./capabilities.js";
 export { DOM_RENDERER_CAPABILITIES, HEADLESS_RENDERER_CAPABILITIES } from "./capabilities.js";
@@ -10,6 +10,9 @@ export type {
   DomRendererFlushSample,
   DomRendererFlushStats,
   DomRendererOptions,
+  DomRendererRowKeyPrepassDebugStats,
+  DomRendererRowKeyPrepassDecision,
+  DomRendererRowKeyPrepassMode,
   DomRendererRowRenderDebugStats,
   DomRendererRowRenderStats,
   DomRendererSyncFlushDecision,

--- a/src/vue/components/TLogView.ts
+++ b/src/vue/components/TLogView.ts
@@ -2691,6 +2691,45 @@ export const TLogView = defineComponent({
       return markRowsDirty(viewportRows());
     }
 
+    type TailVisualSnapshot = Readonly<{
+      start: number;
+      rows: number;
+    }>;
+
+    function visualRangeDirtyRows(start: number, end: number): readonly number[] {
+      if (end <= start) return [];
+      const r = normalizedRect();
+      const { y: clipY } = clipOffsets();
+      const visibleStart = currentScrollTop() + clipY;
+      const rows: number[] = [];
+      for (let y = r.y; y < r.y + r.h; y++) {
+        const visualRow = visibleStart + (y - r.y);
+        if (visualRow >= start && visualRow < end) rows.push(y);
+      }
+      return rows;
+    }
+
+    function tailVisualSnapshot(index: number): TailVisualSnapshot {
+      if (!props.wrap) return { start: index, rows: 1 };
+      ensureVisualIndex();
+      return {
+        start: visualStartForLine(index),
+        rows: Math.max(1, visualCounts[index] ?? 1),
+      };
+    }
+
+    function tailMutationDirtyRows(
+      index: number,
+      previous: TailVisualSnapshot | null,
+    ): readonly number[] {
+      if (index < 0) return [];
+      const next = tailVisualSnapshot(index);
+      const prev = previous ?? next;
+      const start = Math.min(prev.start, next.start);
+      const end = Math.max(prev.start + prev.rows, next.start + next.rows);
+      return visualRangeDirtyRows(start, end);
+    }
+
     function applyLinkFocusToSegments(
       segments: readonly TLogVisualSegment[],
       lineIndex: number,
@@ -2855,6 +2894,10 @@ export const TLogView = defineComponent({
         if (shouldAutoMeasureVisualIndex()) requestVisualIndexMeasurement(measuredLineCount);
         else emitVisualIndex();
       };
+      const sameCountTailIndex =
+        droppedHeadLines === 0 && nextCount === prevCount && nextCount > 0 ? nextCount - 1 : -1;
+      const previousTailSnapshot =
+        sameCountTailIndex >= 0 ? tailVisualSnapshot(sameCountTailIndex) : null;
       let wrapExistingMutation = false;
 
       if (props.wrap && droppedHeadLines > 0) {
@@ -2862,6 +2905,11 @@ export const TLogView = defineComponent({
       } else {
         wrapExistingMutation = prepareWrapIndexForSourceChange(prevCount, nextCount);
       }
+
+      const sameCountTailDirtyRows =
+        sameCountTailIndex >= 0
+          ? tailMutationDirtyRows(sameCountTailIndex, previousTailSnapshot)
+          : [];
 
       lastLineCount = nextCount;
       lastFirstLineIndex = nextFirst;
@@ -2918,7 +2966,10 @@ export const TLogView = defineComponent({
             extraDirtyRows: extraDirtyRow == null ? undefined : [extraDirtyRow],
           },
         );
-        if (!changed) markViewportDirty();
+        if (!changed) {
+          if (sameCountTailDirtyRows.length) markRowsDirty(sameCountTailDirtyRows);
+          else markViewportDirty();
+        }
         resumeVisualMeasurement();
         return true;
       }
@@ -2947,7 +2998,8 @@ export const TLogView = defineComponent({
         nextCount > 0 &&
         viewportIntersectsLines(nextCount - 1, nextCount)
       ) {
-        markViewportDirty();
+        if (sameCountTailDirtyRows.length) markRowsDirty(sameCountTailDirtyRows);
+        else markViewportDirty();
         resumeVisualMeasurement();
         return true;
       }

--- a/src/vue/components/TVirtualMarkdown.ts
+++ b/src/vue/components/TVirtualMarkdown.ts
@@ -14,7 +14,8 @@ import {
   watch,
   watchEffect,
 } from "vue";
-import { buildMarkdownVisualRows } from "../markdown/document.js";
+import { buildMarkdownBlocks } from "../markdown/document.js";
+import { layoutMarkdownBlocksCached, type TuiMarkdownLayoutCache } from "../markdown/layout.js";
 import { createTuiMarkdownParser } from "../markdown/parser.js";
 import { paintMarkdownVisualRow } from "../markdown/render.js";
 import { markdownThemeSignature, type TuiMarkdownThemeOverrides } from "../markdown/theme.js";
@@ -122,6 +123,7 @@ export const TVirtualMarkdown = defineComponent({
     const wheelState = createWheelScrollState();
     let builtOnce = false;
     let rebuildVersion = 0;
+    let layoutCache: TuiMarkdownLayoutCache | undefined;
     let alive = true;
     const parser = shallowRef(
       markRaw(
@@ -147,10 +149,13 @@ export const TVirtualMarkdown = defineComponent({
     function rebuildRows(): void {
       const prevScrollTop = internalScrollTop.value;
       const prevVisibleRows = visibleRowSignatures(rows.value, prevScrollTop);
-      const nextRows = buildMarkdownVisualRows(props.content, props.w, parser.value, {
+      const { blocks } = buildMarkdownBlocks(props.content, parser.value, {
         final: props.final,
         theme: props.theme,
       });
+      const nextLayout = layoutMarkdownBlocksCached(blocks, props.w, layoutCache);
+      layoutCache = markRaw(nextLayout.cache);
+      const nextRows = nextLayout.rows;
       rows.value = markRaw(nextRows);
       reconcileScrollTop();
       const nextScrollTop = internalScrollTop.value;

--- a/src/vue/markdown/document.ts
+++ b/src/vue/markdown/document.ts
@@ -7,9 +7,8 @@ import type { TuiMarkdownBlock, TuiMarkdownVisualRow } from "./types.js";
 import { sanitizeInlineText, sanitizeTextBlock } from "../utils/text.js";
 
 /**
- * Markdown currently rebuilds from the full source string on every scheduled update.
- * Streaming components coalesce burst updates to at most one rebuild per frame,
- * but the rebuild itself is still full-document parse -> block -> visual-row layout.
+ * This helper always builds visual rows from the full source string. Components
+ * that need streaming reuse can call buildMarkdownBlocks and cache block layout.
  */
 export function buildMarkdownBlocks(
   content: string,

--- a/src/vue/markdown/layout.ts
+++ b/src/vue/markdown/layout.ts
@@ -4,12 +4,23 @@ import {
   sliceByCellsRange,
   textCellWidth,
 } from "../utils/text.js";
+import type { Style } from "../../core/types.js";
 import type {
   TuiMarkdownBlock,
   TuiMarkdownInlineSegment,
   TuiMarkdownVisualRow,
   TuiMarkdownVisualSegment,
 } from "./types.js";
+
+export type TuiMarkdownLayoutCache = Readonly<{
+  width: number;
+  entries: ReadonlyMap<string, TuiMarkdownLayoutCacheEntry>;
+}>;
+
+type TuiMarkdownLayoutCacheEntry = Readonly<{
+  signature: string;
+  rows: readonly TuiMarkdownVisualRow[];
+}>;
 
 function toVisualSegment(segment: TuiMarkdownInlineSegment): TuiMarkdownVisualSegment | null {
   if (!segment.text) return null;
@@ -264,36 +275,130 @@ function thematicBreakRows(
   ];
 }
 
-export function layoutMarkdownBlocks(
-  blocks: readonly TuiMarkdownBlock[],
+function styleSignature(style?: Style): string {
+  if (!style) return "";
+  return [
+    style.fg ?? "",
+    style.bg ?? "",
+    style.bold ? "1" : "0",
+    style.dim ? "1" : "0",
+    style.italic ? "1" : "0",
+    style.underline ? "1" : "0",
+    style.inverse ? "1" : "0",
+    style.href ?? "",
+  ].join("\u0001");
+}
+
+function inlineSegmentSignature(segment: TuiMarkdownInlineSegment): string {
+  return [segment.text, segment.hardBreak ? "1" : "0", styleSignature(segment.style)].join(
+    "\u0002",
+  );
+}
+
+function inlineSegmentsSignature(segments?: readonly TuiMarkdownInlineSegment[]): string {
+  return (segments ?? []).map(inlineSegmentSignature).join("\u0003");
+}
+
+function blockLayoutSignature(block: TuiMarkdownBlock): string {
+  switch (block.type) {
+    case "inline":
+      return [
+        block.type,
+        inlineSegmentsSignature(block.segments),
+        inlineSegmentsSignature(block.prefixSegments),
+        inlineSegmentsSignature(block.continuationPrefixSegments),
+      ].join("\u0004");
+    case "code_block":
+      return [
+        block.type,
+        block.lines.join("\u0002"),
+        styleSignature(block.style),
+        inlineSegmentsSignature(block.prefixSegments),
+        inlineSegmentsSignature(block.continuationPrefixSegments),
+      ].join("\u0004");
+    case "thematic_break":
+      return [
+        block.type,
+        block.char ?? "",
+        styleSignature(block.style),
+        inlineSegmentsSignature(block.prefixSegments),
+      ].join("\u0004");
+    case "blank":
+      return block.type;
+  }
+}
+
+export function layoutMarkdownBlock(
+  block: TuiMarkdownBlock,
   width: number,
 ): readonly TuiMarkdownVisualRow[] {
-  const normalizedWidth = Math.max(0, Math.floor(width));
-  if (normalizedWidth <= 0) return [];
-  const rows: TuiMarkdownVisualRow[] = [];
-  for (const block of blocks) {
-    switch (block.type) {
-      case "inline":
-        rows.push(...inlineBlockRows(block, normalizedWidth));
-        break;
-      case "code_block":
-        rows.push(...codeBlockRows(block, normalizedWidth));
-        break;
-      case "thematic_break":
-        rows.push(...thematicBreakRows(block, normalizedWidth));
-        break;
-      case "blank":
-        rows.push({
+  switch (block.type) {
+    case "inline":
+      return inlineBlockRows(block, width);
+    case "code_block":
+      return codeBlockRows(block, width);
+    case "thematic_break":
+      return thematicBreakRows(block, width);
+    case "blank":
+      return [
+        {
           key: `${block.key}:0`,
           blockKey: block.key,
           rowInBlock: 0,
           plainText: "",
           segments: [],
-        });
-        break;
+        },
+      ];
+  }
+}
+
+export function layoutMarkdownBlocksCached(
+  blocks: readonly TuiMarkdownBlock[],
+  width: number,
+  previous?: TuiMarkdownLayoutCache,
+): Readonly<{
+  rows: readonly TuiMarkdownVisualRow[];
+  cache: TuiMarkdownLayoutCache;
+}> {
+  const normalizedWidth = Math.max(0, Math.floor(width));
+  if (normalizedWidth <= 0) {
+    return { rows: [], cache: { width: normalizedWidth, entries: new Map() } };
+  }
+
+  const rows: TuiMarkdownVisualRow[] = [];
+  const entries = new Map<string, TuiMarkdownLayoutCacheEntry>();
+  const previousEntries = previous?.width === normalizedWidth ? previous.entries : undefined;
+
+  for (let index = 0; index < blocks.length; index++) {
+    const block = blocks[index]!;
+    const cacheKey = `${index}\u0000${block.key}`;
+    const signature = blockLayoutSignature(block);
+    const cached = previousEntries?.get(cacheKey);
+    const blockRows =
+      cached?.signature === signature ? cached.rows : layoutMarkdownBlock(block, normalizedWidth);
+    if (blockRows.length) {
+      rows.push(...blockRows);
+      entries.set(cacheKey, { signature, rows: blockRows });
     }
   }
-  return rows.length
-    ? rows
-    : [{ key: "md-empty:0", blockKey: "md-empty", rowInBlock: 0, plainText: "", segments: [] }];
+
+  if (!rows.length) {
+    const emptyRows = [
+      { key: "md-empty:0", blockKey: "md-empty", rowInBlock: 0, plainText: "", segments: [] },
+    ];
+    entries.set("0\u0000md-empty", { signature: "empty", rows: emptyRows });
+    rows.push(...emptyRows);
+  }
+
+  return {
+    rows,
+    cache: { width: normalizedWidth, entries },
+  };
+}
+
+export function layoutMarkdownBlocks(
+  blocks: readonly TuiMarkdownBlock[],
+  width: number,
+): readonly TuiMarkdownVisualRow[] {
+  return layoutMarkdownBlocksCached(blocks, width).rows;
 }

--- a/test/bench-smoke.test.ts
+++ b/test/bench-smoke.test.ts
@@ -22,8 +22,10 @@ describe("bench smoke", () => {
     const results = JSON.parse(output);
 
     expect(results.mixedRowKeyPrepass).toBeDefined();
-    expect(results.mixedRowKeyPrepass.default.secondFlush.rowKeyPrepassChecks).toBe(0);
+    expect(results.mixedRowKeyPrepass.off.secondFlush.rowKeyPrepassChecks).toBe(0);
+    expect(results.mixedRowKeyPrepass.default.secondFlush.rowKeyPrepassChecks).toBeGreaterThan(0);
     expect(results.mixedRowKeyPrepass.prepass.secondFlush.rowKeyPrepassChecks).toBeGreaterThan(0);
+    expect(results.cacheHitPlain.off).toBeDefined();
     expect(results.cacheHitPlain.default).toBeDefined();
     expect(results.cacheHitPlain.prepass).toBeDefined();
   });

--- a/test/color-parity.test.ts
+++ b/test/color-parity.test.ts
@@ -58,6 +58,92 @@ describe("ansi palette parity", () => {
     container.remove();
   });
 
+  it("DomRenderer supports custom palette updates through CSS variables", () => {
+    const terminal = createTerminal({ cols: 3, rows: 1 });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const palette = { red: "#112233" };
+    const renderer = createDomRenderer(terminal, container, { palette });
+
+    expect(container.style.getPropertyValue("--vt-color-red")).toBe("#112233");
+    expect(container.style.getPropertyValue("--vt-color-blue")).toBe(ANSI_PALETTE_HEX.blue);
+
+    terminal.put(0, 0, "X", { fg: "red" });
+    renderer.refresh();
+
+    const span =
+      Array.from(container.querySelectorAll("span")).find((s) =>
+        (s.textContent || "").includes("X"),
+      ) ?? null;
+    expect(span).not.toBe(null);
+    expect((span as HTMLElement).style.color).toBe("var(--vt-color-red)");
+
+    renderer.updateTheme({ palette: { red: "#010203" } });
+    expect(container.style.getPropertyValue("--vt-color-red")).toBe("#010203");
+
+    renderer.updateTheme({ palette: undefined });
+    expect(container.style.getPropertyValue("--vt-color-red")).toBe(ANSI_PALETTE_HEX.red);
+    expect(palette).toEqual({ red: "#112233" });
+
+    renderer.dispose();
+    container.remove();
+  });
+
+  it("DomRenderer ignores unknown color names instead of emitting unresolved CSS variables", () => {
+    const terminal = createTerminal({ cols: 3, rows: 1 });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const renderer = createDomRenderer(terminal, container);
+
+    terminal.put(0, 0, "X", { fg: "unknown" as any, bg: "missing" as any });
+    renderer.refresh();
+
+    const span =
+      Array.from(container.querySelectorAll("span")).find((s) =>
+        (s.textContent || "").includes("X"),
+      ) ?? null;
+    expect(span).not.toBe(null);
+    expect((span as HTMLElement).style.color).toBe("");
+    expect((span as HTMLElement).style.backgroundColor).toBe("");
+
+    renderer.dispose();
+    container.remove();
+  });
+
+  it("DomRenderer maps common style attributes to CSS with inverse colors", () => {
+    const terminal = createTerminal({ cols: 3, rows: 1 });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const renderer = createDomRenderer(terminal, container);
+
+    terminal.put(0, 0, "X", {
+      fg: "red",
+      bg: "blue",
+      bold: true,
+      dim: true,
+      italic: true,
+      underline: true,
+      inverse: true,
+    });
+    renderer.refresh();
+
+    const span =
+      Array.from(container.querySelectorAll("span")).find((s) =>
+        (s.textContent || "").includes("X"),
+      ) ?? null;
+    expect(span).not.toBe(null);
+    const style = (span as HTMLElement).style;
+    expect(style.color).toBe("var(--vt-color-blue)");
+    expect(style.backgroundColor).toBe("var(--vt-color-red)");
+    expect(style.fontWeight).toBe("700");
+    expect(style.opacity).toBe("0.75");
+    expect(style.fontStyle).toBe("italic");
+    expect(style.textDecoration).toBe("underline");
+
+    renderer.dispose();
+    container.remove();
+  });
+
   it("DomRenderer renders terminal planes into separate layers with per-plane offsets", () => {
     const terminal = createTerminal({ cols: 4, rows: 4 });
     const transcript = getPlaneTerminal(terminal, "transcript");
@@ -108,6 +194,45 @@ describe("ansi palette parity", () => {
 
     expect(out).toContain("\u001B[38;2;201;27;0m");
     expect(out).toContain("\u001B[48;2;2;37;199m");
+
+    renderer.dispose();
+  });
+
+  it("StdoutRenderer emits common style attributes with truecolor palette sequences", () => {
+    const terminal = createTerminal({ cols: 3, rows: 1 });
+    let out = "";
+    const output = {
+      isTTY: false,
+      write(chunk: string) {
+        out += chunk;
+      },
+    };
+    const renderer = createStdoutRenderer(terminal, {
+      output,
+      clear: false,
+      hideCursor: false,
+      altScreen: false,
+      colorMode: "truecolor",
+    });
+
+    terminal.put(0, 0, "X", {
+      fg: "red",
+      bg: "blue",
+      bold: true,
+      dim: true,
+      italic: true,
+      underline: true,
+      inverse: true,
+    });
+    terminal.commit();
+
+    expect(out).toContain("\u001B[38;2;201;27;0m");
+    expect(out).toContain("\u001B[48;2;2;37;199m");
+    expect(out).toContain("\u001B[1m");
+    expect(out).toContain("\u001B[2m");
+    expect(out).toContain("\u001B[3m");
+    expect(out).toContain("\u001B[4m");
+    expect(out).toContain("\u001B[7m");
 
     renderer.dispose();
   });

--- a/test/dom-renderer.test.ts
+++ b/test/dom-renderer.test.ts
@@ -488,10 +488,15 @@ describe("DomRenderer row rendering", () => {
     }
   });
 
-  it("uses row cache by default after computing segments", () => {
+  it("uses auto row key prepass by default after the first flush", () => {
     const { terminal, container, renderer } = setup();
 
     try {
+      expect(renderer.debugStats.rowKeyPrepass).toMatchObject({
+        mode: "auto",
+        decision: "sampling",
+      });
+
       terminal.fill(0, 0, 8, 1, "A");
       terminal.commit({ planes: ["default"], sync: true });
 
@@ -502,13 +507,48 @@ describe("DomRenderer row rendering", () => {
       expect(lastRowStats(renderer)).toMatchObject({
         rows: 1,
         cacheHits: 1,
-        rowKeyPrepassChecks: 0,
-        rowKeyPrepassHits: 0,
+        rowKeyPrepassChecks: 1,
+        rowKeyPrepassHits: 1,
         rowKeyPrepassMisses: 0,
         plainTextRows: 0,
         fragmentRows: 0,
         textNodeUpdates: 0,
         replaceChildren: 0,
+      });
+      expect(renderer.debugStats.rowKeyPrepass).toMatchObject({
+        decision: "sampling",
+        sampleRows: 1,
+        sampleHits: 1,
+        sampleMisses: 0,
+        sampleHitRatio: 1,
+      });
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("respects explicit false row key prepass override", () => {
+    const { terminal, container, renderer } = setup(8, 1, { enableRowKeyPrepass: false });
+
+    try {
+      expect(renderer.debugStats.rowKeyPrepass).toMatchObject({
+        mode: false,
+        decision: "forced-disabled",
+      });
+
+      terminal.fill(0, 0, 8, 1, "A");
+      terminal.commit({ planes: ["default"], sync: true });
+
+      terminal.fill(0, 0, 8, 1, "A");
+      terminal.commit({ planes: ["default"], sync: true });
+
+      expect(lastRowStats(renderer)).toMatchObject({
+        rows: 1,
+        cacheHits: 1,
+        rowKeyPrepassChecks: 0,
+        rowKeyPrepassHits: 0,
+        rowKeyPrepassMisses: 0,
       });
     } finally {
       renderer.dispose();
@@ -520,7 +560,97 @@ describe("DomRenderer row rendering", () => {
     const { container, renderer } = setup(8, 1, { enableRowKeyPrepass: true });
 
     try {
+      expect(renderer.debugStats.rowKeyPrepass).toMatchObject({
+        mode: true,
+        decision: "forced-enabled",
+      });
       expect(lastRowStats(renderer)).toMatchObject({
+        rowKeyPrepassChecks: 0,
+        rowKeyPrepassHits: 0,
+        rowKeyPrepassMisses: 0,
+      });
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("auto row key prepass enables for cache-heavy rows", () => {
+    const rows = 512;
+    const { terminal, container, renderer } = setup(4, rows, {
+      syncFlushMaxRows: rows,
+      syncFlushCellBudget: rows * 4,
+    });
+
+    try {
+      for (let y = 0; y < rows; y++) terminal.fill(0, y, 4, 1, "A");
+      terminal.commit({ planes: ["default"], sync: true });
+
+      expect(lastRowStats(renderer)).toMatchObject({
+        rowKeyPrepassChecks: 0,
+      });
+      expect(renderer.debugStats.rowKeyPrepass.decision).toBe("sampling");
+
+      for (let y = 0; y < rows; y++) terminal.fill(0, y, 4, 1, "A");
+      terminal.commit({ planes: ["default"], sync: true });
+
+      expect(lastRowStats(renderer)).toMatchObject({
+        rows,
+        cacheHits: rows,
+        rowKeyPrepassChecks: rows,
+        rowKeyPrepassHits: rows,
+        rowKeyPrepassMisses: 0,
+      });
+      expect(renderer.debugStats.rowKeyPrepass).toMatchObject({
+        decision: "enabled",
+        sampleRows: 0,
+        sampleHits: 0,
+        sampleMisses: 0,
+        lastSampleRows: rows,
+        lastSampleHitRatio: 1,
+      });
+    } finally {
+      renderer.dispose();
+      container.remove();
+    }
+  });
+
+  it("auto row key prepass disables for miss-heavy rows", () => {
+    const rows = 512;
+    const { terminal, container, renderer } = setup(4, rows, {
+      syncFlushMaxRows: rows,
+      syncFlushCellBudget: rows * 4,
+    });
+
+    try {
+      for (let y = 0; y < rows; y++) terminal.fill(0, y, 4, 1, "A");
+      terminal.commit({ planes: ["default"], sync: true });
+
+      for (let y = 0; y < rows; y++) terminal.fill(0, y, 4, 1, "B");
+      terminal.commit({ planes: ["default"], sync: true });
+
+      expect(lastRowStats(renderer)).toMatchObject({
+        rows,
+        cacheHits: 0,
+        rowKeyPrepassChecks: rows,
+        rowKeyPrepassHits: 0,
+        rowKeyPrepassMisses: rows,
+      });
+      expect(renderer.debugStats.rowKeyPrepass).toMatchObject({
+        decision: "disabled",
+        sampleRows: 0,
+        sampleHits: 0,
+        sampleMisses: 0,
+        lastSampleRows: rows,
+        lastSampleHitRatio: 0,
+      });
+
+      for (let y = 0; y < rows; y++) terminal.fill(0, y, 4, 1, "C");
+      terminal.commit({ planes: ["default"], sync: true });
+
+      expect(lastRowStats(renderer)).toMatchObject({
+        rows,
+        cacheHits: 0,
         rowKeyPrepassChecks: 0,
         rowKeyPrepassHits: 0,
         rowKeyPrepassMisses: 0,

--- a/test/package-exports.test.ts
+++ b/test/package-exports.test.ts
@@ -11,8 +11,47 @@ const distTypes = resolve("dist/index.d.ts");
 const distMarkdownTypes = resolve("dist/markdown.d.ts");
 const distExperimentalTypes = resolve("dist/experimental.d.ts");
 const requireDistExports = process.env.VUE_TUI_REQUIRE_DIST_EXPORTS === "1";
+const packageJson = JSON.parse(readFileSync(resolve("package.json"), "utf8")) as {
+  files?: string[];
+  main?: string;
+  module?: string;
+  types?: string;
+  exports?: Record<string, unknown>;
+  peerDependencies?: Record<string, string>;
+};
+
+function collectExportTargets(value: unknown, out: string[] = []): string[] {
+  if (typeof value === "string") {
+    out.push(value);
+    return out;
+  }
+  if (value && typeof value === "object") {
+    for (const child of Object.values(value)) collectExportTargets(child, out);
+  }
+  return out;
+}
 
 describe("package exports", () => {
+  it("publishes every package export target through the files allowlist", () => {
+    expect(packageJson.files).toEqual(["dist"]);
+
+    const targets = [
+      packageJson.main,
+      packageJson.module,
+      packageJson.types,
+      ...collectExportTargets(packageJson.exports),
+    ].filter((target): target is string => typeof target === "string" && target.startsWith("./"));
+
+    expect(targets.length).toBeGreaterThan(0);
+    for (const target of targets) {
+      expect(target).toMatch(/^\.\/dist\//);
+    }
+  });
+
+  it("does not pin Vue consumers to a single patch line", () => {
+    expect(packageJson.peerDependencies?.vue).toBe(">=3.3.0 <4");
+  });
+
   it("keeps high-throughput components behind the experimental entrypoint", async () => {
     const root = await import("../src/index.js");
     const markdown = await import("../src/markdown.js");

--- a/test/stdout-renderer-color-mode.test.ts
+++ b/test/stdout-renderer-color-mode.test.ts
@@ -311,6 +311,31 @@ describe("stdoutRenderer color mode", () => {
     expect(out).not.toContain("\u001B[38;5;");
   });
 
+  it("does not emit invalid SGR for unknown color names in downgraded color modes", () => {
+    for (const colorMode of ["ansi256", "ansi16", "ansi8"] as const) {
+      const terminal = createTerminal({ cols: 3, rows: 1 });
+      const cap = createCapture(false);
+      createStdoutRenderer(terminal, {
+        output: cap.output,
+        clear: false,
+        hideCursor: false,
+        altScreen: false,
+        colorMode,
+      });
+
+      terminal.put(0, 0, "X", { fg: "unknown" as any, bg: "missing" as any });
+      terminal.commit();
+
+      const out = cap.getOut();
+      expect(out).toContain("X");
+      expect(out).not.toContain("undefined");
+      expect(out).not.toContain("\u001B[38;2;");
+      expect(out).not.toContain("\u001B[48;2;");
+      expect(out).not.toContain("\u001B[38;5;");
+      expect(out).not.toContain("\u001B[48;5;");
+    }
+  });
+
   it("does not mutate caller palette objects", () => {
     const terminal = createTerminal({ cols: 3, rows: 1 });
     const cap = createCapture(false);

--- a/test/tlog-view.test.ts
+++ b/test/tlog-view.test.ts
@@ -1595,6 +1595,169 @@ describe("TLogView", () => {
     }
   });
 
+  it("repaints only the visible tail row when replacing an unwrapped tail", async () => {
+    const log = createAppendOnlyLogStore();
+    log.appendLines(Array.from({ length: 19 }, (_, index) => `line-${index}`));
+    log.appendChunk("tail-19");
+    const framePerf = createFramePerfProbe("TLogViewReplaceTailDirtyRowProbe");
+
+    const App = defineComponent({
+      name: "TLogViewReplaceTailDirtyRowApp",
+      setup() {
+        return () => [
+          h(framePerf.component),
+          h(TLogView, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 4,
+            source: log.source,
+            version: log.version.value,
+          }),
+        ];
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 8, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      framePerf.clear();
+
+      const commits: Array<readonly number[] | null> = [];
+      const off = app.terminal.on("commit", ({ dirtyRows }) => {
+        commits.push(dirtyRows);
+      });
+
+      log.replaceTail("tail-19-updated");
+      await nextTick();
+      await nextTick();
+
+      off();
+      expect(rowText(app, 3)).toBe("tail-19-updated");
+      expect(commits).toContainEqual([3]);
+      expect(framePerf.latest()).toMatchObject({
+        reason: "data",
+        dirtyRows: 1,
+        paintedNodes: 1,
+      });
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("repaints only affected wrapped tail visual rows when replacing same-height tail", async () => {
+    const log = createAppendOnlyLogStore();
+    log.appendLines(Array.from({ length: 18 }, (_, index) => `line-${index}`));
+    log.appendChunk("abcdefghijABCDEFGHIJ");
+    const framePerf = createFramePerfProbe("TLogViewReplaceWrappedTailDirtyRowsProbe");
+
+    const App = defineComponent({
+      name: "TLogViewReplaceWrappedTailDirtyRowsApp",
+      setup() {
+        return () => [
+          h(framePerf.component),
+          h(TLogView, {
+            x: 0,
+            y: 0,
+            w: 10,
+            h: 4,
+            source: log.source,
+            version: log.version.value,
+            wrap: true,
+          }),
+        ];
+      },
+    });
+
+    const app = createTerminalApp({ cols: 10, rows: 8, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      framePerf.clear();
+
+      const commits: Array<readonly number[] | null> = [];
+      const off = app.terminal.on("commit", ({ dirtyRows }) => {
+        commits.push(dirtyRows);
+      });
+
+      log.replaceTail("1234567890abcdefghij");
+      await nextTick();
+      await nextTick();
+
+      off();
+      expect([0, 1, 2, 3].map((y) => rowText(app, y))).toEqual([
+        "line-16",
+        "line-17",
+        "1234567890",
+        "abcdefghij",
+      ]);
+      expect(commits).toContainEqual([2, 3]);
+      expect(framePerf.latest()).toMatchObject({
+        reason: "data",
+        dirtyRows: 2,
+        paintedNodes: 1,
+      });
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("repaints only the visible ansi tail row when replacing ansi tail", async () => {
+    const log = createAppendOnlyLogStore();
+    log.appendLines(Array.from({ length: 19 }, (_, index) => `line-${index}`));
+    log.appendChunk("\x1B[31mred-tail\x1B[0m");
+    const framePerf = createFramePerfProbe("TLogViewReplaceAnsiTailDirtyRowProbe");
+
+    const App = defineComponent({
+      name: "TLogViewReplaceAnsiTailDirtyRowApp",
+      setup() {
+        return () => [
+          h(framePerf.component),
+          h(TLogView, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 4,
+            source: log.source,
+            version: log.version.value,
+            ansi: true,
+          }),
+        ];
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 8, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      framePerf.clear();
+
+      const commits: Array<readonly number[] | null> = [];
+      const off = app.terminal.on("commit", ({ dirtyRows }) => {
+        commits.push(dirtyRows);
+      });
+
+      log.replaceTail("\x1B[34mblue-tail\x1B[0m");
+      await nextTick();
+      await nextTick();
+
+      off();
+      expect(rowText(app, 3)).toBe("blue-tail");
+      expect(commits).toContainEqual([3]);
+      expect(framePerf.latest()).toMatchObject({
+        reason: "data",
+        dirtyRows: 1,
+        paintedNodes: 1,
+      });
+    } finally {
+      app.dispose();
+    }
+  });
+
   it("keeps bottom stickiness when retention trims the head", async () => {
     const log = createAppendOnlyLogStore({ maxLines: 5 });
     log.appendLines(Array.from({ length: 5 }, (_, index) => `line-${index}`));
@@ -1948,10 +2111,18 @@ describe("TLogView", () => {
       await nextTick();
       expect(rowText(app, 0)).toBe("hello");
 
+      const commits: Array<readonly number[] | null> = [];
+      const off = app.terminal.on("commit", ({ dirtyRows }) => {
+        commits.push(dirtyRows);
+      });
+
       log.appendChunk(" world");
       await nextTick();
       await nextTick();
+
+      off();
       expect(rowText(app, 0)).toBe("hello world");
+      expect(commits).toContainEqual([0]);
     } finally {
       app.dispose();
     }
@@ -5891,11 +6062,18 @@ describe("TLogView", () => {
       await nextTick();
       expect(rowText(app, 0)).toBe("abc");
 
+      const commits: Array<readonly number[] | null> = [];
+      const off = app.terminal.on("commit", ({ dirtyRows }) => {
+        commits.push(dirtyRows);
+      });
+
       log.appendChunk("de");
       await nextTick();
       await nextTick();
 
+      off();
       expect([0, 1].map((y) => rowText(app, y))).toEqual(["abcd", "e"]);
+      expect(commits).toContainEqual([0, 1]);
     } finally {
       app.dispose();
     }

--- a/test/tmarkdown-layout.test.ts
+++ b/test/tmarkdown-layout.test.ts
@@ -3,7 +3,7 @@ import type { ParsedNode } from "stream-markdown-parser";
 import type { Style, Terminal } from "../src/index.js";
 import { markdownAstToBlocks } from "../src/vue/markdown/ast.js";
 import { buildMarkdownVisualRows } from "../src/vue/markdown/document.js";
-import { layoutMarkdownBlocks } from "../src/vue/markdown/layout.js";
+import { layoutMarkdownBlocks, layoutMarkdownBlocksCached } from "../src/vue/markdown/layout.js";
 import { createTuiMarkdownParser, type TuiMarkdownParser } from "../src/vue/markdown/parser.js";
 import { paintMarkdownVisualRow } from "../src/vue/markdown/render.js";
 import { DEFAULT_TUI_MARKDOWN_THEME } from "../src/vue/markdown/theme.js";
@@ -176,6 +176,51 @@ describe("markdown layout", () => {
   it("does not insert an extra blank row before nested list items", () => {
     const rows = buildMarkdownVisualRows("- parent\n  - child", 40, createTuiMarkdownParser());
     expect(rows.map((row) => row.plainText)).toEqual(["- parent", "  - child"]);
+  });
+
+  it("reuses finalized paragraph rows when only the streaming tail paragraph changes", () => {
+    const parser = createTuiMarkdownParser({ streaming: true });
+    const firstBlocks = markdownAstToBlocks(
+      parser.parse("first paragraph\n\nsecond", false),
+      DEFAULT_TUI_MARKDOWN_THEME,
+    );
+    const first = layoutMarkdownBlocksCached(firstBlocks, 20);
+    const nextBlocks = markdownAstToBlocks(
+      parser.parse("first paragraph\n\nsecond updated", false),
+      DEFAULT_TUI_MARKDOWN_THEME,
+    );
+
+    const next = layoutMarkdownBlocksCached(nextBlocks, 20, first.cache);
+
+    expect(next.rows.map((row) => row.plainText)).toEqual([
+      "first paragraph",
+      "",
+      "second updated",
+    ]);
+    expect(next.rows[0]).toBe(first.rows[0]);
+    expect(next.rows[1]).toBe(first.rows[1]);
+    expect(next.rows[2]).not.toBe(first.rows[2]);
+  });
+
+  it("reuses closed code fence rows when appending a following markdown block", () => {
+    const parser = createTuiMarkdownParser({ streaming: true });
+    const code = "intro\n\n```ts\nconst a = 1\n```";
+    const firstBlocks = markdownAstToBlocks(parser.parse(code, false), DEFAULT_TUI_MARKDOWN_THEME);
+    const first = layoutMarkdownBlocksCached(firstBlocks, 20);
+    const nextBlocks = markdownAstToBlocks(
+      parser.parse(`${code}\n\nnext paragraph`, false),
+      DEFAULT_TUI_MARKDOWN_THEME,
+    );
+
+    const next = layoutMarkdownBlocksCached(nextBlocks, 20, first.cache);
+
+    expect(next.rows.slice(0, first.rows.length).map((row) => row.plainText)).toEqual(
+      first.rows.map((row) => row.plainText),
+    );
+    for (let index = 0; index < first.rows.length; index++) {
+      expect(next.rows[index]).toBe(first.rows[index]);
+    }
+    expect(next.rows.at(-1)?.plainText).toBe("next paragraph");
   });
 
   it("keeps streaming strong parsing strict only when final rendering is non-streaming", () => {

--- a/test/tvirtual-markdown-perf.test.ts
+++ b/test/tvirtual-markdown-perf.test.ts
@@ -5,6 +5,7 @@ vi.mock("../src/vue/markdown/document.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../src/vue/markdown/document.js")>();
   return {
     ...actual,
+    buildMarkdownBlocks: vi.fn(actual.buildMarkdownBlocks),
     buildMarkdownVisualRows: vi.fn(actual.buildMarkdownVisualRows),
   };
 });
@@ -39,7 +40,7 @@ describe("TVirtualMarkdown performance", () => {
       10,
     );
 
-    const buildSpy = vi.mocked(markdownDocument.buildMarkdownVisualRows);
+    const buildSpy = vi.mocked(markdownDocument.buildMarkdownBlocks);
     await nextTick();
     await nextTick();
     const beforeScrollCalls = buildSpy.mock.calls.length;
@@ -79,7 +80,7 @@ describe("TVirtualMarkdown performance", () => {
       8,
     );
 
-    const buildSpy = vi.mocked(markdownDocument.buildMarkdownVisualRows);
+    const buildSpy = vi.mocked(markdownDocument.buildMarkdownBlocks);
     await nextTick();
     await nextTick();
     const before = buildSpy.mock.calls.length;
@@ -216,7 +217,7 @@ describe("TVirtualMarkdown performance", () => {
       8,
     );
 
-    const buildSpy = vi.mocked(markdownDocument.buildMarkdownVisualRows);
+    const buildSpy = vi.mocked(markdownDocument.buildMarkdownBlocks);
     await nextTick();
     await nextTick();
     const beforeBuilds = buildSpy.mock.calls.length;


### PR DESCRIPTION
## Summary

Stacked on top of #52. This checkpoint moves the roadmap forward after the test-hardening sweep:

- add adaptive DOM rowKey prepass with debug decision stats and benchmark coverage
- refine TLogView append/tail dirty-row behavior for streaming workloads
- add block-level markdown layout cache reuse for TVirtualMarkdown streaming scenarios
- align DOM/stdout palette handling through a shared ANSI palette resolver
- update README into user-facing docs and tighten package export / peer dependency checks

## Test plan

- [x] `pnpm run build`
- [x] `VUE_TUI_REQUIRE_DIST_EXPORTS=1 pnpm vitest run test/package-exports.test.ts`
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run format:check`
- [x] `pnpm run test`

## Notes

This is intentionally opened as a draft stacked PR because it contains the follow-up roadmap work after the test sweep, while #52 remains the isolated test-hardening PR.