### PR TITLE
feat(tlog-view): add explicit viewport invalidation API

### DIFF
--- a/src/vue/components/TLogView.ts
+++ b/src/vue/components/TLogView.ts
@@ -259,6 +259,9 @@ export type TLogViewHandle = Readonly<{
       align?: "start" | "center" | "end";
     }>,
   ) => void;
+  refreshViewport: () => void;
+  invalidateLine: (index: number) => void;
+  invalidateRange: (start: number, end: number) => void;
   findNext: () => void;
   findPrevious: () => void;
   clearSearch: () => void;
@@ -3146,6 +3149,58 @@ export const TLogView = defineComponent({
       scrollToVisualRow(target);
     }
 
+    function repaintInvalidatedViewport(): void {
+      const nextTop = stickToBottom.value ? bottomScrollTop() : currentScrollTop();
+      const changed = applyScrollTop(nextTop, "viewport-repaint", {
+        emitScroll: true,
+        stickToBottom: stickToBottom.value && nextTop >= maxScrollTop(),
+      });
+      if (!changed) markViewportDirty();
+      invalidateSelf("normal", "data");
+    }
+
+    function refreshViewport(): void {
+      clearLineCaches();
+      lastPaintedBottom = null;
+      resetVisualIndex(lineCount(), currentWrapWidth());
+      lastLineCount = lineCount();
+      lastFirstLineIndex = firstLineIndex();
+      if (props.wrap && props.visualIndexMode === "exact") requestVisualIndexMeasurement(0);
+      requestSearchScan();
+      repaintInvalidatedViewport();
+    }
+
+    function invalidateRange(start: number, end: number): void {
+      const count = lineCount();
+      const rawStart = Math.floor(Number(start));
+      const rawEnd = Math.ceil(Number(end));
+      if (!Number.isFinite(rawStart) || !Number.isFinite(rawEnd)) return;
+
+      const safeStart = clamp(rawStart, 0, count);
+      const safeEnd = clamp(rawEnd, 0, count);
+      if (safeEnd <= safeStart) return;
+
+      clearLineCaches();
+      lastPaintedBottom = null;
+      if (props.wrap) {
+        ensureVisualIndex();
+        for (let index = safeStart; index < safeEnd; index++) visualKeys[index] = undefined;
+        for (let index = safeStart; index < safeEnd; index++) measureVisualLine(index);
+        syncVisualIndexStatus();
+      } else {
+        syncNonWrappedVisualIndexState();
+      }
+      emitVisualIndex();
+      requestSearchScan();
+      repaintInvalidatedViewport();
+    }
+
+    function invalidateLine(index: number): void {
+      const lineIndex = Math.floor(Number(index));
+      if (!Number.isFinite(lineIndex)) return;
+      invalidateRange(lineIndex, lineIndex + 1);
+    }
+
     function visualRowForMatch(match: TLogViewSearchMatch): number {
       if (!props.wrap) return match.index;
       ensureVisualIndex();
@@ -3336,6 +3391,9 @@ export const TLogView = defineComponent({
       scrollToVisualRow,
       scrollBy,
       scrollToLine,
+      refreshViewport,
+      invalidateLine,
+      invalidateRange,
       findNext,
       findPrevious,
       clearSearch,

--- a/test/tlog-view.test.ts
+++ b/test/tlog-view.test.ts
@@ -1149,6 +1149,100 @@ describe("TLogView", () => {
     }
   });
 
+  it("refreshes visible source mutations without a version change", async () => {
+    const lines = ["alpha", "beta", "gamma"];
+    const source: TLogDataSource = {
+      lineCount: () => lines.length,
+      getLine: (index) => lines[index] ?? "",
+    };
+    const logView = ref<TLogViewHandle | null>(null);
+
+    const App = defineComponent({
+      name: "TLogViewExplicitInvalidationApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            ref: logView,
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 3,
+            source,
+            version: 1,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 20, rows: 5, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      expect(rowText(app, 1)).toBe("beta");
+
+      lines[1] = "BETA";
+      app.scheduler.flushNow();
+      expect(rowText(app, 1)).toBe("beta");
+
+      logView.value!.invalidateLine(1);
+      await nextTick();
+      app.scheduler.flushNow();
+      expect(rowText(app, 1)).toBe("BETA");
+
+      lines[0] = "ALPHA";
+      lines[2] = "GAMMA";
+      logView.value!.refreshViewport();
+      await nextTick();
+      app.scheduler.flushNow();
+      expect([0, 1, 2].map((y) => rowText(app, y))).toEqual(["ALPHA", "BETA", "GAMMA"]);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("remeasures wrapped rows for explicit range invalidation", async () => {
+    const lines = ["abcd", "efgh"];
+    const source: TLogDataSource = {
+      lineCount: () => lines.length,
+      getLine: (index) => lines[index] ?? "",
+    };
+    const logView = ref<TLogViewHandle | null>(null);
+
+    const App = defineComponent({
+      name: "TLogViewWrappedExplicitInvalidationApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            ref: logView,
+            x: 0,
+            y: 0,
+            w: 4,
+            h: 4,
+            source,
+            version: 1,
+            wrap: true,
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 4, rows: 5, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      expect([0, 1].map((y) => rowText(app, y))).toEqual(["abcd", "efgh"]);
+
+      lines[0] = "abcd1234";
+      logView.value!.invalidateRange(0, 1);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect([0, 1, 2].map((y) => rowText(app, y))).toEqual(["abcd", "1234", "efgh"]);
+    } finally {
+      app.dispose();
+    }
+  });
+
   it("exposes visual-row scrollBy", async () => {
     const source: TLogDataSource = {
       lineCount: () => 20,


### PR DESCRIPTION
## Summary
- expose `refreshViewport`, `invalidateLine`, and `invalidateRange` on `TLogViewHandle`
- clear stale line/search/link caches for explicit source mutations without a `version` bump
- remeasure wrapped invalidated lines so changed visual row counts repaint correctly

## Validation
- `bun test test/tlog-view.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `git diff --check`
- `bun run test`
- `bun run lint`