### PR TITLE
docs: refresh project docs and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,69 @@
+name: Bug report
+description: Report incorrect renderer, runtime, event, component, or package behavior.
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please include a small reproduction or the narrowest command that shows the problem.
+  - type: input
+    id: package-version
+    attributes:
+      label: Package version
+      description: The installed `@simon_he/vue-tui` version or commit SHA.
+      placeholder: "0.0.7 or commit SHA"
+    validations:
+      required: true
+  - type: dropdown
+    id: renderer
+    attributes:
+      label: Renderer / runtime
+      options:
+        - Browser DOM renderer
+        - stdout renderer
+        - headless createTerminalApp
+        - core terminal API
+        - docs / package
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Link to a repo, paste a minimal snippet, or list the exact command and example used.
+      placeholder: "pnpm run example:agent-console:smoke"
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened? Include terminal/browser output, screenshots, or failing assertion text when useful.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include OS, package manager, Vue version, browser or terminal, and Node version if relevant.
+      placeholder: |
+        OS:
+        Node:
+        Vue:
+        Browser or terminal:
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation tried
+      description: Commands or checks you already ran.
+      placeholder: |
+        pnpm run test
+        pnpm run docs:build

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Search existing issues
+    url: https://github.com/Simon-He95/vue-tui/issues?q=is%3Aissue
+    about: Check whether the bug, request, or docs gap is already tracked.
+  - name: Read the docs
+    url: https://github.com/Simon-He95/vue-tui/tree/main/docs
+    about: Start with the docs when the question is about expected behavior or supported APIs.

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,34 @@
+name: Documentation issue
+description: Report missing, stale, confusing, or broken documentation.
+title: "docs: "
+labels: ["documentation"]
+body:
+  - type: input
+    id: page
+    attributes:
+      label: Page or section
+      description: Link to the page or name the README/docs section.
+      placeholder: "README.md, docs/performance.md, docs/generated/components-api.md"
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is missing, stale, confusing, or broken?
+    validations:
+      required: true
+  - type: textarea
+    id: suggested-change
+    attributes:
+      label: Suggested change
+      description: Optional wording, examples, links, or commands that should be added.
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Impact
+      options:
+        - Blocks adoption
+        - Causes wrong usage
+        - Minor confusion
+        - Broken link or typo

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,45 @@
+name: Feature request
+description: Propose a focused API, component, renderer, docs, or tooling improvement.
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: What are you trying to build, and where does the current API fall short?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - root entrypoint
+        - markdown entrypoint
+        - experimental entrypoint
+        - DOM renderer
+        - stdout renderer
+        - scheduler / performance
+        - events / input
+        - examples / docs
+        - package / release
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: Describe the smallest API or behavior change that would solve the use case.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Existing APIs, app-level workarounds, or smaller changes you considered.
+  - type: textarea
+    id: migration
+    attributes:
+      label: Compatibility / migration notes
+      description: Mention whether this affects root, markdown, or experimental imports.

--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
-# Vue TUI
+# @simon_he/vue-tui
 
-Vue TUI is a Vue 3 terminal UI toolkit. It lets you render the same component model to a browser DOM surface or to a real terminal through stdout.
+Vue TUI is a Vue 3 terminal UI toolkit for building terminal-style interfaces that can render in a browser or in a real CLI. It gives you Vue components, terminal cell rendering, event dispatch, markdown rendering, and high-throughput primitives for lists, logs, and streaming transcripts.
 
-The package is useful for:
+Use it when you want:
 
-- browser-hosted terminal interfaces and playgrounds
-- CLI apps that want Vue component composition
-- high-throughput views such as virtual lists, streaming logs, and markdown transcripts
-- renderer and terminal experiments that need deterministic tests
+- Browser-hosted terminal interfaces, dashboards, demos, and playgrounds.
+- CLI apps that use Vue component composition instead of imperative stdout drawing.
+- Shared UI code that can run against a DOM renderer, a stdout renderer, or headless tests.
+- Large terminal surfaces such as virtual lists, append-only logs, markdown transcripts, and agent console UIs.
 
-## Installation
+## Install
 
 ```bash
 pnpm add @simon_he/vue-tui vue
 ```
 
-Vue is a peer dependency. The published package supports Vue `>=3.3.0 <4`.
+Vue is a peer dependency. The current package supports Vue `>=3.3.0 <4`.
 
 ## Entry Points
 
-| Import                           | Stability         | Main exports                                                                                                                                                                    |
-| -------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@simon_he/vue-tui`              | Stable            | `TerminalProvider`, `TText`, `TBox`, `TInput`, `createTerminal`, `createDomRenderer`, `createStdoutRenderer`, `createTerminalApp`, event managers, runtime/router/input helpers |
-| `@simon_he/vue-tui/markdown`     | Focused sub-entry | `TMarkdownText`, `TVirtualMarkdown`, markdown parser and layout helpers                                                                                                         |
-| `@simon_he/vue-tui/experimental` | Experimental      | `TVirtualList`, `TLogView`, log search/link/minimap components, append-only log store, TLog plugins                                                                             |
+| Import                           | Stability    | Use it for                                                                                                       |
+| -------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------- |
+| `@simon_he/vue-tui`              | Core         | Terminal runtime, root Vue components, DOM/stdout renderers, events, layout, inputs, router, and runtime helpers |
+| `@simon_he/vue-tui/markdown`     | Focused      | `TMarkdownText`, `TVirtualMarkdown`, markdown parser and layout helpers, streaming markdown block sources        |
+| `@simon_he/vue-tui/experimental` | Experimental | `TVirtualList`, `TLogView`, TLog search/link/minimap companions, append-only log store, and TLog plugins         |
 
-High-throughput log and virtualized APIs are intentionally kept out of the root entrypoint until their API surface settles.
+High-throughput log and virtualization APIs stay under `/experimental` until their public surface settles. Keep those imports isolated in application code.
 
 ## Browser Usage
 
@@ -47,7 +47,9 @@ const input = ref("");
 </template>
 ```
 
-## Terminal Usage
+`TerminalProvider` wires the terminal buffer, DOM renderer, event manager, scheduler, runtime, layout context, and input plugins for browser Vue apps.
+
+## CLI Usage
 
 For a real terminal, mount a headless Vue app and attach stdout/stdin:
 
@@ -90,128 +92,46 @@ const driver = createStdinDriver({
 
 ## Core Concepts
 
-- `createTerminal({ cols, rows })` creates the cell buffer, cursor, planes, scrollback, and commit events.
-- `createDomRenderer(terminal, container)` renders terminal cells to DOM with row caching and optional DOM scroll operations.
+- `createTerminal({ cols, rows })` owns the cell buffer, cursor, planes, scrollback, and commit events.
+- `createDomRenderer(terminal, container)` renders terminal cells to DOM with row caching and fast paths for plain and styled rows.
 - `createStdoutRenderer(terminal, options)` emits ANSI output for real terminal UIs.
-- `TerminalProvider` wires terminal, renderer, events, scheduler, runtime, layout, and input plugins for browser Vue usage.
-- `createTerminalApp()` provides the same runtime wiring without a DOM renderer, for CLI apps and tests.
-- `TRenderPlane` separates transcript, chrome, and overlay surfaces so small UI updates do not repaint large content panes.
+- `TerminalProvider` is the browser-facing Vue runtime provider.
+- `createTerminalApp()` is the headless runtime for CLI apps and deterministic tests.
+- `TRenderPlane` separates transcript, chrome, input, and overlay surfaces so small updates do not repaint large panes.
 
-## API Surface
+## Components
 
-### Root Components
+| Area          | Components                                                                                     |
+| ------------- | ---------------------------------------------------------------------------------------------- |
+| Layout        | `TBox`, `TView`, `TAnchor`, `TFlow`, `TRenderPlane`, `TRenderLayer`                            |
+| Text          | `TText`, `TTransition`, `TMarkdownText`, `TVirtualMarkdown`                                    |
+| Input         | `TInput`, `TInputBox`, `TSelect`, `TPathPicker`, `TJsonEditor`                                 |
+| Overlay       | `TDialog`, `TMultilineModal`, `TDebugOverlay`                                                  |
+| Experimental  | `TVirtualList`, `TLogView`, `TLogSearchBar`, `TLogLinksPanel`, `TLogScrollbar`, `TLogMinimap`  |
+| Runtime tools | `createTerminal`, `createDomRenderer`, `createStdoutRenderer`, `createTerminalApp`, event APIs |
 
-| Component                                                                 | Purpose                                          |
-| ------------------------------------------------------------------------- | ------------------------------------------------ |
-| `TerminalProvider`                                                        | Browser terminal runtime provider                |
-| `TText`                                                                   | Fixed-position text drawing                      |
-| `TBox`                                                                    | Border, title, padding, and clipped content area |
-| `TView`, `TAnchor`, `TFlow`                                               | Layout containers                                |
-| `TInput`, `TInputBox`, `TSelect`, `TDialog`, `TPathPicker`, `TJsonEditor` | Interactive terminal widgets                     |
-| `TRenderPlane`, `TRenderLayer`                                            | Plane/layer routing                              |
-| `TTransition`                                                             | Time-based mount/unmount transitions             |
+See [docs/components.md](./docs/components.md) and [docs/generated/components-api.md](./docs/generated/components-api.md) for props and events.
 
-### Core And Renderer APIs
+## Documentation
 
-| API                                           | Purpose                                     |
-| --------------------------------------------- | ------------------------------------------- |
-| `createTerminal`                              | In-memory terminal and planes               |
-| `createDomRenderer`                           | Browser DOM renderer                        |
-| `createStdoutRenderer`                        | CLI/stdout renderer                         |
-| `createEventManager`, `createCliEventManager` | Pointer/keyboard dispatch to terminal nodes |
-| `createTerminalApp`                           | Headless Vue app for CLI/tests              |
-| `createRuntime`                               | Imperative component mounting               |
-| `createTerminalRouter`                        | Terminal route state                        |
+| Page                                                             | Purpose                                                              |
+| ---------------------------------------------------------------- | -------------------------------------------------------------------- |
+| [Docs home](./docs/index.md)                                     | Product overview and reading path                                    |
+| [Examples index](./docs/examples.md)                             | Browser, terminal, and smoke example commands                        |
+| [Core API](./docs/api.md)                                        | Terminal, renderer, events, runtime, planes, and scheduler contracts |
+| [Performance](./docs/performance.md)                             | Practical performance guidance                                       |
+| [High-throughput rendering](./docs/high-throughput-rendering.md) | Scheduler, dirty rows, mailbox, log, and renderer architecture       |
+| [Agent Console](./docs/agent-console.md)                         | Streaming transcript example stack                                   |
+| [Release candidate](./docs/release-candidate.md)                 | 0.x validation, package export checks, and migration notes           |
 
-### Markdown Entry
-
-| API                                                                      | Purpose                                                  |
-| ------------------------------------------------------------------------ | -------------------------------------------------------- |
-| `TMarkdownText`                                                          | Markdown text block                                      |
-| `TVirtualMarkdown`                                                       | Virtualized markdown viewport for long/streaming content |
-| `createMarkdownBlockSource`                                              | Incremental block source for streaming markdown history  |
-| `createTuiMarkdownParser`                                                | Parser wrapper around `stream-markdown-parser`           |
-| `buildMarkdownBlocks`, `buildMarkdownVisualRows`, `layoutMarkdownBlocks` | Markdown pipeline helpers                                |
-
-### Experimental Entry
-
-| API                                                                                 | Purpose                                              |
-| ----------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| `TVirtualList`                                                                      | Virtual list with dirty-row and scroll optimizations |
-| `TLogView`                                                                          | Append-only / retained-window log viewport           |
-| `createAppendOnlyLogStore`                                                          | Streaming log source for `TLogView`                  |
-| `TLogSearchBar`, `TLogSearchResults`, `TLogVirtualSearchResults`, `TLogSearchPager` | Log search UI                                        |
-| `TLogLinksPanel`, `TLogVirtualLinksPanel`                                           | Link navigation UI                                   |
-| `TLogScrollbar`, `TLogMinimap`                                                      | Log navigation affordances                           |
-
-## Performance Guide
-
-Use the renderer features that match the workload:
-
-- Split large transcript content and frequently changing chrome into different `TRenderPlane`s.
-- Use `TVirtualList` for large lists rather than rendering all rows as components.
-- Use `TLogView` with `createAppendOnlyLogStore({ maxLines })` for streaming logs.
-- Provide stable line keys for custom `TLogView` sources; mutable tail rows should get changing keys.
-- For DOM rendering, row-key prepass defaults to `"auto"` and enables itself only when cached-row hit ratio is useful.
-- For stdout rendering, set `colorMode` or `DIMCODE_COLOR_MODE` when the terminal color capability is known.
-- Reuse style objects on hot paths instead of creating new object literals every frame.
-
-Useful checks:
+Run the docs locally:
 
 ```bash
-pnpm run bench:dom-renderer
-pnpm run bench:scroll-mailbox
-pnpm run bench:phase2
+pnpm run docs:dev
+pnpm run docs:build
 ```
 
-More detail: [docs/performance.md](./docs/performance.md) and [docs/high-throughput-rendering.md](./docs/high-throughput-rendering.md).
-
-## Colors And Themes
-
-Styles support ANSI color names, hex colors, and terminal text attributes:
-
-```ts
-type Style = {
-  fg?: string;
-  bg?: string;
-  bold?: boolean;
-  dim?: boolean;
-  italic?: boolean;
-  underline?: boolean;
-  inverse?: boolean;
-  href?: string;
-};
-```
-
-DOM and stdout renderers share the same ANSI palette resolver. `createDomRenderer` exposes palette values as CSS variables, while `createStdoutRenderer` maps them to truecolor or downgraded ANSI sequences depending on `colorMode`.
-
-## Package And Release Notes
-
-- The published package ships `dist` only. Export targets point to built ESM/CJS/types files.
-- Root, markdown, and experimental entrypoints are available as both ESM and CJS after build.
-- The package does not declare a Node engine for the root browser/core API. CLI usage requires a Node-like process/stdout/stdin environment.
-- The markdown sub-entry depends on `stream-markdown-parser`; check that dependency chain if your runtime has strict engine policies.
-- Experimental APIs can change before the next stable release. Keep imports from `/experimental` isolated in application code.
-
-## Known Limitations
-
-- `TVirtualMarkdown` reuses block-level layout during streaming. The `content` path still parses the current full markdown string; stream-driven apps that can finalize transcript blocks can use `createMarkdownBlockSource` and pass `blocks` to avoid reparsing finalized history.
-- `TLogView` is optimized for append-only and retained-window sources; arbitrary random mutation workloads should provide explicit stable keys and should be tested with the target renderer.
-- Terminal emoji and East Asian width behavior still depends on the user terminal and font.
-- ANSI16 colors follow the terminal theme; use truecolor or ansi256 for more deterministic color output.
-- No canvas renderer is currently shipped.
-
-## Development
-
-```bash
-pnpm install
-pnpm run typecheck
-pnpm run lint
-pnpm run test
-pnpm run build
-```
-
-Examples:
+## Examples
 
 ```bash
 pnpm -C examples/basic dev
@@ -224,23 +144,58 @@ pnpm run example:agent-console:smoke
 pnpm run example:agent-console:terminal:smoke
 ```
 
-Docs:
+The smoke commands are deterministic and avoid real LLM APIs, real TTY dependencies, and timing-only pass/fail gates.
+
+## Performance Notes
+
+- Use `TVirtualList` instead of rendering thousands of row components.
+- Use `TLogView` with `createAppendOnlyLogStore({ maxLines })` for retained streaming logs.
+- Provide stable line keys for custom `TLogView` sources; mutable rows should change keys or call the explicit invalidation APIs.
+- Split high-volume content and frequently changing chrome into different `TRenderPlane`s.
+- Reuse style objects on hot paths instead of creating new object literals every frame.
+
+Useful checks:
 
 ```bash
-pnpm run docs:gen
-pnpm run docs:dev
-pnpm run docs:build
+pnpm run bench:dom-renderer
+pnpm run bench:scroll-mailbox
+pnpm run bench:phase2
+```
+
+## Issues And Feedback
+
+- Report bugs: [new bug report](https://github.com/Simon-He95/vue-tui/issues/new?template=bug_report.yml)
+- Request features: [new feature request](https://github.com/Simon-He95/vue-tui/issues/new?template=feature_request.yml)
+- Report documentation issues: [new docs issue](https://github.com/Simon-He95/vue-tui/issues/new?template=docs.yml)
+- Browse existing issues: [GitHub issues](https://github.com/Simon-He95/vue-tui/issues)
+
+For renderer, scheduler, or terminal behavior bugs, include the renderer target (`DOM`, `stdout`, or headless), the relevant command, and a minimal reproduction when possible.
+
+## Development
+
+```bash
+pnpm install
+pnpm run format:check
+pnpm run lint
+pnpm run typecheck
+pnpm run test
+pnpm run build
 ```
 
 Release validation:
 
 ```bash
-pnpm run release:check
-pnpm run release:bench
-pnpm run release:smoke
+pnpm run release:dry-run
 ```
 
-See [docs/release-candidate.md](./docs/release-candidate.md) for the expanded validation matrix, package export checks, examples index, and migration notes.
+`release:dry-run` runs checks, tests, docs build, benchmarks, examples smoke, and packed package install smoke.
+
+## Package Notes
+
+- The published package ships `dist` only.
+- Root, markdown, and experimental entrypoints are available as ESM, CJS, and type declarations after build.
+- The root browser/core API does not require a Node runtime, but CLI usage expects a Node-like stdout/stdin environment.
+- Terminal emoji and East Asian width behavior still depends on the user terminal and font.
 
 ## License
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -8,9 +8,29 @@ function shim(path: string): string {
 export default defineConfig({
   lang: "zh-CN",
   title: "Vue TUI",
-  description: "Vue 3 terminal UI component library",
+  description: "Vue 3 terminal UI toolkit for browser DOM and CLI stdout renderers",
   cleanUrls: true,
   lastUpdated: true,
+  head: [
+    [
+      "meta",
+      {
+        name: "keywords",
+        content:
+          "Vue, Vue 3, terminal UI, TUI, CLI, stdout renderer, DOM renderer, ANSI, markdown, virtual list, log viewer",
+      },
+    ],
+    ["meta", { property: "og:title", content: "Vue TUI" }],
+    [
+      "meta",
+      {
+        property: "og:description",
+        content: "Vue 3 terminal UI toolkit for browser DOM and CLI stdout renderers.",
+      },
+    ],
+    ["meta", { property: "og:type", content: "website" }],
+    ["meta", { name: "twitter:card", content: "summary" }],
+  ],
   vite: {
     resolve: {
       alias: [
@@ -44,6 +64,17 @@ export default defineConfig({
       { text: "Planes", link: "/planes-and-compositor" },
       { text: "扩展性", link: "/extensibility" },
       { text: "组件 API（生成）", link: "/generated/components-api" },
+      {
+        text: "GitHub",
+        items: [
+          { text: "Repository", link: "https://github.com/Simon-He95/vue-tui" },
+          { text: "Issues", link: "https://github.com/Simon-He95/vue-tui/issues" },
+          {
+            text: "New issue",
+            link: "https://github.com/Simon-He95/vue-tui/issues/new/choose",
+          },
+        ],
+      },
     ],
     sidebar: [
       {
@@ -77,14 +108,23 @@ export default defineConfig({
         ],
       },
       {
-        text: "验收与评审",
+        text: "验收",
         items: [
-          { text: "Components Acceptance", link: "/components-acceptance" },
-          { text: "Design Review", link: "/design-review" },
           { text: "Overflow", link: "/overflow" },
+          { text: "Examples Index", link: "/examples" },
+          { text: "0.x Release Candidate", link: "/release-candidate" },
         ],
       },
     ],
+    editLink: {
+      pattern: "https://github.com/Simon-He95/vue-tui/edit/main/docs/:path",
+      text: "在 GitHub 上编辑此页",
+    },
+    footer: {
+      message:
+        "Bug reports, feature requests, and documentation issues are tracked on GitHub Issues.",
+      copyright: "Released under the MIT License.",
+    },
     socialLinks: [{ icon: "github", link: "https://github.com/Simon-He95/vue-tui" }],
   },
 });

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: Vue TUI
+description: Vue 3 terminal UI toolkit for browser DOM and CLI stdout renderers.
 ---
 
 <script setup lang="ts">
@@ -8,46 +9,79 @@ import DocsLandingTerminal from './.vitepress/components/DocsLandingTerminal.vue
 
 # Vue TUI
 
-用 Vue 3 组件语法开发终端 UI，同时保留两套渲染落点：
-
-- 浏览器里的 `DOM renderer`，适合文档站、playground、视觉验收
-- 真实终端里的 `stdout renderer`，适合 CLI、snapshot replay、record/replay parity
+Vue TUI 是面向 Vue 3 的 terminal UI toolkit。你可以用同一套组件模型渲染到浏览器 DOM，也可以渲染到真实终端 stdout；适合构建 CLI、terminal-style dashboard、日志视图、markdown transcript 和 agent console。
 
 <ClientOnly>
   <DocsLandingTerminal />
 </ClientOnly>
 
-## 这个站点现在解决什么问题
+## 适合什么场景
 
-- 直接在网站里渲染真实的 TUI 组件，而不是另外做一层“静态截图式官网”
-- 把组件清单、参数、用法、自动生成 API 和 live demo 放到同一个入口
-- 把 `GoatChain` / `dimcode` 参考实现和框架能力拆开来看，避免误把 reference app 当成框架边界
+- 浏览器里的 terminal UI、playground、文档 demo 和视觉验收页面
+- 真实终端里的 Vue 组件式 CLI
+- 需要 DOM renderer、stdout renderer 和 headless tests 共用一套 UI 逻辑的项目
+- 大列表、append-only log、streaming markdown、agent transcript 这类高吞吐界面
 
-## 快速入口
+## 安装
 
-- [Live Showcase](/showcase)
-- [Examples Index](/examples)
-- [Agent Console 示例](/agent-console)
-- [组件总览](/components)
-- [组件 API（自动生成）](/generated/components-api)
-- [核心 API](/api)
-- [Planes 与 Compositor](/planes-and-compositor)
-- [0.x Release Candidate](/release-candidate)
-- [扩展性与插件化](/extensibility)
+```bash
+pnpm add @simon_he/vue-tui vue
+```
 
-## 架构速览
+Vue 是 peer dependency。当前发布包支持 Vue `>=3.3.0 <4`。
 
-| 层级      | 主要内容                                                | 是否通用 |
-| --------- | ------------------------------------------------------- | -------- |
-| Core      | `createTerminal()`、buffer、ANSI、scrollback            | 高       |
-| Renderer  | DOM renderer / stdout renderer                          | 高       |
-| Vue Layer | `TerminalProvider`、布局组件、交互组件、router、runtime | 高       |
+## 入口选择
 
-## 推荐阅读顺序
+| 入口                             | 稳定性       | 主要用途                                                                 |
+| -------------------------------- | ------------ | ------------------------------------------------------------------------ |
+| `@simon_he/vue-tui`              | Core         | Terminal runtime、基础组件、DOM/stdout renderer、events、router、runtime |
+| `@simon_he/vue-tui/markdown`     | Focused      | `TMarkdownText`、`TVirtualMarkdown`、markdown parser、block source       |
+| `@simon_he/vue-tui/experimental` | Experimental | `TVirtualList`、`TLogView`、TLog companions、append-only log store       |
 
-1. 先看 [Live Showcase](/showcase)，确认这套组件在网页里如何真实渲染。
-2. 再看 [组件总览](/components) 和 [组件 API（自动生成）](/generated/components-api)，查 props / events / usage。
-3. 如果你关心 CLI 级性能和分层渲染，接着看 [Planes 与 Compositor](/planes-and-compositor)。
-4. 如果你关心大列表、日志和 streaming 输出，看 [Agent Console 示例](/agent-console) 和 [高吞吐渲染架构规格](/high-throughput-rendering)。
-5. 准备发布前看 [Examples Index](/examples) 和 [0.x Release Candidate](/release-candidate)，确认 smoke、bench、docs、exports 都走通。
-6. 最后看 [扩展性与插件化](/extensibility)，判断哪些能力已经能注入，哪些还值得继续抽象。
+`/experimental` API 仍可能在下一个 stable release 前变化。生产应用建议把这些 import 隔离在少量边界文件内。
+
+## 快速路径
+
+| 目标         | 先读这些页面                                                                                            |
+| ------------ | ------------------------------------------------------------------------------------------------------- |
+| 了解能力边界 | [Live Showcase](/showcase)、[组件总览](/components)、[核心 API](/api)                                   |
+| 跑示例       | [Examples Index](/examples)、[Agent Console 示例](/agent-console)                                       |
+| 做 CLI       | [Runtime](/runtime)、[CLI Events](/cli-events)、[Terminal Compatibility](/terminal-compatibility)       |
+| 做高吞吐 UI  | [Performance](/performance)、[高吞吐渲染](/high-throughput-rendering)、[TLogView Lab](/tlog-view-lab)   |
+| 准备发布     | [0.x Release Candidate](/release-candidate)、[TLogView Release Readiness](/tlog-view-release-readiness) |
+
+完整 props / events 以 [组件 API（自动生成）](/generated/components-api) 为准。
+
+## 核心模型
+
+| 层级      | 内容                                                    |
+| --------- | ------------------------------------------------------- |
+| Core      | `createTerminal()`、buffer、planes、ANSI、scrollback    |
+| Renderer  | DOM renderer、stdout renderer、row cache、ANSI output   |
+| Vue Layer | `TerminalProvider`、布局组件、交互组件、runtime、router |
+| Events    | pointer / keyboard / wheel 映射、capture/bubble、focus  |
+
+常见组合是把 transcript、chrome、input 和 overlay 分到不同 `TRenderPlane`，让高频正文更新和低频 UI chrome 拆开 repaint。
+
+## 示例命令
+
+```bash
+pnpm -C examples/basic dev
+pnpm run run:basic:terminal
+pnpm run example:tlog-view-lab
+pnpm run example:agent-console
+pnpm run example:agent-console:smoke
+```
+
+发布前完整验证：
+
+```bash
+pnpm run release:dry-run
+```
+
+## 反馈
+
+- [提交 bug](https://github.com/Simon-He95/vue-tui/issues/new?template=bug_report.yml)
+- [提交 feature request](https://github.com/Simon-He95/vue-tui/issues/new?template=feature_request.yml)
+- [提交文档问题](https://github.com/Simon-He95/vue-tui/issues/new?template=docs.yml)
+- [查看已有 issues](https://github.com/Simon-He95/vue-tui/issues)

--- a/package.json
+++ b/package.json
@@ -1,10 +1,26 @@
 {
   "name": "@simon_he/vue-tui",
   "version": "0.0.7",
-  "description": "A Vue 3 terminal UI component library",
-  "keywords": [],
+  "description": "Vue 3 terminal UI toolkit for browser DOM and CLI stdout renderers",
+  "keywords": [
+    "ansi",
+    "cli",
+    "component-library",
+    "dom-renderer",
+    "log-viewer",
+    "markdown",
+    "stdout",
+    "terminal",
+    "terminal-ui",
+    "tui",
+    "virtual-list",
+    "vue",
+    "vue3"
+  ],
   "homepage": "https://github.com/Simon-He95/vue-tui#readme",
-  "bugs": "https://github.com/Simon-He95/vue-tui/issues",
+  "bugs": {
+    "url": "https://github.com/Simon-He95/vue-tui/issues"
+  },
   "license": "MIT",
   "author": "Simon He",
   "repository": {


### PR DESCRIPTION
## Summary

- Rewrite README and docs home as clearer user-facing entrypoints.
- Add VitePress SEO metadata, GitHub issue links, edit links, footer copy, and remove stale sidebar entries.
- Add GitHub issue forms for bug reports, feature requests, and documentation issues.
- Update package metadata with a stronger description, keywords, and a structured bugs URL.

## Validation

- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run docs:build`