### PR TITLE
chore(release): finalize 0.1.0-rc.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,41 +1,103 @@
 # Changelog
 
-## Unreleased
+## 0.1.0-rc.0
 
-### 0.0.x Breaking Behavior Changes
+### Added
 
-- `TList` treats `update:modelValue` as selection-change, not selection-confirm.
-- `TList` wheel scrolling is now viewport-only. It emits `scroll`, but no longer mutates active selection or emits `update:modelValue`.
+- Agent Console browser example for streaming transcript, log/markdown modes, split render planes, input stability, search, links, and command palette overlay.
+- Agent Console terminal runner, terminal smoke path, and replay log.
+- `TLogView` explicit invalidation APIs: `refreshViewport()`, `invalidateLine()`, and `invalidateRange()`.
+- `TVirtualMarkdown` external block source support and block-level cache reuse.
+- `createMarkdownBlockSource()` in the markdown entrypoint for streaming transcript apps that finalize markdown blocks.
+- stdout renderer custom palette support.
+- Examples index covering browser, terminal, and smoke entrypoints.
+- Release candidate docs covering validation commands, package export boundaries, examples, migration notes, and experimental API warnings.
+- Release validation scripts for `release:check`, `release:bench`, `release:smoke`, `release:pack`, `release:pack-smoke`, and `release:dry-run`.
+- Packed package dry-run smoke that installs the generated `.tgz` into an external project and verifies ESM, CJS, and type export targets.
+- Internal `createFrameMailbox()` for coalescing latest-only producer updates into one scheduler frame task.
+- `RenderManager.markDirtyRows(id, rows)` for absolute dirty-row repaint within the node's plane.
+- `TerminalFrameContext.reportDroppedUpdates()` for coalesced producer metrics.
+
+### Changed
+
+- `TList` wheel scrolling is viewport-only. It emits `scroll`, but no longer mutates active selection or emits `update:modelValue`.
+- `TList` now splits selection updates from confirmation: `update:modelValue` represents selection changes, while `change` represents confirmation.
 - `TList` keyboard, click, double click, and Enter reattach selection to the visible viewport after wheel detachment.
-- `TList` Enter and double click emit `change`; they do not emit `update:modelValue` when committing the already-active item.
 - `TList` keyboard-driven and external-model-driven viewport changes no longer emit `scroll`.
 - `TList` `scroll` now represents viewport-driven scroll changes, especially wheel scrolling and programmatic clamp.
 - `TList` cancels a pending wheel frame if the viewport is hidden or fully clipped before the frame runs.
 - `TList` same-length item text updates require replacing the `items` array reference or bumping `itemVersion` to schedule repaint.
-- `TRenderPlane.plane` is immutable after mount. Use `:key="plane"` to move a subtree to another plane.
+- `TRenderPlane.plane` is immutable after mount.
 - `scheduler.queueFrameTask()` may return `false` when rejected; `true` or `undefined` means accepted.
-- `scheduler.cancelFrameTask()` is best-effort. Frame task callbacks must still guard stale or disposed local state.
-- `TerminalFrameContext` now includes optional `reportDroppedUpdates()` for coalesced producer metrics.
+- `scheduler.cancelFrameTask()` remains best-effort, so frame task callbacks should still guard stale or disposed local state.
+- DOM renderer rowKey prepass now supports automatic/default adaptive behavior.
 - `sliceByCellsRange()` preserves cell occupancy with spaces when a range cuts through a wide grapheme. This affects `TList`, `TLogView`, Markdown, `TVirtualMarkdown`, and direct text utility users.
-
-### Added
-
-- Internal `createFrameMailbox()` coalesces latest-only producer updates into one scheduler frame task. It is not exported from the package root or experimental entrypoint.
-- `RenderManager.markDirtyRows(id, rows)` marks absolute terminal rows for the node's plane and repaints same-plane overlapping nodes in z-order.
-- Agent Console example covering streaming transcript, log/markdown modes, split render planes, input stability, search, links, command palette overlay, browser smoke, and stdout smoke.
-- `createMarkdownBlockSource()` in the markdown entrypoint lets streaming transcript apps finalize markdown blocks and pass `blocks` to `TVirtualMarkdown` without reparsing finalized history.
-- `TVirtualMarkdown` accepts external markdown `blocks` in addition to the existing `content` string path.
-- 0.x release candidate docs covering validation commands, package export boundaries, examples, migration notes, and experimental API warnings.
-- Release validation scripts split 0.x checks into `release:check`, `release:bench`, and `release:smoke`.
-
-### Migration Notes
-
-- Treat `@simon_he/vue-tui/experimental` as an opt-in boundary. Keep `TVirtualList`, `TLogView`, log companions, and log plugins isolated from root-entry application code.
-- For `TLogView`, custom mutable sources should bump `version` or return changing `getLineKey(index)` values for rows whose content changes.
-- Browser and terminal examples now have separate smoke paths; release validation should run headless smoke in CI and reserve real terminal runners for manual checks.
+- README was rewritten into user-facing docs for entrypoints, examples, validation, and performance guidance.
+- Vue peer dependency range now allows Vue 3.3 through Vue 3.x.
+- Package exports were tightened around root, markdown, and experimental entrypoints.
 
 ### Fixed
 
+- `TDialog` selected button underline rendering.
+- `TDialog` pointerup/click double confirm behavior.
+- `EventManager` stale same-rect remount bubbling.
 - DOM renderer span fast paths now work in Node DOM environments that do not expose `HTMLSpanElement` globally.
 - Basic browser example build avoids bundling Node-only terminal/event/profiler modules while keeping terminal builds on the root package entry.
+- `TLogView` wrap scroll fast path is disabled when it is unsafe.
 - CI now runs the VitePress docs build during verification so broken docs links fail before release.
+
+### Performance
+
+- Frame mailbox for `TList`, `TLogView`, and `TVirtualList`.
+- Dirty-row repaint primitive for same-plane repaint.
+- `TLogView` data and wheel coalescing.
+- `TLogView` append/tail dirty-row refinement.
+- `TVirtualList` controlled `scrollTop` and mailbox path.
+- DOM renderer plain text fast path.
+- DOM renderer single styled row fast path.
+- DOM renderer multi-segment span reuse.
+- DOM renderer row render stats.
+- DOM renderer rowKey prepass and adaptive decision.
+- Markdown block-level cache reuse.
+- `bench:scroll-mailbox`.
+- `bench:dom-renderer`.
+- `bench:phase2`.
+
+### Experimental
+
+- `TVirtualList`.
+- `TLogView`.
+- TLog search, link, scrollbar, and minimap companions.
+- Append-only log store.
+- TLog plugins.
+- Agent Console example stack.
+
+Experimental APIs remain under `@simon_he/vue-tui/experimental` and may change before the next stable release.
+
+### Breaking / Migration Notes
+
+- `TList` wheel events now update viewport scroll only. They no longer mutate active selection or emit `update:modelValue`.
+- `TList` confirmation is represented by `change`; `update:modelValue` represents selection changes.
+- `TList` Enter and double click emit `change`; they do not emit `update:modelValue` when committing the already-active item.
+- `TRenderPlane.plane` is immutable after mount. Use a keyed remount to move a subtree to another plane.
+- `scheduler.queueFrameTask()` may return `false` when rejected. Producers should clear pending state or retry explicitly.
+- `TLogView` custom mutable sources should bump `version`, provide changing `getLineKey(index)`, or call `refreshViewport()` / `invalidateLine()` / `invalidateRange()`.
+- Browser and terminal examples now have separate smoke paths. Run headless smoke in CI and reserve real terminal runners for manual checks.
+- High-throughput APIs remain outside the root entrypoint.
+
+### Release Validation
+
+Run the full local release gate before publishing:
+
+```bash
+pnpm run release:dry-run
+```
+
+`release:dry-run` includes:
+
+- `release:check`
+- `release:bench`
+- `release:smoke`
+- `release:pack-smoke`
+
+The release validation flow also covers `release:pack` through the packed package smoke.

--- a/docs/release-candidate.md
+++ b/docs/release-candidate.md
@@ -18,7 +18,7 @@
 - 高吞吐组件继续从 `@simon_he/vue-tui/experimental` 引入，应用代码应把这些 imports 隔离在少量边界文件内。
 - 自定义 `TLogView` source 仍应通过 `version` 或 `getLineKey(index)` 表达内容变化，避免复用 stale line cache。
 
-完整行为变更列表以 [CHANGELOG](https://github.com/Simon-He95/vue-tui/blob/main/CHANGELOG.md) 的 `Unreleased` 为准。
+完整行为变更列表以 [CHANGELOG](https://github.com/Simon-He95/vue-tui/blob/main/CHANGELOG.md) 的 `0.1.0-rc.0` 为准。
 
 ## Package Exports
 


### PR DESCRIPTION
## Summary

- Move the accumulated changelog into a `0.1.0-rc.0` release notes section.
- Group release notes into Added, Changed, Fixed, Performance, Experimental, Breaking / Migration Notes, and Release Validation.
- Update the release candidate doc reference from `Unreleased` to `0.1.0-rc.0`.

## Validation

- `pnpm run format:check`
- `pnpm run release:dry-run`