### PR TITLE
ci: verify docs build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
           node-version: 20
           cache: pnpm
 
+      - uses: oven-sh/setup-bun@v2
+
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm run check:hidden-unicode
@@ -44,7 +46,7 @@ jobs:
       # Deterministic smoke bench: behavior thresholds only, no runner-timing gate.
       - run: pnpm run bench:scroll-mailbox
 
-      - run: pnpm exec tsx scripts/generate-component-api-docs.ts
+      - run: pnpm run docs:build
 
       - run: git diff --exit-code docs/generated/components-api.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,4 @@
 
 - DOM renderer span fast paths now work in Node DOM environments that do not expose `HTMLSpanElement` globally.
 - Basic browser example build avoids bundling Node-only terminal/event/profiler modules while keeping terminal builds on the root package entry.
+- CI now runs the VitePress docs build during verification so broken docs links fail before release.


### PR DESCRIPTION
## Summary
- replace the CI docs generation step with `pnpm run docs:build`
- keep the generated component API diff check after the docs build
- note the CI docs-build coverage in CHANGELOG

## Validation
- `pnpm run docs:build`
- `git diff --exit-code docs/generated/components-api.md`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test:unit`