### PR TITLE
feat(agent-console): add transcript replay log

### DIFF
--- a/examples/agent-console/src/AgentConsoleSurface.ts
+++ b/examples/agent-console/src/AgentConsoleSurface.ts
@@ -37,9 +37,10 @@ import {
 import { TVirtualMarkdown } from "@simon_he/vue-tui/markdown";
 import { TLogView } from "@simon_he/vue-tui/experimental";
 import { handleAgentConsoleKeymap } from "./keymap";
-import { createMockAgentStream } from "./mock-agent-stream";
+import { createMockAgentStream, type AgentEvent } from "./mock-agent-stream";
 import {
   createAgentTranscriptStore,
+  type AgentReplayLog,
   type TranscriptLink,
   type TranscriptMode,
 } from "./transcript-store";
@@ -64,11 +65,16 @@ export type AgentConsoleApi = Readonly<{
   mode: Ref<TranscriptMode>;
   input: Ref<string>;
   searchQuery: Ref<string>;
+  replayCursor: Ref<number>;
+  replayTotal: Ref<number>;
   metrics: Ref<TLogViewScrollMetrics | null>;
   searchState: Ref<TLogViewSearchState>;
   seed: (count?: number) => void;
   appendSyntheticChunk: (index: number) => void;
   appendBurst: (count: number) => Promise<void>;
+  captureReplayLog: () => AgentReplayLog;
+  loadReplayLog: (log: AgentReplayLog, eventIndex?: number) => void;
+  seekReplay: (eventIndex: number) => void;
   jumpToBottom: () => void;
   openSearch: (query?: string) => void;
   openLinks: () => void;
@@ -83,6 +89,7 @@ export type AgentConsoleApi = Readonly<{
   getInputValue: () => string;
   getTranscriptRows: () => readonly string[];
   getChromeRows: () => readonly string[];
+  getTerminalSnapshot: () => readonly string[];
 }>;
 
 function fit(value: string, width: number): string {
@@ -141,8 +148,11 @@ export const AgentConsoleSurface = defineComponent({
     const thinkingExpanded = ref(true);
     const toolCallExpanded = ref(true);
     const streamState = ref<"connected" | "paused">("paused");
+    const replayCursor = ref(0);
+    const replayTotal = ref(0);
     const stream = createMockAgentStream(260);
     const streamIndex = ref(0);
+    let replaySource: readonly AgentEvent[] | null = null;
     let timer: ReturnType<typeof setInterval> | null = null;
     let ready = false;
 
@@ -163,6 +173,20 @@ export const AgentConsoleSurface = defineComponent({
     const activePlaneLabel = computed<TerminalRenderPlane>(() =>
       overlay.value ? "overlay" : inputFocused.value ? "default" : "transcript",
     );
+
+    function syncReplayCursor(): void {
+      replaySource = null;
+      replayCursor.value = transcript.eventLog.value.length;
+      replayTotal.value = transcript.eventLog.value.length;
+    }
+
+    function statusFrom(events: readonly AgentEvent[]): "connected" | "paused" {
+      let state: "connected" | "paused" = "paused";
+      for (const event of events) {
+        if (event.type === "status") state = event.state;
+      }
+      return state;
+    }
 
     function refreshMetrics(): void {
       const handle = logView.value;
@@ -228,6 +252,7 @@ export const AgentConsoleSurface = defineComponent({
     function applyNextEvent(): void {
       transcript.apply(stream.next());
       streamIndex.value++;
+      syncReplayCursor();
       if (mode.value === "markdown" && markdownStickToBottom.value) {
         markdownScrollTop.value = 1_000_000;
       }
@@ -240,6 +265,8 @@ export const AgentConsoleSurface = defineComponent({
     function startStream(): void {
       if (timer) return;
       streamState.value = "connected";
+      transcript.apply({ type: "status", state: "connected" });
+      syncReplayCursor();
       timer = setInterval(applyNextEvent, 12);
     }
 
@@ -248,6 +275,8 @@ export const AgentConsoleSurface = defineComponent({
       clearInterval(timer);
       timer = null;
       streamState.value = "paused";
+      transcript.apply({ type: "status", state: "paused" });
+      syncReplayCursor();
     }
 
     function seed(count = 36): void {
@@ -255,6 +284,7 @@ export const AgentConsoleSurface = defineComponent({
       stream.reset();
       streamIndex.value = 0;
       transcript.seed(count);
+      syncReplayCursor();
       markdownScrollTop.value = 1_000_000;
       markdownStickToBottom.value = true;
       void nextTick(() => {
@@ -266,6 +296,7 @@ export const AgentConsoleSurface = defineComponent({
 
     function appendSyntheticChunk(index: number): void {
       transcript.appendSyntheticChunk(index);
+      syncReplayCursor();
       if (mode.value === "markdown" && markdownStickToBottom.value) {
         markdownScrollTop.value = 1_000_000;
       }
@@ -276,6 +307,27 @@ export const AgentConsoleSurface = defineComponent({
         appendSyntheticChunk(i);
         await nextTick();
       }
+    }
+
+    function loadReplayLog(log: AgentReplayLog, eventIndex = log.events.length): void {
+      stopStream();
+      replaySource = log.events.slice();
+      const cursor = Math.max(0, Math.min(eventIndex, replaySource.length));
+      transcript.loadReplayLog(log, cursor);
+      streamState.value = statusFrom(replaySource.slice(0, cursor));
+      replayCursor.value = cursor;
+      replayTotal.value = replaySource.length;
+      markdownScrollTop.value = 1_000_000;
+      markdownStickToBottom.value = true;
+      void nextTick(() => {
+        jumpToBottom();
+        refreshSearchState();
+        refreshLinks();
+      });
+    }
+
+    function seekReplay(eventIndex: number): void {
+      loadReplayLog({ version: 1, events: replaySource ?? transcript.eventLog.value }, eventIndex);
     }
 
     function focusNextLink(): boolean {
@@ -340,6 +392,7 @@ export const AgentConsoleSurface = defineComponent({
       if (!text) return;
       transcript.apply({ type: "user", text });
       input.value = "";
+      syncReplayCursor();
       jumpToBottom();
     }
 
@@ -410,6 +463,7 @@ export const AgentConsoleSurface = defineComponent({
         `model=gpt-5.3-codex`,
         `state=${streamState.value}`,
         `mode=${mode.value}`,
+        `replay=${replayCursor.value}/${replayTotal.value}`,
         `rate=${tokenRate.value}`,
         `scroll=${scrollLabel.value}`,
         `plane=${activePlaneLabel.value}`,
@@ -724,11 +778,16 @@ export const AgentConsoleSurface = defineComponent({
       mode,
       input,
       searchQuery,
+      replayCursor,
+      replayTotal,
       metrics,
       searchState,
       seed,
       appendSyntheticChunk,
       appendBurst,
+      captureReplayLog: transcript.captureReplayLog,
+      loadReplayLog,
+      seekReplay,
       jumpToBottom,
       openSearch,
       openLinks,
@@ -749,6 +808,7 @@ export const AgentConsoleSurface = defineComponent({
         Array.from({ length: AGENT_CONSOLE_LAYOUT.chrome.h }, (_, index) =>
           rowTextFromTerminal(terminalContext.terminal, AGENT_CONSOLE_LAYOUT.chrome.y + index),
         ),
+      getTerminalSnapshot: () => terminalContext.terminal.snapshot().lines,
     };
 
     watch(

--- a/examples/agent-console/src/mock-agent-stream.ts
+++ b/examples/agent-console/src/mock-agent-stream.ts
@@ -1,5 +1,6 @@
 export type AgentEvent =
   | { type: "user"; text: string }
+  | { type: "status"; state: "connected" | "paused" }
   | { type: "assistant-delta"; text: string }
   | { type: "tool-start"; name: string }
   | { type: "tool-log"; text: string }

--- a/examples/agent-console/src/smoke.ts
+++ b/examples/agent-console/src/smoke.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import { nextTick } from "vue";
 import { createTerminalApp } from "@simon_he/vue-tui";
 import { AgentConsoleSurface, AGENT_CONSOLE_LAYOUT } from "./AgentConsoleSurface";
+import { parseAgentReplayLog, stringifyAgentReplayLog } from "./transcript-store";
 
 type ManualRaf = Readonly<{
   pending: () => number;
@@ -238,6 +239,34 @@ try {
     overlayVisibleBeforeEscape && !rowsText(app).includes("Command Palette");
   const inputStillVisibleAfterResize = inputBorderVisible(app);
   const overlayChrome = api.getChromeRows().join("\n");
+  const replayLog = api.captureReplayLog();
+  const replayPayload = stringifyAgentReplayLog(replayLog);
+  const parsedReplayLog = parseAgentReplayLog(replayPayload);
+  const replaySeekIndex = Math.max(1, Math.floor(parsedReplayLog.events.length / 3));
+  api.loadReplayLog(parsedReplayLog);
+  await nextTick();
+  app.scheduler.flushNow();
+  await flushFrame(raf);
+  const replayFinalSnapshot = api.getTerminalSnapshot().join("\n");
+  const replayFullLoaded =
+    api.replayCursor.value === parsedReplayLog.events.length &&
+    api.replayTotal.value === parsedReplayLog.events.length;
+  api.seekReplay(replaySeekIndex);
+  await nextTick();
+  app.scheduler.flushNow();
+  await flushFrame(raf);
+  const replaySeekSnapshot = api.getTerminalSnapshot().join("\n");
+  const replaySeekLoaded =
+    api.replayCursor.value === replaySeekIndex &&
+    api.captureReplayLog().events.length === replaySeekIndex;
+  api.seekReplay(parsedReplayLog.events.length);
+  await nextTick();
+  app.scheduler.flushNow();
+  await flushFrame(raf);
+  const replayRestoredSnapshot = api.getTerminalSnapshot().join("\n");
+  const replayRestored =
+    api.replayCursor.value === parsedReplayLog.events.length &&
+    replayRestoredSnapshot.includes("dirtyRows");
   api.mode.value = "markdown";
   api.seed(18);
   await nextTick();
@@ -271,6 +300,13 @@ try {
     overlayMaxDirtyRows: maxSampleValue(overlaySamples, "dirtyRows"),
     overlayMaxPaintedNodes: maxSampleValue(overlaySamples, "paintedNodes"),
     overlayInputStable,
+    replayEvents: parsedReplayLog.events.length,
+    replayFullLoaded,
+    replaySeekLoaded,
+    replaySnapshotChanged: replaySeekSnapshot !== replayFinalSnapshot,
+    replayRestored,
+    replayFinalSnapshotRows: replayFinalSnapshot.split("\n").length,
+    terminalRows: resizedSize.rows,
     expandableRowsRendered:
       overlayChrome.includes("▸ Thinking") && overlayChrome.includes("▸ Run 3"),
     bestAgentFixtureRowsRendered,
@@ -292,6 +328,12 @@ try {
   assert.equal(output.logHasStyledBackground, true);
   assert.equal(output.markdownHasStyledBackground, true);
   assert.equal(output.overlayInputStable, true);
+  assert.ok(output.replayEvents > 0, "expected replay event log");
+  assert.equal(output.replayFullLoaded, true);
+  assert.equal(output.replaySeekLoaded, true);
+  assert.equal(output.replaySnapshotChanged, true);
+  assert.equal(output.replayRestored, true);
+  assert.equal(output.replayFinalSnapshotRows, output.terminalRows);
   assert.equal(output.expandableRowsRendered, true);
   assert.equal(output.bestAgentFixtureRowsRendered, true);
   assert.ok(output.overlayMaxDirtyRows <= AGENT_CONSOLE_LAYOUT.rows);

--- a/examples/agent-console/src/transcript-store.ts
+++ b/examples/agent-console/src/transcript-store.ts
@@ -24,14 +24,22 @@ export type TranscriptStats = Readonly<{
   approxTokens: number;
 }>;
 
+export type AgentReplayLog = Readonly<{
+  version: 1;
+  events: readonly AgentEvent[];
+}>;
+
 export type AgentTranscriptStore = Readonly<{
   logStore: AppendOnlyLogStore;
   markdown: Ref<string>;
   markdownBlocks: Ref<readonly TuiMarkdownBlock[]>;
   links: Ref<readonly TranscriptLink[]>;
   stats: Ref<TranscriptStats>;
+  eventLog: Ref<readonly AgentEvent[]>;
   apply: (event: AgentEvent) => void;
   appendSyntheticChunk: (index: number) => void;
+  captureReplayLog: () => AgentReplayLog;
+  loadReplayLog: (log: AgentReplayLog, eventIndex?: number) => void;
   seed: (count?: number) => void;
   clear: () => void;
 }>;
@@ -62,6 +70,25 @@ function countApproxTokens(text: string): number {
   return Math.max(1, Math.ceil(text.trim().length / 4));
 }
 
+export function createAgentReplayLog(events: readonly AgentEvent[]): AgentReplayLog {
+  return {
+    version: 1,
+    events: events.slice(),
+  };
+}
+
+export function stringifyAgentReplayLog(log: AgentReplayLog): string {
+  return JSON.stringify(log);
+}
+
+export function parseAgentReplayLog(raw: string): AgentReplayLog {
+  const value = JSON.parse(raw) as AgentReplayLog;
+  if (value.version !== 1 || !Array.isArray(value.events)) {
+    throw new Error("Invalid agent replay log");
+  }
+  return createAgentReplayLog(value.events);
+}
+
 export function createAgentTranscriptStore(): AgentTranscriptStore {
   const logStore = createAppendOnlyLogStore({ maxLines: 8_000 });
   const markdownSource = createMarkdownBlockSource({ theme: markdownTheme });
@@ -75,6 +102,7 @@ export function createAgentTranscriptStore(): AgentTranscriptStore {
     toolErrors: 0,
     approxTokens: 0,
   });
+  const eventLog = ref<readonly AgentEvent[]>([]);
   let assistantOpen = false;
   let toolFenceOpen = false;
 
@@ -113,6 +141,8 @@ export function createAgentTranscriptStore(): AgentTranscriptStore {
   }
 
   function apply(event: AgentEvent): void {
+    eventLog.value = [...eventLog.value, event];
+
     if (event.type === "user") {
       closeAssistantLine();
       closeToolFence();
@@ -126,6 +156,15 @@ export function createAgentTranscriptStore(): AgentTranscriptStore {
         userMessages: stats.value.userMessages + 1,
         approxTokens: stats.value.approxTokens + countApproxTokens(event.text),
       });
+      return;
+    }
+
+    if (event.type === "status") {
+      closeAssistantLine();
+      closeToolFence();
+      logStore.appendLine(`\x1b[30;46m status \x1b[0m ${event.state}`);
+      appendMarkdown(`\n\n_Status: ${event.state}_\n\n`);
+      finalizeMarkdownBlock();
       return;
     }
 
@@ -189,6 +228,7 @@ export function createAgentTranscriptStore(): AgentTranscriptStore {
     markdownSource.clear();
     markdownBlocks.value = markdownSource.blocks;
     links.value = [];
+    eventLog.value = [];
     assistantOpen = false;
     toolFenceOpen = false;
     stats.value = {
@@ -205,16 +245,27 @@ export function createAgentTranscriptStore(): AgentTranscriptStore {
     for (const event of createMockAgentEvents(count)) apply(event);
   }
 
+  function loadReplayLog(log: AgentReplayLog, eventIndex = log.events.length): void {
+    clear();
+    const end = Math.max(0, Math.min(eventIndex, log.events.length));
+    for (const event of log.events.slice(0, end)) apply(event);
+  }
+
   return {
     logStore,
     markdown,
     markdownBlocks,
     links,
     stats,
+    eventLog,
     apply,
     appendSyntheticChunk(index) {
       apply(createSyntheticAgentEvent(index));
     },
+    captureReplayLog() {
+      return createAgentReplayLog(eventLog.value);
+    },
+    loadReplayLog,
     seed,
     clear,
   };


### PR DESCRIPTION
## Summary
- record agent transcript events as a replay log, including user, assistant, tool, and stream status events
- add JSON serialization/parsing for the agent replay log
- expose AgentConsole API methods to capture, load, seek replay logs, and snapshot the terminal buffer
- extend the agent-console smoke to round-trip a replay payload, seek to a prefix, restore the full replay, and assert final terminal snapshot rows

## Validation
- pnpm run example:agent-console:smoke
- pnpm run example:agent-console:terminal:smoke
- pnpm run typecheck
- pnpm run format:check
- pnpm run lint
- pnpm run test