### PR TITLE
fix(selection): cross-viewport selection for virtual scroll components

### DIFF
--- a/docs/generated/components-api.md
+++ b/docs/generated/components-api.md
@@ -191,9 +191,9 @@
 
 ### Events
 
-| 名称                       | Payload                                                          | 说明 |
-| -------------------------- | ---------------------------------------------------------------- | ---- |
-| <code>selectionCopy</code> | <code>(_payload: TerminalSelectionCopyPayload) =&gt; true</code> | —    |
+| 名称                       | Payload                                                           | 说明 |
+| -------------------------- | ----------------------------------------------------------------- | ---- |
+| <code>selectionCopy</code> | <code>(\_payload: TerminalSelectionCopyPayload) =&gt; true</code> | —    |
 
 ## TFlow
 

--- a/docs/generated/components-api.md
+++ b/docs/generated/components-api.md
@@ -191,9 +191,9 @@
 
 ### Events
 
-| 名称                       | Payload | 说明 |
-| -------------------------- | ------- | ---- |
-| <code>selectionCopy</code> | —       | —    |
+| 名称                       | Payload                                                          | 说明 |
+| -------------------------- | ---------------------------------------------------------------- | ---- |
+| <code>selectionCopy</code> | <code>(_payload: TerminalSelectionCopyPayload) =&gt; true</code> | —    |
 
 ## TFlow
 
@@ -973,6 +973,7 @@
 | <code>style</code>         | <code>Style</code>                                        | <code>undefined</code>       | 否   | —    |
 | <code>activeStyle</code>   | <code>Style</code>                                        | <code>undefined</code>       | 否   | —    |
 | <code>autoFocus</code>     | <code>boolean</code>                                      | <code>false</code>           | 否   | —    |
+| <code>selectionText</code> | <code>(item: unknown, index: number) =&gt; string</code>  | <code>undefined</code>       | 否   | —    |
 | <code>selectable</code>    | <code>boolean</code>                                      | <code>false</code>           | 否   | —    |
 | <code>rowScrollMode</code> | <code>RowScrollMode</code>                                | <code>&quot;off&quot;</code> | 否   | —    |
 

--- a/docs/generated/components-api.md
+++ b/docs/generated/components-api.md
@@ -191,9 +191,9 @@
 
 ### Events
 
-| 名称                       | Payload                                                           | 说明 |
-| -------------------------- | ----------------------------------------------------------------- | ---- |
-| <code>selectionCopy</code> | <code>(\_payload: TerminalSelectionCopyPayload) =&gt; true</code> | —    |
+| 名称                       | Payload                                                          | 说明 |
+| -------------------------- | ---------------------------------------------------------------- | ---- |
+| <code>selectionCopy</code> | <code>(_payload: TerminalSelectionCopyPayload) =&gt; true</code> | —    |
 
 ## TFlow
 

--- a/docs/generated/components-api.md
+++ b/docs/generated/components-api.md
@@ -332,23 +332,23 @@
 
 ### Props
 
-| 名称                                     | 类型                                  | 默认值                                          | 必填 | 说明 |
-| ---------------------------------------- | ------------------------------------- | ----------------------------------------------- | ---- | ---- |
-| <code>x</code>                           | <code>number</code>                   | —                                               | 是   | —    |
-| <code>y</code>                           | <code>number</code>                   | —                                               | 是   | —    |
-| <code>w</code>                           | <code>number</code>                   | —                                               | 是   | —    |
-| <code>h</code>                           | <code>number</code>                   | <code>8</code>                                  | 否   | —    |
-| <code>zIndex</code>                      | <code>number</code>                   | <code>0</code>                                  | 否   | —    |
-| <code>modelValue</code>                  | <code>string</code>                   | —                                               | 是   | —    |
-| <code>placeholder</code>                 | <code>string</code>                   | <code>&quot;&quot;</code>                       | 否   | —    |
-| <code>style</code>                       | <code>Style</code>                    | <code>undefined</code>                          | 否   | —    |
-| <code>showIndentGuides</code>            | <code>boolean</code>                  | <code>true</code>                               | 否   | —    |
-| <code>indentSize</code>                  | <code>number</code>                   | <code>2</code>                                  | 否   | —    |
-| <code>guideColors</code>                 | <code>readonly AnsiColorName[]</code> | <code>() =&gt; [...DEFAULT_GUIDE_COLORS]</code> | 否   | —    |
-| <code>autoFocus</code>                   | <code>boolean</code>                  | <code>false</code>                              | 否   | —    |
-| <code>cursorToEndOnFirstFocus</code>     | <code>boolean</code>                  | <code>true</code>                               | 否   | —    |
-| <code>cursorToEndOnExternalUpdate</code> | <code>boolean</code>                  | <code>true</code>                               | 否   | —    |
-| <code>submitOnEnter</code>               | <code>boolean</code>                  | <code>false</code>                              | 否   | —    |
+| 名称                                     | 类型                                  | 默认值                                            | 必填 | 说明 |
+| ---------------------------------------- | ------------------------------------- | ------------------------------------------------- | ---- | ---- |
+| <code>x</code>                           | <code>number</code>                   | —                                                 | 是   | —    |
+| <code>y</code>                           | <code>number</code>                   | —                                                 | 是   | —    |
+| <code>w</code>                           | <code>number</code>                   | —                                                 | 是   | —    |
+| <code>h</code>                           | <code>number</code>                   | <code>8</code>                                    | 否   | —    |
+| <code>zIndex</code>                      | <code>number</code>                   | <code>0</code>                                    | 否   | —    |
+| <code>modelValue</code>                  | <code>string</code>                   | —                                                 | 是   | —    |
+| <code>placeholder</code>                 | <code>string</code>                   | <code>&quot;&quot;</code>                         | 否   | —    |
+| <code>style</code>                       | <code>Style</code>                    | <code>undefined</code>                            | 否   | —    |
+| <code>showIndentGuides</code>            | <code>boolean</code>                  | <code>true</code>                                 | 否   | —    |
+| <code>indentSize</code>                  | <code>number</code>                   | <code>2</code>                                    | 否   | —    |
+| <code>guideColors</code>                 | <code>readonly AnsiColorName[]</code> | <code>() =&gt; [...DEFAULT\_GUIDE\_COLORS]</code> | 否   | —    |
+| <code>autoFocus</code>                   | <code>boolean</code>                  | <code>false</code>                                | 否   | —    |
+| <code>cursorToEndOnFirstFocus</code>     | <code>boolean</code>                  | <code>true</code>                                 | 否   | —    |
+| <code>cursorToEndOnExternalUpdate</code> | <code>boolean</code>                  | <code>true</code>                                 | 否   | —    |
+| <code>submitOnEnter</code>               | <code>boolean</code>                  | <code>false</code>                                | 否   | —    |
 
 ### Events
 

--- a/examples/basic/dist-terminal-multi-select/path-suggest-Dw4FNBt9.js
+++ b/examples/basic/dist-terminal-multi-select/path-suggest-Dw4FNBt9.js
@@ -1,5 +1,5 @@
 import process from "node:process";
-import { r as resolvePath, n as normalizePath, i as isAbsolutePath } from "./terminal-multi-select-D18FBSN7.js";
+import { r as resolvePath, n as normalizePath, i as isAbsolutePath } from "./terminal-multi-select-qND_iMwz.js";
 function lower(s) {
   return s.toLowerCase();
 }

--- a/examples/basic/dist-terminal-multi-select/terminal-multi-select-qND_iMwz.js
+++ b/examples/basic/dist-terminal-multi-select/terminal-multi-select-qND_iMwz.js
@@ -1647,11 +1647,11 @@ function createNodePathPickerProvider() {
       }
     },
     async suggest(info) {
-      const { suggestPaths } = await import("./path-suggest-C-jTVgYW.js");
+      const { suggestPaths } = await import("./path-suggest-Dw4FNBt9.js");
       return suggestPaths({ ...info, listDir: provider.listDir });
     },
     async resolvePath(workspaceAbs, input) {
-      const { resolveUserPath } = await import("./path-suggest-C-jTVgYW.js");
+      const { resolveUserPath } = await import("./path-suggest-Dw4FNBt9.js");
       return resolveUserPath(workspaceAbs, input);
     }
   };
@@ -10905,6 +10905,8 @@ function rectRowRange(rect) {
   return { y0, y1 };
 }
 const SUPPRESS_TERMINAL_POINTER_UP$1 = "__vueTuiSuppressTerminalPointerUp";
+const SUPPRESS_TERMINAL_POINTER_DOWN$1 = "__vueTuiSuppressTerminalPointerDown";
+const SUPPRESS_TERMINAL_POINTER_MOVE$1 = "__vueTuiSuppressTerminalPointerMove";
 let nextId = 0;
 function createCliEventManager(options) {
   const nodes = /* @__PURE__ */ new Map();
@@ -11348,6 +11350,12 @@ function createCliEventManager(options) {
           if (event.type === "pointerdown") {
             const list = candidatesAt(event.cellX, event.cellY);
             const target = pickTarget(list);
+            if (event[SUPPRESS_TERMINAL_POINTER_DOWN$1]) {
+              if (target?.focusable) setFocus(target.id);
+              capturedId = target?.id ?? null;
+              updateHover(target, event);
+              return true;
+            }
             if (target?.focusable) setFocus(target.id);
             capturedId = target?.id ?? null;
             updateHover(target, event);
@@ -11355,6 +11363,11 @@ function createCliEventManager(options) {
             return prevented;
           }
           if (event.type === "pointermove" && capturedId) {
+            if (event[SUPPRESS_TERMINAL_POINTER_MOVE$1]) {
+              const target2 = nodes.get(capturedId) ?? null;
+              if (target2) updateHover(target2, event);
+              return true;
+            }
             const target = nodes.get(capturedId) ?? null;
             if (!target) return prevented;
             updateHover(target, event);
@@ -11365,6 +11378,9 @@ function createCliEventManager(options) {
             return prevented;
           }
           if (event.type === "pointermove") {
+            if (event[SUPPRESS_TERMINAL_POINTER_MOVE$1]) {
+              return true;
+            }
             const list = candidatesAt(event.cellX, event.cellY);
             const target = pickTarget(list);
             updateHover(target, event);
@@ -13329,12 +13345,18 @@ function copyPayload(text, ok, error) {
     ...error === void 0 ? {} : { error }
   };
 }
+function clampPointToRect(point, rect) {
+  return {
+    x: Math.max(rect.x, Math.min(rect.x + Math.max(0, rect.w - 1), Math.floor(point.x))),
+    y: Math.max(rect.y, Math.min(rect.y + Math.max(0, rect.h - 1), Math.floor(point.y)))
+  };
+}
 function createTerminalSelectionController(options) {
   const state = /* @__PURE__ */ shallowRef(EMPTY_STATE);
   let range = null;
   let providerAnchor = null;
   let providerFocus = null;
-  let overlayRows = /* @__PURE__ */ new Map();
+  let overlaySpans = /* @__PURE__ */ new Map();
   let dirtyRows = /* @__PURE__ */ new Set();
   const readOptions = () => ({
     autoCopy: true,
@@ -13366,8 +13388,9 @@ function createTerminalSelectionController(options) {
     }
     return best;
   };
-  const providerPointForCell = (provider, point) => {
-    const providerPoint = provider.pointForCell?.(point) ?? point;
+  const providerPointForCell = (provider, point, options2) => {
+    const inputPoint = options2?.clampToRect ? clampPointToRect(point, provider.rect) : point;
+    const providerPoint = provider.pointForCell?.(inputPoint) ?? inputPoint;
     return providerPoint ? { providerId: provider.id, point: providerPoint } : null;
   };
   const textFromTerminalBuffer = (nextRange) => {
@@ -13379,57 +13402,86 @@ function createTerminalSelectionController(options) {
     }
     return lines.join("\n");
   };
+  const providerRangeFor = (provider, screenRange, anchorOverride, focusOverride) => {
+    if (anchorOverride && focusOverride && anchorOverride.providerId === provider.id && focusOverride.providerId === provider.id) {
+      return {
+        anchor: anchorOverride.point,
+        focus: focusOverride.point,
+        mode: screenRange.mode
+      };
+    }
+    const anchor = providerPointForCell(provider, screenRange.anchor, { clampToRect: true });
+    const focus = providerPointForCell(provider, screenRange.focus, { clampToRect: true });
+    if (!anchor || !focus) return null;
+    if (anchor.providerId !== provider.id || focus.providerId !== provider.id) return null;
+    return {
+      anchor: anchor.point,
+      focus: focus.point,
+      mode: screenRange.mode
+    };
+  };
   const selectedText = () => {
     if (!range) return "";
     if (providerAnchor && providerFocus && providerAnchor.providerId === providerFocus.providerId) {
       const provider2 = providerById(providerAnchor.providerId);
       if (provider2) {
-        return provider2.getText({
-          anchor: providerAnchor.point,
-          focus: providerFocus.point,
-          mode: range.mode
-        });
+        const providerRange = providerRangeFor(provider2, range, providerAnchor, providerFocus);
+        if (providerRange) return provider2.getText(providerRange);
       }
     }
     const provider = providers().find((candidate) => candidate.canHandle(range));
-    if (provider) return provider.getText(range);
+    if (provider) {
+      const providerRange = providerRangeFor(provider, range);
+      if (providerRange) return provider.getText(providerRange);
+    }
     return textFromTerminalBuffer(range);
   };
   const setResolvedText = (text) => {
     if (!range || !state.value.active || state.value.text === text) return;
     state.value = { ...state.value, text };
   };
+  const resolveProvider = (nextRange, nextProviderAnchor) => {
+    if (!nextRange) return null;
+    if (nextProviderAnchor) {
+      const provider = providerById(nextProviderAnchor.providerId);
+      if (provider) return provider;
+    }
+    return providers().find((candidate) => candidate.canHandle(nextRange)) ?? null;
+  };
   const rebuild = (nextRange, nextProviderAnchor, nextProviderFocus) => {
     const previousRows = dirtyRows;
     const size = options.terminal.size();
-    const nextOverlayRows = /* @__PURE__ */ new Map();
+    const nextOverlaySpans = /* @__PURE__ */ new Map();
     const nextDirtyRows = /* @__PURE__ */ new Set();
     let hasRange = false;
     if (nextRange) {
-      const selectionStyle = readOptions().style;
-      const spans = terminalSelectionRowSpans(nextRange, size.cols, size.rows);
+      const activeProvider = resolveProvider(nextRange, nextProviderAnchor);
+      let spans;
+      const providerRange = activeProvider != null ? providerRangeFor(activeProvider, nextRange, nextProviderAnchor, nextProviderFocus) : null;
+      if (activeProvider?.getVisibleSpans && providerRange) {
+        spans = activeProvider.getVisibleSpans(providerRange, nextRange);
+      } else {
+        spans = terminalSelectionRowSpans(nextRange, size.cols, size.rows);
+      }
       hasRange = spans.length > 0 || providerPointsDiffer(nextProviderAnchor, nextProviderFocus);
       for (const span of spans) {
-        const row = options.terminal.getRow(span.y);
-        const cells = [];
-        for (let x = span.x0; x < span.x1; x++) {
-          const cell = row[x];
-          if (!cell || cell.continuation) continue;
-          const { href: _href, ...baseStyle } = cell.style;
-          cells.push({
-            x,
-            ch: cell.ch || " ",
-            style: { ...baseStyle, ...selectionStyle }
-          });
+        const x0 = Math.max(0, Math.min(size.cols, Math.floor(span.x0)));
+        const x1 = Math.max(0, Math.min(size.cols, Math.floor(span.x1)));
+        const y = Math.floor(span.y);
+        if (y < 0 || y >= size.rows || x1 <= x0) continue;
+        let list = nextOverlaySpans.get(y);
+        if (!list) {
+          list = [];
+          nextOverlaySpans.set(y, list);
         }
-        nextOverlayRows.set(span.y, cells);
-        nextDirtyRows.add(span.y);
+        list.push({ y, x0, x1 });
+        nextDirtyRows.add(y);
       }
     }
     range = nextRange;
     providerAnchor = nextProviderAnchor;
     providerFocus = nextProviderFocus;
-    overlayRows = nextOverlayRows;
+    overlaySpans = nextOverlaySpans;
     dirtyRows = nextDirtyRows;
     state.value = nextRange ? {
       active: true,
@@ -13448,22 +13500,24 @@ function createTerminalSelectionController(options) {
       const anchor = startOptions?.extend && range?.anchor ? clampPoint(range.anchor, size.cols, size.rows) : focus;
       const anchorProvider = providerForCell(anchor);
       const focusProvider = providerForCell(focus);
+      const activeProvider = startOptions?.extend && providerAnchor ? providerById(providerAnchor.providerId) : null;
       const nextProviderAnchor = startOptions?.extend && providerAnchor ? providerAnchor : anchorProvider ? providerPointForCell(anchorProvider, anchor) : null;
-      const nextProviderFocus = nextProviderAnchor && focusProvider?.id === nextProviderAnchor.providerId ? providerPointForCell(focusProvider, focus) : null;
+      const nextProviderFocus = activeProvider ? providerPointForCell(activeProvider, focus, { clampToRect: true }) : nextProviderAnchor && focusProvider?.id === nextProviderAnchor.providerId ? providerPointForCell(focusProvider, focus) : null;
       rebuild({ anchor, focus, mode: "linear" }, nextProviderAnchor, nextProviderFocus);
     },
     update(point) {
       if (!range) return;
       const size = options.terminal.size();
       const focus = clampPoint(point, size.cols, size.rows);
-      const focusProvider = providerAnchor ? providerById(providerAnchor.providerId) : null;
+      const activeProvider = providerAnchor ? providerById(providerAnchor.providerId) : null;
+      const nextProviderFocus = activeProvider ? providerPointForCell(activeProvider, focus, { clampToRect: true }) : null;
       rebuild(
         {
           ...range,
           focus
         },
         providerAnchor,
-        focusProvider ? providerPointForCell(focusProvider, focus) : null
+        nextProviderFocus
       );
     },
     async finish() {
@@ -13499,11 +13553,38 @@ function createTerminalSelectionController(options) {
       }
     },
     paint(dirtyRowsHint) {
-      const rows2 = dirtyRowsHint ?? Array.from(overlayRows.keys());
+      const rows2 = dirtyRowsHint ?? Array.from(overlaySpans.keys());
+      const selectionStyle = readOptions().style;
       for (const y of rows2) {
-        const cells = overlayRows.get(y);
-        if (!cells) continue;
-        for (const cell of cells) options.overlayTerminal.put(cell.x, y, cell.ch, cell.style);
+        const spans = overlaySpans.get(y);
+        if (!spans?.length) continue;
+        const row = options.terminal.getRow(y);
+        for (const span of spans) {
+          for (let x = span.x0; x < span.x1; x++) {
+            const cell = row[x];
+            if (!cell || cell.continuation) continue;
+            const { href: _href, ...baseStyle } = cell.style;
+            options.overlayTerminal.put(x, y, cell.ch || " ", {
+              ...baseStyle,
+              ...selectionStyle
+            });
+          }
+        }
+      }
+    },
+    refresh(refreshOptions) {
+      if (!range) return;
+      if (refreshOptions?.remapFocus) {
+        const activeProvider = providerAnchor ? providerById(providerAnchor.providerId) : resolveProvider(range, null);
+        const nextProviderFocus = activeProvider ? providerPointForCell(activeProvider, range.focus, { clampToRect: true }) : providerFocus;
+        rebuild(range, providerAnchor, nextProviderFocus);
+        return;
+      }
+      rebuild(range, providerAnchor, providerFocus);
+    },
+    clearProvider(providerId) {
+      if (providerAnchor?.providerId === providerId || providerFocus?.providerId === providerId) {
+        controller.clear();
       }
     }
   };
@@ -15097,6 +15178,8 @@ function createSchedulerFrameTasks(options) {
 }
 let portalId = 0;
 const SUPPRESS_TERMINAL_POINTER_UP = "__vueTuiSuppressTerminalPointerUp";
+const SUPPRESS_TERMINAL_POINTER_DOWN = "__vueTuiSuppressTerminalPointerDown";
+const SUPPRESS_TERMINAL_POINTER_MOVE = "__vueTuiSuppressTerminalPointerMove";
 function resolveSelectionConfig(config) {
   if (config == null || config === false) {
     return {
@@ -15222,6 +15305,12 @@ function createTerminalApp(options) {
     if (pendingInvalidateAllPlanes) return;
     pendingInvalidatePlanes.add(plane);
   }
+  const sortRenderPlanes = (planes) => {
+    const order = new Map(
+      TERMINAL_RENDER_PLANES.map((plane, index) => [plane, index])
+    );
+    return [...planes].sort((a, b) => (order.get(a) ?? 999) - (order.get(b) ?? 999));
+  };
   function takeActivePlanes() {
     if (pendingInvalidateAllPlanes) {
       pendingInvalidateAllPlanes = false;
@@ -15229,7 +15318,7 @@ function createTerminalApp(options) {
       return null;
     }
     if (pendingInvalidatePlanes.size === 0) return null;
-    const activePlanes = Array.from(pendingInvalidatePlanes);
+    const activePlanes = sortRenderPlanes(Array.from(pendingInvalidatePlanes));
     pendingInvalidatePlanes.clear();
     return activePlanes;
   }
@@ -15470,13 +15559,20 @@ function createTerminalApp(options) {
     registerTextProvider(provider) {
       selectionTextProviders.set(provider.id, provider);
       return () => {
-        if (selectionTextProviders.get(provider.id) === provider)
-          selectionTextProviders.delete(provider.id);
+        if (selectionTextProviders.get(provider.id) !== provider) return;
+        selectionTextProviders.delete(provider.id);
+        selection.clearProvider(provider.id);
       };
     },
     onCopy(handler) {
       selectionCopyHandlers.add(handler);
       return () => selectionCopyHandlers.delete(handler);
+    },
+    refresh(options2) {
+      selection.refresh(options2);
+    },
+    clear() {
+      selection.clear();
     }
   };
   const selectionOverlay = getPlaneTerminal(terminal, "overlay");
@@ -15534,6 +15630,18 @@ function createTerminalApp(options) {
   let selectionAutoScrollTimer = null;
   let selectionDragStarted = false;
   let suppressNextSelectionClick = false;
+  const resetSelectionGesture = (options2) => {
+    selecting = false;
+    selectionStartPoint = null;
+    selectionScrollOrigin = null;
+    selectionLastPoint = null;
+    selectionDragStarted = false;
+    suppressNextSelectionClick = false;
+    clearSelectionAutoScroll();
+    {
+      selection.clear();
+    }
+  };
   const clearSelectionAutoScroll = () => {
     if (selectionAutoScrollTimer == null) return;
     clearTimeout(selectionAutoScrollTimer);
@@ -15562,8 +15670,8 @@ function createTerminalApp(options) {
   });
   const dispatchWithSelection = (event) => {
     if (!selectionEnabled()) return baseEvents.dispatch(event);
-    if (event.type === "keydown" && event.key === "Escape" && selection.state.value.active) {
-      selection.clear();
+    if (event.type === "keydown" && event.key === "Escape" && (selecting || selection.state.value.active)) {
+      resetSelectionGesture();
       return true;
     }
     if (event.type === "click" || event.type === "dblclick" || event.type === "contextmenu") {
@@ -15583,6 +15691,9 @@ function createTerminalApp(options) {
           selectionScrollOrigin = point;
           selectionLastPoint = point;
           scheduleSelectionAutoScroll();
+          event[SUPPRESS_TERMINAL_POINTER_DOWN] = true;
+          baseEvents.dispatch(event);
+          return true;
         }
       }
       return baseEvents.dispatch(event);
@@ -15595,7 +15706,9 @@ function createTerminalApp(options) {
       }
       selection.update(point);
       scheduleSelectionAutoScroll();
-      return baseEvents.dispatch(event);
+      event[SUPPRESS_TERMINAL_POINTER_MOVE] = true;
+      baseEvents.dispatch(event);
+      return true;
     }
     if (event.type === "pointerup" && selecting) {
       const point = eventPoint(event);

--- a/examples/basic/dist-terminal-multi-select/terminal.js
+++ b/examples/basic/dist-terminal-multi-select/terminal.js
@@ -1,1 +1,1 @@
-import "./terminal-multi-select-D18FBSN7.js";
+import "./terminal-multi-select-qND_iMwz.js";

--- a/scripts/generate-component-api-docs.ts
+++ b/scripts/generate-component-api-docs.ts
@@ -66,7 +66,10 @@ function formatMaybeCode(text: string | null): string {
   // Markdown tables split columns by `|` even inside inline code spans.
   // Use HTML <code> + entity to keep union types/payloads (A | B) intact.
   // oxfmt escapes underscores in markdown files, so match that behavior to avoid format/diff conflicts.
-  const escaped = escapeHtml(text).replaceAll("\n", "<br>").replaceAll("|", "&#124;").replaceAll("_", "\\_");
+  const escaped = escapeHtml(text)
+    .replaceAll("\n", "<br>")
+    .replaceAll("|", "&#124;")
+    .replaceAll("_", "\\_");
   return `<code>${escaped}</code>`;
 }
 

--- a/scripts/generate-component-api-docs.ts
+++ b/scripts/generate-component-api-docs.ts
@@ -65,7 +65,8 @@ function formatMaybeCode(text: string | null): string {
   if (!text) return "—";
   // Markdown tables split columns by `|` even inside inline code spans.
   // Use HTML <code> + entity to keep union types/payloads (A | B) intact.
-  const escaped = escapeHtml(text).replaceAll("\n", "<br>").replaceAll("|", "&#124;");
+  // oxfmt escapes underscores in markdown files, so match that behavior to avoid format/diff conflicts.
+  const escaped = escapeHtml(text).replaceAll("\n", "<br>").replaceAll("|", "&#124;").replaceAll("_", "\\_");
   return `<code>${escaped}</code>`;
 }
 

--- a/src/create-terminal-app.ts
+++ b/src/create-terminal-app.ts
@@ -68,6 +68,8 @@ interface Portal {
 
 let portalId = 0;
 const SUPPRESS_TERMINAL_POINTER_UP = "__vueTuiSuppressTerminalPointerUp";
+const SUPPRESS_TERMINAL_POINTER_DOWN = "__vueTuiSuppressTerminalPointerDown";
+const SUPPRESS_TERMINAL_POINTER_MOVE = "__vueTuiSuppressTerminalPointerMove";
 
 type ResolvedTerminalSelectionConfig = Readonly<{
   enabled: boolean;
@@ -667,7 +669,11 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
           selectionLastPoint = point;
           scheduleSelectionAutoScroll();
 
-          // selection owns this gesture; do not dispatch pointerdown to the node
+          // Set suppress flag and dispatch so the CLI event manager's
+          // suppressed path still resolves focus/capture for parity
+          // with the DOM event manager.
+          (event as any)[SUPPRESS_TERMINAL_POINTER_DOWN] = true;
+          baseEvents.dispatch(event);
           return true;
         }
       }
@@ -685,7 +691,11 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
       }
       selection.update(point);
       scheduleSelectionAutoScroll();
-      // selection owns this gesture; do not dispatch pointermove to the node
+      // Set suppress flag and dispatch so the CLI event manager's
+      // suppressed path still updates hover state for parity with
+      // the DOM event manager.
+      (event as any)[SUPPRESS_TERMINAL_POINTER_MOVE] = true;
+      baseEvents.dispatch(event);
       return true;
     }
 

--- a/src/create-terminal-app.ts
+++ b/src/create-terminal-app.ts
@@ -666,6 +666,9 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
           selectionScrollOrigin = point;
           selectionLastPoint = point;
           scheduleSelectionAutoScroll();
+
+          // selection owns this gesture; do not dispatch pointerdown to the node
+          return true;
         }
       }
       return baseEvents.dispatch(event);
@@ -682,7 +685,8 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
       }
       selection.update(point);
       scheduleSelectionAutoScroll();
-      return baseEvents.dispatch(event);
+      // selection owns this gesture; do not dispatch pointermove to the node
+      return true;
     }
 
     if (event.type === "pointerup" && selecting) {

--- a/src/create-terminal-app.ts
+++ b/src/create-terminal-app.ts
@@ -58,6 +58,11 @@ import {
   type SchedulerFrameTaskRunStats,
   createSchedulerFrameTasks,
 } from "./vue/scheduler/frame-scheduler.js";
+import {
+  SUPPRESS_TERMINAL_POINTER_DOWN,
+  SUPPRESS_TERMINAL_POINTER_MOVE,
+  SUPPRESS_TERMINAL_POINTER_UP,
+} from "./events/manager/selection-suppression.js";
 
 interface Portal {
   id: string;
@@ -67,9 +72,6 @@ interface Portal {
 }
 
 let portalId = 0;
-const SUPPRESS_TERMINAL_POINTER_UP = "__vueTuiSuppressTerminalPointerUp";
-const SUPPRESS_TERMINAL_POINTER_DOWN = "__vueTuiSuppressTerminalPointerDown";
-const SUPPRESS_TERMINAL_POINTER_MOVE = "__vueTuiSuppressTerminalPointerMove";
 
 type ResolvedTerminalSelectionConfig = Readonly<{
   enabled: boolean;

--- a/src/create-terminal-app.ts
+++ b/src/create-terminal-app.ts
@@ -9,6 +9,7 @@ import type {
   SelectionTextProvider,
   TerminalSelectionConfig,
   TerminalSelectionCopyPayload,
+  TerminalSelectionRefreshOptions,
 } from "./selection/terminal-selection.js";
 import type { TInputPlugin } from "./vue/components/input/plugins/types.js";
 
@@ -544,8 +545,8 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
       selectionCopyHandlers.add(handler);
       return () => selectionCopyHandlers.delete(handler);
     },
-    refresh() {
-      selection.refresh();
+    refresh(options) {
+      selection.refresh(options);
     },
     clear() {
       selection.clear();

--- a/src/create-terminal-app.ts
+++ b/src/create-terminal-app.ts
@@ -9,7 +9,6 @@ import type {
   SelectionTextProvider,
   TerminalSelectionConfig,
   TerminalSelectionCopyPayload,
-  TerminalSelectionRefreshOptions,
 } from "./selection/terminal-selection.js";
 import type { TInputPlugin } from "./vue/components/input/plugins/types.js";
 
@@ -661,7 +660,11 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
   const dispatchWithSelection = (event: TerminalEventRecord): boolean => {
     if (!selectionEnabled()) return baseEvents.dispatch(event);
 
-    if (event.type === "keydown" && event.key === "Escape" && (selecting || selection.state.value.active)) {
+    if (
+      event.type === "keydown" &&
+      event.key === "Escape" &&
+      (selecting || selection.state.value.active)
+    ) {
       resetSelectionGesture({ clearSelection: true });
       return true;
     }

--- a/src/create-terminal-app.ts
+++ b/src/create-terminal-app.ts
@@ -1,5 +1,6 @@
 import type { App, Component, Ref } from "vue";
 import type { PathPickerProvider } from "./cli/path-provider.js";
+import { TERMINAL_RENDER_PLANES } from "./core/render-plane.js";
 import type { TerminalRenderPlane, TerminalRenderPlanes } from "./core/render-plane.js";
 import type { Style, Terminal } from "./core/types.js";
 import type { CliEventManager, TerminalEventRecord } from "./events/index.js";
@@ -234,6 +235,13 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
     pendingInvalidatePlanes.add(plane);
   }
 
+  const sortRenderPlanes = (planes: TerminalRenderPlanes): TerminalRenderPlanes => {
+    const order = new Map<TerminalRenderPlane, number>(
+      TERMINAL_RENDER_PLANES.map((plane, index) => [plane, index]),
+    );
+    return [...planes].sort((a, b) => (order.get(a) ?? 999) - (order.get(b) ?? 999));
+  };
+
   function takeActivePlanes(): TerminalRenderPlanes | null {
     if (pendingInvalidateAllPlanes) {
       pendingInvalidateAllPlanes = false;
@@ -241,7 +249,7 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
       return null;
     }
     if (pendingInvalidatePlanes.size === 0) return null;
-    const activePlanes = Array.from(pendingInvalidatePlanes);
+    const activePlanes = sortRenderPlanes(Array.from(pendingInvalidatePlanes));
     pendingInvalidatePlanes.clear();
     return activePlanes;
   }

--- a/src/create-terminal-app.ts
+++ b/src/create-terminal-app.ts
@@ -536,6 +536,12 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
       selectionCopyHandlers.add(handler);
       return () => selectionCopyHandlers.delete(handler);
     },
+    refresh() {
+      selection.refresh();
+    },
+    clear() {
+      selection.clear();
+    },
   } as const;
   const selectionOverlay = getPlaneTerminal(terminal, "overlay");
   let selectionRenderNodeId: string | null = null;

--- a/src/create-terminal-app.ts
+++ b/src/create-terminal-app.ts
@@ -612,6 +612,20 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
   let selectionDragStarted = false;
   let suppressNextSelectionClick = false;
 
+  const resetSelectionGesture = (options?: { clearSelection?: boolean }): void => {
+    selecting = false;
+    selectionStartPoint = null;
+    selectionScrollOrigin = null;
+    selectionLastPoint = null;
+    selectionDragStarted = false;
+    suppressNextSelectionClick = false;
+    clearSelectionAutoScroll();
+
+    if (options?.clearSelection ?? true) {
+      selection.clear();
+    }
+  };
+
   const clearSelectionAutoScroll = () => {
     if (selectionAutoScrollTimer == null) return;
     clearTimeout(selectionAutoScrollTimer);
@@ -645,8 +659,8 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
   const dispatchWithSelection = (event: TerminalEventRecord): boolean => {
     if (!selectionEnabled()) return baseEvents.dispatch(event);
 
-    if (event.type === "keydown" && event.key === "Escape" && selection.state.value.active) {
-      selection.clear();
+    if (event.type === "keydown" && event.key === "Escape" && (selecting || selection.state.value.active)) {
+      resetSelectionGesture({ clearSelection: true });
       return true;
     }
 

--- a/src/create-terminal-app.ts
+++ b/src/create-terminal-app.ts
@@ -537,8 +537,9 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
     registerTextProvider(provider: SelectionTextProvider) {
       selectionTextProviders.set(provider.id, provider);
       return () => {
-        if (selectionTextProviders.get(provider.id) === provider)
-          selectionTextProviders.delete(provider.id);
+        if (selectionTextProviders.get(provider.id) !== provider) return;
+        selectionTextProviders.delete(provider.id);
+        selection.clearProvider(provider.id);
       };
     },
     onCopy(handler: (payload: TerminalSelectionCopyPayload) => void) {

--- a/src/events/manager/cli-event-manager.ts
+++ b/src/events/manager/cli-event-manager.ts
@@ -68,6 +68,8 @@ export interface CliEventManager {
 }
 
 const SUPPRESS_TERMINAL_POINTER_UP = "__vueTuiSuppressTerminalPointerUp";
+const SUPPRESS_TERMINAL_POINTER_DOWN = "__vueTuiSuppressTerminalPointerDown";
+const SUPPRESS_TERMINAL_POINTER_MOVE = "__vueTuiSuppressTerminalPointerMove";
 
 let nextId = 0;
 
@@ -653,6 +655,15 @@ export function createCliEventManager(
           if (event.type === "pointerdown") {
             const list = candidatesAt(event.cellX, event.cellY);
             const target = pickTarget(list);
+            // When selection owns the gesture, still resolve focus/capture
+            // for parity with the DOM event manager's suppressed path,
+            // but skip dispatching the pointerdown event to the node.
+            if ((event as any)[SUPPRESS_TERMINAL_POINTER_DOWN]) {
+              if (target?.focusable) setFocus(target.id);
+              capturedId = target?.id ?? null;
+              updateHover(target, event);
+              return true;
+            }
             if (target?.focusable) setFocus(target.id);
             capturedId = target?.id ?? null;
             updateHover(target, event);
@@ -661,6 +672,11 @@ export function createCliEventManager(
           }
 
           if (event.type === "pointermove" && capturedId) {
+            if ((event as any)[SUPPRESS_TERMINAL_POINTER_MOVE]) {
+              const target = nodes.get(capturedId) ?? null;
+              if (target) updateHover(target, event);
+              return true;
+            }
             const target = nodes.get(capturedId) ?? null;
             if (!target) return prevented;
             updateHover(target, event);
@@ -672,6 +688,9 @@ export function createCliEventManager(
           }
 
           if (event.type === "pointermove") {
+            if ((event as any)[SUPPRESS_TERMINAL_POINTER_MOVE]) {
+              return true;
+            }
             const list = candidatesAt(event.cellX, event.cellY);
             const target = pickTarget(list);
             updateHover(target, event);

--- a/src/events/manager/cli-event-manager.ts
+++ b/src/events/manager/cli-event-manager.ts
@@ -13,6 +13,11 @@ import type {
 import { appendFileSync } from "node:fs";
 import process from "node:process";
 import { getCliLatencyProfiler } from "../../observability/cli-latency.js";
+import {
+  SUPPRESS_TERMINAL_POINTER_DOWN,
+  SUPPRESS_TERMINAL_POINTER_MOVE,
+  SUPPRESS_TERMINAL_POINTER_UP,
+} from "./selection-suppression.js";
 
 function contains(rect: Rect, x: number, y: number): boolean {
   return x >= rect.x && y >= rect.y && x < rect.x + rect.w && y < rect.y + rect.h;
@@ -66,10 +71,6 @@ export interface CliEventManager {
   debugNodes: () => TerminalDebugNode[];
   dispose: () => void;
 }
-
-const SUPPRESS_TERMINAL_POINTER_UP = "__vueTuiSuppressTerminalPointerUp";
-const SUPPRESS_TERMINAL_POINTER_DOWN = "__vueTuiSuppressTerminalPointerDown";
-const SUPPRESS_TERMINAL_POINTER_MOVE = "__vueTuiSuppressTerminalPointerMove";
 
 let nextId = 0;
 

--- a/src/events/manager/event-manager.ts
+++ b/src/events/manager/event-manager.ts
@@ -78,6 +78,12 @@ export function createEventManager(
     textInputTarget?: HTMLElement | null;
     debugIme?: boolean;
     onFocusChange?: (prev: string | null, next: string | null) => void;
+    /**
+     * When true, native DOM listeners are not attached until manager.attach()
+     * is called explicitly. Used by TerminalProvider so selection capture
+     * listeners can be registered first.
+     */
+    deferAttach?: boolean;
   }>,
 ): EventManager {
   let currentMetrics = metrics;
@@ -1257,6 +1263,10 @@ export function createEventManager(
       passive: true,
     });
     window.addEventListener("resize", markContainerRectDirty, { passive: true });
+  }
+
+  if (!options?.deferAttach) {
+    attach();
   }
 
   return {

--- a/src/events/manager/event-manager.ts
+++ b/src/events/manager/event-manager.ts
@@ -41,6 +41,8 @@ function now(): number {
 }
 
 const SUPPRESS_TERMINAL_POINTER_UP = "__vueTuiSuppressTerminalPointerUp";
+const SUPPRESS_TERMINAL_POINTER_DOWN = "__vueTuiSuppressTerminalPointerDown";
+const SUPPRESS_TERMINAL_POINTER_MOVE = "__vueTuiSuppressTerminalPointerMove";
 
 type RowRange = Readonly<{ y0: number; y1: number }>;
 
@@ -588,6 +590,51 @@ export function createEventManager(
   }
 
   function onPointerDown(e: PointerEvent): void {
+    if ((e as any)[SUPPRESS_TERMINAL_POINTER_DOWN]) {
+      // Keep IME focus working even when selection suppresses the gesture.
+      if (textInputTarget && !container.contains(textInputTarget)) {
+        try {
+          (textInputTarget as any).focus?.({ preventScroll: true });
+        } catch {
+          textInputTarget.focus?.();
+        }
+      } else {
+        try {
+          (container as any).focus?.({ preventScroll: true });
+        } catch {
+          container.focus?.();
+        }
+      }
+      // Still resolve the target and set focus/capture so that component
+      // activation (e.g. TVirtualList focus) works during selection.
+      const { cellX, cellY } = toCell(e.clientX, e.clientY);
+      const list = candidatesAt(cellX, cellY);
+      const target = pickTarget(list);
+      const allowSelection = target ? (target.selectable ?? !target.focusable) : true;
+      container.style.userSelect = allowSelection ? defaultUserSelect : "none";
+      if (target) {
+        if (target.focusable) {
+          setFocus(target.id);
+        }
+      }
+      capturedId = target?.id ?? null;
+      updateHover(target, e);
+      record?.({
+        type: "pointerdown",
+        cellX,
+        cellY,
+        clientX: e.clientX,
+        clientY: e.clientY,
+        button: e.button,
+        buttons: e.buttons,
+        ctrlKey: e.ctrlKey,
+        shiftKey: e.shiftKey,
+        altKey: e.altKey,
+        metaKey: e.metaKey,
+      });
+      // Skip the terminal pointerdown event dispatch to the node.
+      return;
+    }
     // Keep an actual text input focused so browsers can start IME/composition.
     // (The terminal container itself isn't an editable element.)
     if (textInputTarget && !container.contains(textInputTarget)) {
@@ -683,6 +730,9 @@ export function createEventManager(
   }
 
   function onPointerMove(e: PointerEvent): void {
+    if ((e as any)[SUPPRESS_TERMINAL_POINTER_MOVE]) {
+      return;
+    }
     lastPointerMoveEvent = e;
     const { cellX, cellY } = toCell(e.clientX, e.clientY);
     record?.({

--- a/src/events/manager/event-manager.ts
+++ b/src/events/manager/event-manager.ts
@@ -10,6 +10,11 @@ import type {
   TerminalNode,
   TerminalPointerEvent,
 } from "./types.js";
+import {
+  SUPPRESS_TERMINAL_POINTER_DOWN,
+  SUPPRESS_TERMINAL_POINTER_MOVE,
+  SUPPRESS_TERMINAL_POINTER_UP,
+} from "./selection-suppression.js";
 
 function contains(rect: Rect, x: number, y: number): boolean {
   return x >= rect.x && y >= rect.y && x < rect.x + rect.w && y < rect.y + rect.h;
@@ -39,10 +44,6 @@ function sameRect(a: Rect, b: Rect): boolean {
 function now(): number {
   return typeof performance !== "undefined" ? performance.now() : Date.now();
 }
-
-const SUPPRESS_TERMINAL_POINTER_UP = "__vueTuiSuppressTerminalPointerUp";
-const SUPPRESS_TERMINAL_POINTER_DOWN = "__vueTuiSuppressTerminalPointerDown";
-const SUPPRESS_TERMINAL_POINTER_MOVE = "__vueTuiSuppressTerminalPointerMove";
 
 type RowRange = Readonly<{ y0: number; y1: number }>;
 

--- a/src/events/manager/event-manager.ts
+++ b/src/events/manager/event-manager.ts
@@ -617,13 +617,14 @@ export function createEventManager(
       const { cellX, cellY } = toCell(e.clientX, e.clientY);
       const list = candidatesAt(cellX, cellY);
       const target = pickTarget(list);
-      const allowSelection = target ? (target.selectable ?? !target.focusable) : true;
-      container.style.userSelect = allowSelection ? defaultUserSelect : "none";
-      if (target) {
-        if (target.focusable) {
-          setFocus(target.id);
-        }
+
+      // Important: do not touch container.style.userSelect here.
+      // Selection layer owns userSelect for suppressed gestures.
+
+      if (target?.focusable) {
+        setFocus(target.id);
       }
+
       capturedId = target?.id ?? null;
       updateHover(target, e);
       record?.({

--- a/src/events/manager/event-manager.ts
+++ b/src/events/manager/event-manager.ts
@@ -64,6 +64,7 @@ export interface EventManager {
   focus: (id: string | null) => void;
   getFocused: () => string | null;
   debugNodes: () => TerminalDebugNode[];
+  attach: () => void;
   dispose: () => void;
 }
 
@@ -1218,38 +1219,45 @@ export function createEventManager(
     keyboardTargets.push(textInputTarget);
   }
 
-  container.addEventListener("pointerdown", onPointerDown);
-  container.addEventListener("pointermove", onPointerMove);
-  container.addEventListener("pointerup", onPointerUp);
-  container.addEventListener("mousedown", onMouseDown);
-  container.addEventListener("mousemove", onMouseMove);
-  container.addEventListener("mouseup", onMouseUp);
-  container.addEventListener("mouseleave", onMouseLeave);
-  container.addEventListener("click", onClick);
-  container.addEventListener("dblclick", onDblClick);
-  container.addEventListener("contextmenu", onContextMenu);
-  container.addEventListener("wheel", onWheel, { passive: false });
-  container.addEventListener("dragover", onDragOver);
-  container.addEventListener("drop", onDrop);
-  for (const target of keyboardTargets) {
-    target.addEventListener("keydown", onKeyDown);
-    target.addEventListener("keyup", onKeyUp);
-  }
+  let attached = false;
 
-  for (const target of textTargets) {
-    target.addEventListener("beforeinput", onBeforeInput as any);
-    target.addEventListener("input", onInput as any);
-    target.addEventListener("compositionstart", onCompositionStart as any);
-    target.addEventListener("compositionupdate", onCompositionUpdate as any);
-    target.addEventListener("compositionend", onCompositionEnd as any);
-    target.addEventListener("paste", onPaste as any);
-  }
+  function attach(): void {
+    if (attached) return;
+    attached = true;
 
-  window.addEventListener("scroll", markContainerRectDirty, {
-    capture: true,
-    passive: true,
-  });
-  window.addEventListener("resize", markContainerRectDirty, { passive: true });
+    container.addEventListener("pointerdown", onPointerDown);
+    container.addEventListener("pointermove", onPointerMove);
+    container.addEventListener("pointerup", onPointerUp);
+    container.addEventListener("mousedown", onMouseDown);
+    container.addEventListener("mousemove", onMouseMove);
+    container.addEventListener("mouseup", onMouseUp);
+    container.addEventListener("mouseleave", onMouseLeave);
+    container.addEventListener("click", onClick);
+    container.addEventListener("dblclick", onDblClick);
+    container.addEventListener("contextmenu", onContextMenu);
+    container.addEventListener("wheel", onWheel, { passive: false });
+    container.addEventListener("dragover", onDragOver);
+    container.addEventListener("drop", onDrop);
+    for (const target of keyboardTargets) {
+      target.addEventListener("keydown", onKeyDown);
+      target.addEventListener("keyup", onKeyUp);
+    }
+
+    for (const target of textTargets) {
+      target.addEventListener("beforeinput", onBeforeInput as any);
+      target.addEventListener("input", onInput as any);
+      target.addEventListener("compositionstart", onCompositionStart as any);
+      target.addEventListener("compositionupdate", onCompositionUpdate as any);
+      target.addEventListener("compositionend", onCompositionEnd as any);
+      target.addEventListener("paste", onPaste as any);
+    }
+
+    window.addEventListener("scroll", markContainerRectDirty, {
+      capture: true,
+      passive: true,
+    });
+    window.addEventListener("resize", markContainerRectDirty, { passive: true });
+  }
 
   return {
     register(node) {
@@ -1351,9 +1359,12 @@ export function createEventManager(
         focusable: Boolean(n.focusable),
       }));
     },
+    attach,
     dispose() {
       window.removeEventListener("scroll", markContainerRectDirty, true);
       window.removeEventListener("resize", markContainerRectDirty);
+      if (!attached) return;
+      attached = false;
       container.removeEventListener("pointerdown", onPointerDown);
       container.removeEventListener("pointermove", onPointerMove);
       container.removeEventListener("pointerup", onPointerUp);

--- a/src/events/manager/selection-suppression.ts
+++ b/src/events/manager/selection-suppression.ts
@@ -1,0 +1,3 @@
+export const SUPPRESS_TERMINAL_POINTER_UP = "__vueTuiSuppressTerminalPointerUp";
+export const SUPPRESS_TERMINAL_POINTER_DOWN = "__vueTuiSuppressTerminalPointerDown";
+export const SUPPRESS_TERMINAL_POINTER_MOVE = "__vueTuiSuppressTerminalPointerMove";

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,6 +130,7 @@ export type {
   TerminalSelectionOptions,
   TerminalSelectionPoint,
   TerminalSelectionRange,
+  TerminalSelectionRefreshOptions,
   TerminalSelectionState,
 } from "./selection/terminal-selection.js";
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,6 +138,7 @@ export type {
 export {
   createTerminalSelectionController,
   terminalSelectionRowSpans,
+  terminalSelectionVisibleRowSpans,
 } from "./selection/terminal-selection.js";
 export type {
   TerminalProviderSelectionConfig,

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,9 @@ export type {
   TerminalSelectionRange,
   TerminalSelectionState,
 } from "./selection/terminal-selection.js";
+export type {
+  SelectedRowSpan,
+} from "./selection/terminal-selection.js";
 export {
   createTerminalSelectionController,
   terminalSelectionRowSpans,

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,9 +133,7 @@ export type {
   TerminalSelectionRefreshOptions,
   TerminalSelectionState,
 } from "./selection/terminal-selection.js";
-export type {
-  SelectedRowSpan,
-} from "./selection/terminal-selection.js";
+export type { SelectedRowSpan } from "./selection/terminal-selection.js";
 export {
   createTerminalSelectionController,
   terminalSelectionRowSpans,

--- a/src/selection/terminal-selection.ts
+++ b/src/selection/terminal-selection.ts
@@ -102,12 +102,6 @@ export type TerminalSelectionController = Readonly<{
   refresh: () => void;
 }>;
 
-type SelectionCell = Readonly<{
-  x: number;
-  ch: string;
-  style: Style;
-}>;
-
 type ProviderSelectionPoint = Readonly<{
   providerId: string;
   point: TerminalSelectionPoint;
@@ -253,7 +247,7 @@ export function createTerminalSelectionController(
   let range: TerminalSelectionRange | null = null;
   let providerAnchor: ProviderSelectionPoint | null = null;
   let providerFocus: ProviderSelectionPoint | null = null;
-  let overlayRows = new Map<number, readonly SelectionCell[]>();
+  let overlaySpans = new Map<number, SelectedRowSpan[]>();
   let dirtyRows = new Set<number>();
 
   const readOptions = (): ResolvedSelectionOptions => ({
@@ -317,21 +311,55 @@ export function createTerminalSelectionController(
     return lines.join("\n");
   };
 
+  const providerRangeFor = (
+    provider: SelectionTextProvider,
+    screenRange: TerminalSelectionRange,
+    anchorOverride?: ProviderSelectionPoint | null,
+    focusOverride?: ProviderSelectionPoint | null,
+  ): TerminalSelectionRange | null => {
+    if (
+      anchorOverride &&
+      focusOverride &&
+      anchorOverride.providerId === provider.id &&
+      focusOverride.providerId === provider.id
+    ) {
+      return {
+        anchor: anchorOverride.point,
+        focus: focusOverride.point,
+        mode: screenRange.mode,
+      };
+    }
+
+    const anchor = providerPointForCell(provider, screenRange.anchor, { clampToRect: true });
+    const focus = providerPointForCell(provider, screenRange.focus, { clampToRect: true });
+
+    if (!anchor || !focus) return null;
+    if (anchor.providerId !== provider.id || focus.providerId !== provider.id) return null;
+
+    return {
+      anchor: anchor.point,
+      focus: focus.point,
+      mode: screenRange.mode,
+    };
+  };
+
   const selectedText = (): string => {
     if (!range) return "";
+
     if (providerAnchor && providerFocus && providerAnchor.providerId === providerFocus.providerId) {
       const provider = providerById(providerAnchor.providerId);
       if (provider) {
-        return provider.getText({
-          anchor: providerAnchor.point,
-          focus: providerFocus.point,
-          mode: range.mode,
-        });
+        const providerRange = providerRangeFor(provider, range, providerAnchor, providerFocus);
+        if (providerRange) return provider.getText(providerRange);
       }
     }
 
     const provider = providers().find((candidate) => candidate.canHandle(range));
-    if (provider) return provider.getText(range);
+    if (provider) {
+      const providerRange = providerRangeFor(provider, range);
+      if (providerRange) return provider.getText(providerRange);
+    }
+
     return textFromTerminalBuffer(range);
   };
 
@@ -359,54 +387,47 @@ export function createTerminalSelectionController(
   ): void => {
     const previousRows = dirtyRows;
     const size = options.terminal.size();
-    const nextOverlayRows = new Map<number, readonly SelectionCell[]>();
+    const nextOverlaySpans = new Map<number, SelectedRowSpan[]>();
     const nextDirtyRows = new Set<number>();
     let hasRange = false;
 
     if (nextRange) {
-      const selectionStyle = readOptions().style;
       const activeProvider = resolveProvider(nextRange, nextProviderAnchor);
       let spans: readonly SelectedRowSpan[];
 
-      if (
-        activeProvider?.getVisibleSpans &&
-        nextProviderAnchor &&
-        nextProviderFocus &&
-        nextProviderAnchor.providerId === nextProviderFocus.providerId
-      ) {
-        const providerRange: TerminalSelectionRange = {
-          anchor: nextProviderAnchor.point,
-          focus: nextProviderFocus.point,
-          mode: nextRange.mode,
-        };
+      const providerRange =
+        activeProvider != null
+          ? providerRangeFor(activeProvider, nextRange, nextProviderAnchor, nextProviderFocus)
+          : null;
+
+      if (activeProvider?.getVisibleSpans && providerRange) {
         spans = activeProvider.getVisibleSpans(providerRange, nextRange);
       } else {
         spans = terminalSelectionRowSpans(nextRange, size.cols, size.rows);
       }
 
       hasRange = spans.length > 0 || providerPointsDiffer(nextProviderAnchor, nextProviderFocus);
+
       for (const span of spans) {
-        const row = options.terminal.getRow(span.y);
-        const cells: SelectionCell[] = [];
-        for (let x = span.x0; x < span.x1; x++) {
-          const cell = row[x];
-          if (!cell || cell.continuation) continue;
-          const { href: _href, ...baseStyle } = cell.style;
-          cells.push({
-            x,
-            ch: cell.ch || " ",
-            style: { ...baseStyle, ...selectionStyle },
-          });
+        const x0 = Math.max(0, Math.min(size.cols, Math.floor(span.x0)));
+        const x1 = Math.max(0, Math.min(size.cols, Math.floor(span.x1)));
+        const y = Math.floor(span.y);
+        if (y < 0 || y >= size.rows || x1 <= x0) continue;
+
+        let list = nextOverlaySpans.get(y);
+        if (!list) {
+          list = [];
+          nextOverlaySpans.set(y, list);
         }
-        nextOverlayRows.set(span.y, cells);
-        nextDirtyRows.add(span.y);
+        list.push({ y, x0, x1 });
+        nextDirtyRows.add(y);
       }
     }
 
     range = nextRange;
     providerAnchor = nextProviderAnchor;
     providerFocus = nextProviderFocus;
-    overlayRows = nextOverlayRows;
+    overlaySpans = nextOverlaySpans;
     dirtyRows = nextDirtyRows;
     state.value = nextRange
       ? {
@@ -499,11 +520,27 @@ export function createTerminalSelectionController(
       }
     },
     paint(dirtyRowsHint) {
-      const rows = dirtyRowsHint ?? Array.from(overlayRows.keys());
+      const rows = dirtyRowsHint ?? Array.from(overlaySpans.keys());
+      const selectionStyle = readOptions().style;
+
       for (const y of rows) {
-        const cells = overlayRows.get(y);
-        if (!cells) continue;
-        for (const cell of cells) options.overlayTerminal.put(cell.x, y, cell.ch, cell.style);
+        const spans = overlaySpans.get(y);
+        if (!spans?.length) continue;
+
+        const row = options.terminal.getRow(y);
+
+        for (const span of spans) {
+          for (let x = span.x0; x < span.x1; x++) {
+            const cell = row[x];
+            if (!cell || cell.continuation) continue;
+
+            const { href: _href, ...baseStyle } = cell.style;
+            options.overlayTerminal.put(x, y, cell.ch || " ", {
+              ...baseStyle,
+              ...selectionStyle,
+            });
+          }
+        }
       }
     },
     refresh() {

--- a/src/selection/terminal-selection.ts
+++ b/src/selection/terminal-selection.ts
@@ -39,9 +39,17 @@ export type TerminalSelectionOptions = Readonly<{
 
 export type TerminalSelectionConfig = boolean | TerminalSelectionOptions;
 
+/**
+ * A visible overlay span in terminal screen coordinates.
+ * Provider-space spans must be translated to screen coordinates before
+ * returning from `getVisibleSpans()`.
+ */
 export type SelectedRowSpan = Readonly<{
+  /** Terminal screen row y */
   y: number;
+  /** Terminal screen column x inclusive */
   x0: number;
+  /** Terminal screen column x exclusive */
   x1: number;
 }>;
 

--- a/src/selection/terminal-selection.ts
+++ b/src/selection/terminal-selection.ts
@@ -51,7 +51,6 @@ export type SelectionTextProvider = Readonly<{
   canHandle: (range: TerminalSelectionRange) => boolean;
   pointForCell?: (point: TerminalSelectionPoint) => TerminalSelectionPoint | null;
   getText: (range: TerminalSelectionRange) => string;
-  scrollBy?: (deltaRows: number) => void;
   /**
    * Return overlay highlight spans for the portion of the selection that is
    * currently visible in the viewport. Coordinates are terminal screen cells.
@@ -171,6 +170,37 @@ export function terminalSelectionRowSpans(
   return spans;
 }
 
+export function terminalSelectionVisibleRowSpans(
+  range: TerminalSelectionRange,
+  cols: number,
+  rows: number,
+  visibleStartY: number,
+  visibleEndY: number,
+): SelectedRowSpan[] {
+  if (cols <= 0 || rows <= 0) return [];
+
+  const anchor = clampPoint(range.anchor, cols, rows);
+  const focus = clampPoint(range.focus, cols, rows);
+  if (pointKey(anchor) === pointKey(focus)) return [];
+
+  const start = comparePoints(anchor, focus) <= 0 ? anchor : focus;
+  const end = start === anchor ? focus : anchor;
+
+  const fromY = Math.max(start.y, Math.floor(visibleStartY), 0);
+  const toY = Math.min(end.y, Math.ceil(visibleEndY) - 1, rows - 1);
+
+  if (toY < fromY) return [];
+
+  const spans: SelectedRowSpan[] = [];
+  for (let y = fromY; y <= toY; y++) {
+    const x0 = y === start.y ? start.x : 0;
+    const x1 = y === end.y ? end.x + 1 : cols;
+    if (x1 > x0) spans.push({ y, x0, x1 });
+  }
+
+  return spans;
+}
+
 function selectedRowText(row: readonly Cell[], x0: number, x1: number, cols: number): string {
   let out = "";
   for (let x = x0; x < x1; x++) {
@@ -188,6 +218,13 @@ function copyPayload(text: string, ok: boolean, error?: unknown): TerminalSelect
     chars: text.length,
     ok,
     ...(error === undefined ? {} : { error }),
+  };
+}
+
+function clampPointToRect(point: TerminalSelectionPoint, rect: Rect): TerminalSelectionPoint {
+  return {
+    x: Math.max(rect.x, Math.min(rect.x + Math.max(0, rect.w - 1), Math.floor(point.x))),
+    y: Math.max(rect.y, Math.min(rect.y + Math.max(0, rect.h - 1), Math.floor(point.y))),
   };
 }
 
@@ -245,8 +282,10 @@ export function createTerminalSelectionController(
   const providerPointForCell = (
     provider: SelectionTextProvider,
     point: TerminalSelectionPoint,
+    options?: { clampToRect?: boolean },
   ): ProviderSelectionPoint | null => {
-    const providerPoint = provider.pointForCell?.(point) ?? point;
+    const inputPoint = options?.clampToRect ? clampPointToRect(point, provider.rect) : point;
+    const providerPoint = provider.pointForCell?.(inputPoint) ?? inputPoint;
     return providerPoint ? { providerId: provider.id, point: providerPoint } : null;
   };
 
@@ -374,30 +413,39 @@ export function createTerminalSelectionController(
           : focus;
       const anchorProvider = providerForCell(anchor);
       const focusProvider = providerForCell(focus);
+      const activeProvider =
+        startOptions?.extend && providerAnchor ? providerById(providerAnchor.providerId) : null;
       const nextProviderAnchor =
         startOptions?.extend && providerAnchor
           ? providerAnchor
           : anchorProvider
             ? providerPointForCell(anchorProvider, anchor)
             : null;
-      const nextProviderFocus =
-        nextProviderAnchor && focusProvider?.id === nextProviderAnchor.providerId
+      const nextProviderFocus = activeProvider
+        ? providerPointForCell(activeProvider, focus, { clampToRect: true })
+        : nextProviderAnchor && focusProvider?.id === nextProviderAnchor.providerId
           ? providerPointForCell(focusProvider, focus)
           : null;
       rebuild({ anchor, focus, mode: "linear" }, nextProviderAnchor, nextProviderFocus);
     },
     update(point) {
       if (!range) return;
+
       const size = options.terminal.size();
       const focus = clampPoint(point, size.cols, size.rows);
-      const focusProvider = providerAnchor ? providerById(providerAnchor.providerId) : null;
+
+      const activeProvider = providerAnchor ? providerById(providerAnchor.providerId) : null;
+      const nextProviderFocus = activeProvider
+        ? providerPointForCell(activeProvider, focus, { clampToRect: true })
+        : null;
+
       rebuild(
         {
           ...range,
           focus,
         },
         providerAnchor,
-        focusProvider ? providerPointForCell(focusProvider, focus) : null,
+        nextProviderFocus,
       );
     },
     async finish() {

--- a/src/selection/terminal-selection.ts
+++ b/src/selection/terminal-selection.ts
@@ -39,6 +39,12 @@ export type TerminalSelectionOptions = Readonly<{
 
 export type TerminalSelectionConfig = boolean | TerminalSelectionOptions;
 
+export type SelectedRowSpan = Readonly<{
+  y: number;
+  x0: number;
+  x1: number;
+}>;
+
 export type SelectionTextProvider = Readonly<{
   id: string;
   rect: Rect;
@@ -46,6 +52,27 @@ export type SelectionTextProvider = Readonly<{
   pointForCell?: (point: TerminalSelectionPoint) => TerminalSelectionPoint | null;
   getText: (range: TerminalSelectionRange) => string;
   scrollBy?: (deltaRows: number) => void;
+  /**
+   * Return overlay highlight spans for the portion of the selection that is
+   * currently visible in the viewport. Coordinates are terminal screen cells.
+   *
+   * When a virtual-scrolling provider scrolls during a drag-selection, the
+   * selection range may span content that has already scrolled out of view.
+   * The default `terminalSelectionRowSpans()` uses screen coordinates and
+   * cannot account for this, so the highlight becomes stale after each scroll
+   * tick. Providers that support cross-viewport selection should implement
+   * this method to return only the spans that intersect the current viewport,
+   * mapped back to screen cell coordinates.
+   *
+   * @param providerRange - The selection range in provider-space coordinates
+   *   (i.e. after `pointForCell` mapping).
+   * @param screenRange - The same selection range in terminal screen
+   *   coordinates (before `pointForCell` mapping).
+   */
+  getVisibleSpans?: (
+    providerRange: TerminalSelectionRange,
+    screenRange: TerminalSelectionRange,
+  ) => readonly SelectedRowSpan[];
 }>;
 
 export type TerminalSelectionController = Readonly<{
@@ -62,12 +89,6 @@ type SelectionCell = Readonly<{
   x: number;
   ch: string;
   style: Style;
-}>;
-
-type SelectedRowSpan = Readonly<{
-  y: number;
-  x0: number;
-  x1: number;
 }>;
 
 type ProviderSelectionPoint = Readonly<{
@@ -262,6 +283,18 @@ export function createTerminalSelectionController(
     state.value = { ...state.value, text };
   };
 
+  const resolveProvider = (
+    nextRange: TerminalSelectionRange | null,
+    nextProviderAnchor: ProviderSelectionPoint | null,
+  ): SelectionTextProvider | null => {
+    if (!nextRange) return null;
+    if (nextProviderAnchor) {
+      const provider = providerById(nextProviderAnchor.providerId);
+      if (provider) return provider;
+    }
+    return providers().find((candidate) => candidate.canHandle(nextRange)) ?? null;
+  };
+
   const rebuild = (
     nextRange: TerminalSelectionRange | null,
     nextProviderAnchor: ProviderSelectionPoint | null,
@@ -275,7 +308,25 @@ export function createTerminalSelectionController(
 
     if (nextRange) {
       const selectionStyle = readOptions().style;
-      const spans = terminalSelectionRowSpans(nextRange, size.cols, size.rows);
+      const activeProvider = resolveProvider(nextRange, nextProviderAnchor);
+      let spans: readonly SelectedRowSpan[];
+
+      if (
+        activeProvider?.getVisibleSpans &&
+        nextProviderAnchor &&
+        nextProviderFocus &&
+        nextProviderAnchor.providerId === nextProviderFocus.providerId
+      ) {
+        const providerRange: TerminalSelectionRange = {
+          anchor: nextProviderAnchor.point,
+          focus: nextProviderFocus.point,
+          mode: nextRange.mode,
+        };
+        spans = activeProvider.getVisibleSpans(providerRange, nextRange);
+      } else {
+        spans = terminalSelectionRowSpans(nextRange, size.cols, size.rows);
+      }
+
       hasRange = spans.length > 0 || providerPointsDiffer(nextProviderAnchor, nextProviderFocus);
       for (const span of spans) {
         const row = options.terminal.getRow(span.y);

--- a/src/selection/terminal-selection.ts
+++ b/src/selection/terminal-selection.ts
@@ -506,14 +506,18 @@ export function createTerminalSelectionController(
     },
     async finish() {
       if (!range) return;
-      const text = selectedText();
-      if (!text) {
+
+      if (!state.value.hasRange) {
         controller.clear();
         return;
       }
-      setResolvedText(text);
+
       const current = readOptions();
-      if (current.autoCopy && current.copyOnMouseUp) await controller.copy();
+      if (!current.autoCopy || !current.copyOnMouseUp) {
+        return;
+      }
+
+      await controller.copy();
     },
     clear() {
       if (!range && !dirtyRows.size) return;

--- a/src/selection/terminal-selection.ts
+++ b/src/selection/terminal-selection.ts
@@ -47,10 +47,27 @@ export type SelectedRowSpan = Readonly<{
 
 export type SelectionTextProvider = Readonly<{
   id: string;
+
+  /**
+   * Current provider viewport rect in terminal screen coordinates.
+   */
   rect: Rect;
-  canHandle: (range: TerminalSelectionRange) => boolean;
-  pointForCell?: (point: TerminalSelectionPoint) => TerminalSelectionPoint | null;
-  getText: (range: TerminalSelectionRange) => string;
+
+  /**
+   * Receives a terminal screen-space range. Return true when this provider
+   * can resolve the range without relying on the terminal buffer fallback.
+   */
+  canHandle: (screenRange: TerminalSelectionRange) => boolean;
+
+  /**
+   * Maps a terminal screen-space point to provider-space point.
+   */
+  pointForCell?: (screenPoint: TerminalSelectionPoint) => TerminalSelectionPoint | null;
+
+  /**
+   * Receives a provider-space range (i.e. after `pointForCell` mapping).
+   */
+  getText: (providerRange: TerminalSelectionRange) => string;
   /**
    * Return overlay highlight spans for the portion of the selection that is
    * currently visible in the viewport. Coordinates are terminal screen cells.
@@ -82,6 +99,7 @@ export type TerminalSelectionController = Readonly<{
   clear: () => void;
   copy: () => Promise<boolean>;
   paint: (dirtyRows?: readonly number[]) => void;
+  refresh: () => void;
 }>;
 
 type SelectionCell = Readonly<{
@@ -487,6 +505,10 @@ export function createTerminalSelectionController(
         if (!cells) continue;
         for (const cell of cells) options.overlayTerminal.put(cell.x, y, cell.ch, cell.style);
       }
+    },
+    refresh() {
+      if (!range) return;
+      rebuild(range, providerAnchor, providerFocus);
     },
   };
 

--- a/src/selection/terminal-selection.ts
+++ b/src/selection/terminal-selection.ts
@@ -108,6 +108,7 @@ export type TerminalSelectionController = Readonly<{
   copy: () => Promise<boolean>;
   paint: (dirtyRows?: readonly number[]) => void;
   refresh: (options?: TerminalSelectionRefreshOptions) => void;
+  clearProvider: (providerId: string) => void;
 }>;
 
 type ProviderSelectionPoint = Readonly<{
@@ -568,6 +569,14 @@ export function createTerminalSelectionController(
       }
 
       rebuild(range, providerAnchor, providerFocus);
+    },
+    clearProvider(providerId) {
+      if (
+        providerAnchor?.providerId === providerId ||
+        providerFocus?.providerId === providerId
+      ) {
+        controller.clear();
+      }
     },
   };
 

--- a/src/selection/terminal-selection.ts
+++ b/src/selection/terminal-selection.ts
@@ -91,6 +91,14 @@ export type SelectionTextProvider = Readonly<{
   ) => readonly SelectedRowSpan[];
 }>;
 
+export type TerminalSelectionRefreshOptions = Readonly<{
+  /**
+   * Re-map the current screen-space focus point through the active provider.
+   * Use this for selection-driven auto-scroll after the viewport has moved.
+   */
+  remapFocus?: boolean;
+}>;
+
 export type TerminalSelectionController = Readonly<{
   state: Ref<TerminalSelectionState>;
   start: (point: TerminalSelectionPoint, options?: { extend?: boolean }) => void;
@@ -99,7 +107,7 @@ export type TerminalSelectionController = Readonly<{
   clear: () => void;
   copy: () => Promise<boolean>;
   paint: (dirtyRows?: readonly number[]) => void;
-  refresh: () => void;
+  refresh: (options?: TerminalSelectionRefreshOptions) => void;
 }>;
 
 type ProviderSelectionPoint = Readonly<{
@@ -543,8 +551,22 @@ export function createTerminalSelectionController(
         }
       }
     },
-    refresh() {
+    refresh(refreshOptions) {
       if (!range) return;
+
+      if (refreshOptions?.remapFocus) {
+        const activeProvider = providerAnchor
+          ? providerById(providerAnchor.providerId)
+          : resolveProvider(range, null);
+
+        const nextProviderFocus = activeProvider
+          ? providerPointForCell(activeProvider, range.focus, { clampToRect: true })
+          : providerFocus;
+
+        rebuild(range, providerAnchor, nextProviderFocus);
+        return;
+      }
+
       rebuild(range, providerAnchor, providerFocus);
     },
   };

--- a/src/selection/terminal-selection.ts
+++ b/src/selection/terminal-selection.ts
@@ -583,10 +583,7 @@ export function createTerminalSelectionController(
       rebuild(range, providerAnchor, providerFocus);
     },
     clearProvider(providerId) {
-      if (
-        providerAnchor?.providerId === providerId ||
-        providerFocus?.providerId === providerId
-      ) {
+      if (providerAnchor?.providerId === providerId || providerFocus?.providerId === providerId) {
         controller.clear();
       }
     },

--- a/src/vue/components/TLogView.ts
+++ b/src/vue/components/TLogView.ts
@@ -4,6 +4,7 @@ import type { Style } from "../../core/types.js";
 import type { Rect, TerminalKeyboardEvent, TerminalPointerEvent } from "../../events/index.js";
 import type { FramePerfReason } from "../../observability/frame-perf.js";
 import type {
+  SelectedRowSpan,
   SelectionTextProvider,
   TerminalSelectionPoint,
   TerminalSelectionRange,
@@ -3198,6 +3199,34 @@ export const TLogView = defineComponent({
         .join("\n");
     }
 
+    function visibleSpansForSelectionRange(
+      providerRange: TerminalSelectionRange,
+      _screenRange: TerminalSelectionRange,
+    ): readonly SelectedRowSpan[] {
+      const r = normalizedRect();
+      const { x: clipX, y: clipY } = clipOffsets();
+      const cols = currentWrapWidth();
+      const totalRows = estimatedVisualRowCount();
+      const top = currentScrollTop() + clipY;
+      const bottom = top + r.h;
+      const providerSpans = terminalSelectionRowSpans(providerRange, cols, totalRows);
+      const result: SelectedRowSpan[] = [];
+      for (const span of providerSpans) {
+        if (span.y < top || span.y >= bottom) continue;
+        const screenY = r.y + (span.y - top);
+        const screenX0 = r.x + span.x0 - clipX;
+        const screenX1 = r.x + span.x1 - clipX;
+        if (screenY >= r.y && screenY < r.y + r.h && screenX1 > screenX0) {
+          result.push({
+            y: screenY,
+            x0: Math.max(r.x, screenX0),
+            x1: Math.min(r.x + r.w, screenX1),
+          });
+        }
+      }
+      return result;
+    }
+
     function scrollToLine(
       index: number,
       options?: Readonly<{
@@ -3548,6 +3577,7 @@ export const TLogView = defineComponent({
       canHandle: canHandleSelectionRange,
       pointForCell: selectionPointForCell,
       getText: textForSelectionRange,
+      getVisibleSpans: visibleSpansForSelectionRange,
     };
     const unregisterSelectionTextProvider = selection.registerTextProvider(selectionTextProvider);
     onBeforeUnmount(unregisterSelectionTextProvider);

--- a/src/vue/components/TLogView.ts
+++ b/src/vue/components/TLogView.ts
@@ -3149,6 +3149,22 @@ export const TLogView = defineComponent({
       const n = Math.trunc(Number(delta));
       if (!Number.isFinite(n) || n === 0) return false;
       cancelWheelScrollFrame();
+
+      if (isScrollControlled()) {
+        const target = currentScrollTop() + n;
+        const clampedTop = normalizeScrollTop(target);
+        if (clampedTop === currentScrollTop()) return false;
+
+        // Do not spam update:scrollTop while waiting for parent-controlled prop.
+        if (pendingSelectionScrollFocusRemap) return false;
+
+        pendingSelectionScrollFocusRemap = true;
+        emit("update:scrollTop", clampedTop);
+        emit("scroll", scrollPayload(clampedTop));
+        invalidateSelf("high", "scroll");
+        return true;
+      }
+
       const target = currentScrollTop() + n;
       const changed = applyScrollTop(target, "viewport-repaint", {
         emitScroll: true,
@@ -3156,13 +3172,7 @@ export const TLogView = defineComponent({
       });
       if (!changed) return false;
 
-      if (isScrollControlled()) {
-        // Wait for parent scrollTop prop to come back, then remap screen focus.
-        pendingSelectionScrollFocusRemap = true;
-      } else {
-        selection.refresh({ remapFocus: true });
-      }
-
+      selection.refresh({ remapFocus: true });
       invalidateSelf("high", "scroll");
       return true;
     }
@@ -3725,10 +3735,10 @@ export const TLogView = defineComponent({
         cancelWheelScrollFrame();
         syncStickFromCurrentScrollTop();
 
-        selection.refresh({
-          remapFocus: pendingSelectionScrollFocusRemap,
-        });
+        const remap = pendingSelectionScrollFocusRemap;
         pendingSelectionScrollFocusRemap = false;
+
+        selection.refresh(remap ? { remapFocus: true } : undefined);
 
         markViewportDirty();
         invalidateSelf("high", "scroll");

--- a/src/vue/components/TLogView.ts
+++ b/src/vue/components/TLogView.ts
@@ -17,7 +17,7 @@ import type {
   TLogViewVisualIndexStatus,
 } from "../log/types.js";
 import { applyAnsiSgrStyle, parseAnsiSgr } from "../../core/ansi/sgr.js";
-import { terminalSelectionRowSpans } from "../../selection/terminal-selection.js";
+import { terminalSelectionRowSpans, terminalSelectionVisibleRowSpans } from "../../selection/terminal-selection.js";
 import {
   computed,
   defineComponent,
@@ -3207,21 +3207,28 @@ export const TLogView = defineComponent({
       const { x: clipX, y: clipY } = clipOffsets();
       const cols = currentWrapWidth();
       const totalRows = estimatedVisualRowCount();
+
       const top = currentScrollTop() + clipY;
       const bottom = top + r.h;
-      const providerSpans = terminalSelectionRowSpans(providerRange, cols, totalRows);
+
+      const providerSpans = terminalSelectionVisibleRowSpans(
+        providerRange,
+        cols,
+        totalRows,
+        top,
+        bottom,
+      );
+
       const result: SelectedRowSpan[] = [];
       for (const span of providerSpans) {
-        if (span.y < top || span.y >= bottom) continue;
         const screenY = r.y + (span.y - top);
         const screenX0 = r.x + span.x0 - clipX;
         const screenX1 = r.x + span.x1 - clipX;
-        if (screenY >= r.y && screenY < r.y + r.h && screenX1 > screenX0) {
-          result.push({
-            y: screenY,
-            x0: Math.max(r.x, screenX0),
-            x1: Math.min(r.x + r.w, screenX1),
-          });
+
+        const x0 = Math.max(r.x, screenX0);
+        const x1 = Math.min(r.x + r.w, screenX1);
+        if (screenY >= r.y && screenY < r.y + r.h && x1 > x0) {
+          result.push({ y: screenY, x0, x1 });
         }
       }
       return result;

--- a/src/vue/components/TLogView.ts
+++ b/src/vue/components/TLogView.ts
@@ -17,7 +17,10 @@ import type {
   TLogViewVisualIndexStatus,
 } from "../log/types.js";
 import { applyAnsiSgrStyle, parseAnsiSgr } from "../../core/ansi/sgr.js";
-import { terminalSelectionRowSpans, terminalSelectionVisibleRowSpans } from "../../selection/terminal-selection.js";
+import {
+  terminalSelectionRowSpans,
+  terminalSelectionVisibleRowSpans,
+} from "../../selection/terminal-selection.js";
 import {
   computed,
   defineComponent,

--- a/src/vue/components/TLogView.ts
+++ b/src/vue/components/TLogView.ts
@@ -3248,7 +3248,11 @@ export const TLogView = defineComponent({
       const r = normalizedRect();
       const { x: clipX, y: clipY } = clipOffsets();
       const cols = currentWrapWidth();
-      const totalRows = estimatedVisualRowCount();
+      const totalRows = Math.max(
+        estimatedVisualRowCount(),
+        providerRange.anchor.y + 1,
+        providerRange.focus.y + 1,
+      );
 
       const top = currentScrollTop() + clipY;
       const bottom = top + r.h;

--- a/src/vue/components/TLogView.ts
+++ b/src/vue/components/TLogView.ts
@@ -2623,6 +2623,7 @@ export const TLogView = defineComponent({
           resetWheelScrollState(wheelState);
           return;
         }
+        selection.refresh();
         ctx.invalidate({ priority: "high", plane: plane.value, reason: "scroll" });
       },
     });
@@ -2946,6 +2947,7 @@ export const TLogView = defineComponent({
           emitScroll: true,
           stickToBottom: false,
         });
+        if (changed) selection.refresh();
         if (!changed) markViewportDirty();
         resumeVisualMeasurement();
         return true;
@@ -2957,6 +2959,7 @@ export const TLogView = defineComponent({
           emitScroll: true,
           stickToBottom: stickToBottom.value && nextTop >= maxScrollTop(),
         });
+        if (changed) selection.refresh();
         if (!changed) markViewportDirty();
         resumeVisualMeasurement();
         return true;
@@ -2977,6 +2980,7 @@ export const TLogView = defineComponent({
             extraDirtyRows: extraDirtyRow == null ? undefined : [extraDirtyRow],
           },
         );
+        if (changed) selection.refresh();
         if (!changed) {
           if (sameCountTailDirtyRows.length) markRowsDirty(sameCountTailDirtyRows);
           else markViewportDirty();
@@ -2999,6 +3003,7 @@ export const TLogView = defineComponent({
           emitScroll: true,
           stickToBottom: isAtBottom(),
         });
+        if (changed) selection.refresh();
         if (!changed) markViewportDirty();
         resumeVisualMeasurement();
         return true;
@@ -3091,7 +3096,10 @@ export const TLogView = defineComponent({
         stickToBottom: nextStick,
       });
       if (!changed && nextStick != null) stickToBottom.value = nextStick;
-      if (changed) invalidateSelf("high", "input");
+      if (changed) {
+        selection.refresh();
+        invalidateSelf("high", "input");
+      }
     }
 
     function scrollToBottom(): void {
@@ -3100,7 +3108,10 @@ export const TLogView = defineComponent({
         emitScroll: true,
         stickToBottom: true,
       });
-      if (changed) invalidateSelf("high", "scroll");
+      if (changed) {
+        selection.refresh();
+        invalidateSelf("high", "scroll");
+      }
     }
 
     function scrollToTop(): void {
@@ -3109,7 +3120,10 @@ export const TLogView = defineComponent({
         emitScroll: true,
         stickToBottom: false,
       });
-      if (changed) invalidateSelf("high", "scroll");
+      if (changed) {
+        selection.refresh();
+        invalidateSelf("high", "scroll");
+      }
     }
 
     function scrollToVisualRow(row: number): void {
@@ -3119,7 +3133,10 @@ export const TLogView = defineComponent({
         emitScroll: true,
         stickToBottom: target >= maxScrollTop(),
       });
-      if (changed) invalidateSelf("high", "scroll");
+      if (changed) {
+        selection.refresh();
+        invalidateSelf("high", "scroll");
+      }
     }
 
     function scrollBy(delta: number): void {
@@ -3270,6 +3287,7 @@ export const TLogView = defineComponent({
         emitScroll: true,
         stickToBottom: stickToBottom.value && nextTop >= maxScrollTop(),
       });
+      if (changed) selection.refresh();
       if (!changed) markViewportDirty();
       invalidateSelf("normal", "data");
     }
@@ -3793,6 +3811,7 @@ export const TLogView = defineComponent({
           emitUpdate: wasInitialized,
           stickToBottom: nextStick,
         });
+        if (changed) selection.refresh();
         if (!changed) markViewportDirty();
         invalidateSelf("normal", "data");
       },

--- a/src/vue/components/TLogView.ts
+++ b/src/vue/components/TLogView.ts
@@ -812,6 +812,7 @@ export const TLogView = defineComponent({
     let renderNodeId: string | null = null;
     let alive = true;
     let pendingWheelTop: number | null = null;
+    let pendingSelectionScrollFocusRemap = false;
     let initializedScrollTop = false;
     let lastLineCount = 0;
     let lastFirstLineIndex = 0;
@@ -3153,8 +3154,17 @@ export const TLogView = defineComponent({
         emitScroll: true,
         stickToBottom: target >= maxScrollTop(),
       });
-      if (changed) invalidateSelf("high", "scroll");
-      return changed;
+      if (!changed) return false;
+
+      if (isScrollControlled()) {
+        // Wait for parent scrollTop prop to come back, then remap screen focus.
+        pendingSelectionScrollFocusRemap = true;
+      } else {
+        selection.refresh({ remapFocus: true });
+      }
+
+      invalidateSelf("high", "scroll");
+      return true;
     }
 
     function selectionPointForCell(point: TerminalSelectionPoint): TerminalSelectionPoint | null {
@@ -3714,6 +3724,12 @@ export const TLogView = defineComponent({
       () => {
         cancelWheelScrollFrame();
         syncStickFromCurrentScrollTop();
+
+        selection.refresh({
+          remapFocus: pendingSelectionScrollFocusRemap,
+        });
+        pendingSelectionScrollFocusRemap = false;
+
         markViewportDirty();
         invalidateSelf("high", "scroll");
       },

--- a/src/vue/components/TLogView.ts
+++ b/src/vue/components/TLogView.ts
@@ -812,6 +812,11 @@ export const TLogView = defineComponent({
     let renderNodeId: string | null = null;
     let alive = true;
     let pendingWheelTop: number | null = null;
+
+    // Under controlled scrollTop, selection auto-scroll only emits a single
+    // pending update:scrollTop; the selection focus is remapped only after the
+    // parent writes scrollTop back. If the parent never writes back, selection
+    // auto-scroll pauses. This is the intended controlled-component semantic.
     let pendingSelectionScrollFocusRemap = false;
     let initializedScrollTop = false;
     let lastLineCount = 0;

--- a/src/vue/components/TVirtualList.ts
+++ b/src/vue/components/TVirtualList.ts
@@ -137,6 +137,11 @@ export const TVirtualList = defineComponent({
     let warnedRenderItemIdentity = false;
     let alive = true;
     let pendingWheelTop: number | null = null;
+
+    // Under controlled scrollTop, selection auto-scroll only emits a single
+    // pending update:scrollTop; the selection focus is remapped only after the
+    // parent writes scrollTop back. If the parent never writes back, selection
+    // auto-scroll pauses. This is the intended controlled-component semantic.
     let pendingSelectionScrollFocusRemap = false;
     const wheelState = createWheelScrollState();
 

--- a/src/vue/components/TVirtualList.ts
+++ b/src/vue/components/TVirtualList.ts
@@ -137,6 +137,7 @@ export const TVirtualList = defineComponent({
     let warnedRenderItemIdentity = false;
     let alive = true;
     let pendingWheelTop: number | null = null;
+    let pendingSelectionScrollFocusRemap = false;
     const wheelState = createWheelScrollState();
 
     const itemCount = computed(() => {
@@ -358,6 +359,7 @@ export const TVirtualList = defineComponent({
       () => props.scrollTop,
       () => {
         if (!isScrollControlled()) return;
+
         const wasInitialized = initializedScrollTop;
         initializedScrollTop = true;
         cancelWheelScrollFrame();
@@ -365,6 +367,12 @@ export const TVirtualList = defineComponent({
         const changed = scrollTop.value !== nextTop;
         scrollTop.value = nextTop;
         if (!wasInitialized || !changed) return;
+
+        selection.refresh({
+          remapFocus: pendingSelectionScrollFocusRemap,
+        });
+        pendingSelectionScrollFocusRemap = false;
+
         markViewportDirty();
         invalidateSelf("high", "scroll");
       },
@@ -484,7 +492,17 @@ export const TVirtualList = defineComponent({
         priority: "high",
         reason: "scroll",
       });
-      return changed.changed;
+
+      if (!changed.changed) return false;
+
+      if (changed.controlled) {
+        // Wait for parent scrollTop prop to come back, then remap screen focus.
+        pendingSelectionScrollFocusRemap = true;
+      } else {
+        selection.refresh({ remapFocus: true });
+      }
+
+      return true;
     }
 
     function selectionPointForCell(point: TerminalSelectionPoint): TerminalSelectionPoint | null {

--- a/src/vue/components/TVirtualList.ts
+++ b/src/vue/components/TVirtualList.ts
@@ -395,6 +395,13 @@ export const TVirtualList = defineComponent({
       },
     );
 
+    watch(
+      () => props.itemVersion,
+      () => {
+        selection.refresh();
+      },
+    );
+
     function itemText(index: number): string {
       const item = props.getItem(index);
       const raw = props.renderItem ? props.renderItem(item, index) : item;

--- a/src/vue/components/TVirtualList.ts
+++ b/src/vue/components/TVirtualList.ts
@@ -27,7 +27,7 @@ import { useTerminal } from "../composables/use-terminal.js";
 import { useVisibility } from "../composables/use-visibility.js";
 import { EventZIndexContextKey, RenderPlaneContextKey } from "../context.js";
 import { createFrameMailbox } from "../scheduler/frame-mailbox.js";
-import { terminalSelectionRowSpans } from "../../selection/terminal-selection.js";
+import { terminalSelectionRowSpans, terminalSelectionVisibleRowSpans } from "../../selection/terminal-selection.js";
 import { intersectRect, normalizeCellRect, translateRect } from "../utils/rect.js";
 import { defaultActiveStyle } from "../utils/style-cache.js";
 import { formatInlineCellLine, padEndByCells, sliceByCellsRange } from "../utils/text.js";
@@ -513,19 +513,24 @@ export const TVirtualList = defineComponent({
       const cols = Math.max(1, Math.floor(props.w));
       const top = scrollTop.value + clipY;
       const bottom = top + r.h;
-      const providerSpans = terminalSelectionRowSpans(providerRange, cols, itemCount.value);
+
+      const providerSpans = terminalSelectionVisibleRowSpans(
+        providerRange,
+        cols,
+        itemCount.value,
+        top,
+        bottom,
+      );
+
       const result: SelectedRowSpan[] = [];
       for (const span of providerSpans) {
-        if (span.y < top || span.y >= bottom) continue;
         const screenY = r.y + (span.y - top);
         const screenX0 = r.x + span.x0 - clipX;
         const screenX1 = r.x + span.x1 - clipX;
-        if (screenY >= r.y && screenY < r.y + r.h && screenX1 > screenX0) {
-          result.push({
-            y: screenY,
-            x0: Math.max(r.x, screenX0),
-            x1: Math.min(r.x + r.w, screenX1),
-          });
+        const x0 = Math.max(r.x, screenX0);
+        const x1 = Math.min(r.x + r.w, screenX1);
+        if (screenY >= r.y && screenY < r.y + r.h && x1 > x0) {
+          result.push({ y: screenY, x0, x1 });
         }
       }
       return result;

--- a/src/vue/components/TVirtualList.ts
+++ b/src/vue/components/TVirtualList.ts
@@ -27,7 +27,10 @@ import { useTerminal } from "../composables/use-terminal.js";
 import { useVisibility } from "../composables/use-visibility.js";
 import { EventZIndexContextKey, RenderPlaneContextKey } from "../context.js";
 import { createFrameMailbox } from "../scheduler/frame-mailbox.js";
-import { terminalSelectionRowSpans, terminalSelectionVisibleRowSpans } from "../../selection/terminal-selection.js";
+import {
+  terminalSelectionRowSpans,
+  terminalSelectionVisibleRowSpans,
+} from "../../selection/terminal-selection.js";
 import { intersectRect, normalizeCellRect, translateRect } from "../utils/rect.js";
 import { defaultActiveStyle } from "../utils/style-cache.js";
 import { formatInlineCellLine, padEndByCells, sliceByCellsRange } from "../utils/text.js";

--- a/src/vue/components/TVirtualList.ts
+++ b/src/vue/components/TVirtualList.ts
@@ -368,10 +368,10 @@ export const TVirtualList = defineComponent({
         scrollTop.value = nextTop;
         if (!wasInitialized || !changed) return;
 
-        selection.refresh({
-          remapFocus: pendingSelectionScrollFocusRemap,
-        });
+        const remap = pendingSelectionScrollFocusRemap;
         pendingSelectionScrollFocusRemap = false;
+
+        selection.refresh(remap ? { remapFocus: true } : undefined);
 
         markViewportDirty();
         invalidateSelf("high", "scroll");
@@ -486,6 +486,20 @@ export const TVirtualList = defineComponent({
       const n = Math.trunc(Number(delta));
       if (!Number.isFinite(n) || n === 0) return false;
       cancelWheelScrollFrame();
+
+      if (isScrollControlled()) {
+        const nextTop = clampScrollTop(scrollTop.value + n);
+        if (nextTop === scrollTop.value) return false;
+
+        // Do not spam update:scrollTop while waiting for parent-controlled prop.
+        if (pendingSelectionScrollFocusRemap) return false;
+
+        pendingSelectionScrollFocusRemap = true;
+        emit("update:scrollTop", nextTop);
+        emit("scroll", nextTop);
+        return true;
+      }
+
       const changed = applyScrollTop(scrollTop.value + n, {
         emitScroll: true,
         emitUpdate: true,
@@ -495,13 +509,7 @@ export const TVirtualList = defineComponent({
 
       if (!changed.changed) return false;
 
-      if (changed.controlled) {
-        // Wait for parent scrollTop prop to come back, then remap screen focus.
-        pendingSelectionScrollFocusRemap = true;
-      } else {
-        selection.refresh({ remapFocus: true });
-      }
-
+      selection.refresh({ remapFocus: true });
       return true;
     }
 

--- a/src/vue/components/TVirtualList.ts
+++ b/src/vue/components/TVirtualList.ts
@@ -3,6 +3,12 @@ import type { TerminalRenderPlane } from "../../core/render-plane.js";
 import type { Style } from "../../core/types.js";
 import type { Rect, TerminalKeyboardEvent, TerminalPointerEvent } from "../../events/index.js";
 import type { FramePerfReason } from "../../observability/frame-perf.js";
+import type {
+  SelectedRowSpan,
+  SelectionTextProvider,
+  TerminalSelectionPoint,
+  TerminalSelectionRange,
+} from "../../selection/terminal-selection.js";
 import {
   computed,
   defineComponent,
@@ -21,6 +27,7 @@ import { useTerminal } from "../composables/use-terminal.js";
 import { useVisibility } from "../composables/use-visibility.js";
 import { EventZIndexContextKey, RenderPlaneContextKey } from "../context.js";
 import { createFrameMailbox } from "../scheduler/frame-mailbox.js";
+import { terminalSelectionRowSpans } from "../../selection/terminal-selection.js";
 import { intersectRect, normalizeCellRect, translateRect } from "../utils/rect.js";
 import { defaultActiveStyle } from "../utils/style-cache.js";
 import { formatInlineCellLine, padEndByCells, sliceByCellsRange } from "../utils/text.js";
@@ -109,7 +116,7 @@ export const TVirtualList = defineComponent({
     "keydown",
   ],
   setup(props, { emit }) {
-    const { terminal, scheduler, render, defaultStyle, events } = useTerminal();
+    const { terminal, scheduler, render, defaultStyle, events, selection } = useTerminal();
     const instance = getCurrentInstance();
     const layout = useLayout();
     const { visible, rootProps } = useVisibility();
@@ -468,6 +475,74 @@ export const TVirtualList = defineComponent({
       });
       return changed.changed;
     }
+
+    function selectionPointForCell(point: TerminalSelectionPoint): TerminalSelectionPoint | null {
+      const r = normalizedRect();
+      if (point.x < r.x || point.y < r.y || point.x >= r.x + r.w || point.y >= r.y + r.h) {
+        return null;
+      }
+      const { x: clipX, y: clipY } = clipOffsets();
+      const virtualY = scrollTop.value + clipY + (point.y - r.y);
+      if (virtualY < 0 || virtualY >= itemCount.value) return null;
+      return {
+        x: clamp(clipX + (point.x - r.x), 0, Math.max(0, props.w - 1)),
+        y: virtualY,
+      };
+    }
+
+    function canHandleSelectionRange(range: TerminalSelectionRange): boolean {
+      return Boolean(selectionPointForCell(range.anchor) && selectionPointForCell(range.focus));
+    }
+
+    function textForSelectionRange(range: TerminalSelectionRange): string {
+      const cols = Math.max(1, Math.floor(props.w));
+      return terminalSelectionRowSpans(range, cols, itemCount.value)
+        .map((span) => {
+          const text = sliceByCellsRange(itemText(span.y), span.x0, span.x1);
+          return span.x1 >= cols ? text.trimEnd() : text;
+        })
+        .join("\n");
+    }
+
+    function visibleSpansForSelectionRange(
+      providerRange: TerminalSelectionRange,
+      _screenRange: TerminalSelectionRange,
+    ): readonly SelectedRowSpan[] {
+      const r = normalizedRect();
+      const { x: clipX, y: clipY } = clipOffsets();
+      const cols = Math.max(1, Math.floor(props.w));
+      const top = scrollTop.value + clipY;
+      const bottom = top + r.h;
+      const providerSpans = terminalSelectionRowSpans(providerRange, cols, itemCount.value);
+      const result: SelectedRowSpan[] = [];
+      for (const span of providerSpans) {
+        if (span.y < top || span.y >= bottom) continue;
+        const screenY = r.y + (span.y - top);
+        const screenX0 = r.x + span.x0 - clipX;
+        const screenX1 = r.x + span.x1 - clipX;
+        if (screenY >= r.y && screenY < r.y + r.h && screenX1 > screenX0) {
+          result.push({
+            y: screenY,
+            x0: Math.max(r.x, screenX0),
+            x1: Math.min(r.x + r.w, screenX1),
+          });
+        }
+      }
+      return result;
+    }
+
+    const selectionTextProvider: SelectionTextProvider = {
+      id: `TVirtualList:${virtualListInstanceId}:selection-text`,
+      get rect() {
+        return normalizedRect();
+      },
+      canHandle: canHandleSelectionRange,
+      pointForCell: selectionPointForCell,
+      getText: textForSelectionRange,
+      getVisibleSpans: visibleSpansForSelectionRange,
+    };
+    const unregisterSelectionTextProvider = selection.registerTextProvider(selectionTextProvider);
+    onBeforeUnmount(unregisterSelectionTextProvider);
 
     const eventNode = useTerminalNode(() => ({
       rect: normalizedRect(),

--- a/src/vue/components/TVirtualList.ts
+++ b/src/vue/components/TVirtualList.ts
@@ -239,7 +239,9 @@ export const TVirtualList = defineComponent({
       if (active.value < visibleStart) nextTop = clamp(active.value - clipY, 0, maxTop);
       else if (active.value > visibleEnd)
         nextTop = clamp(active.value - (clipY + clip.h - 1), 0, maxTop);
-      return applyScrollTop(nextTop, options);
+      const result = applyScrollTop(nextTop, options);
+      if (result.changed) selection.refresh();
+      return result;
     }
 
     function normalizedModelValue(): number {
@@ -266,6 +268,7 @@ export const TVirtualList = defineComponent({
           resetWheelScrollState(wheelState);
           return;
         }
+        selection.refresh();
         if (changed.dirty)
           ctx.invalidate({ priority: "high", plane: plane.value, reason: "scroll" });
       },
@@ -334,6 +337,7 @@ export const TVirtualList = defineComponent({
         active.value = normalizedModelValue();
         const nextTop = clampScrollTop(scrollTop.value);
         const changed = applyScrollTop(nextTop, { emitScroll });
+        if (changed.changed) selection.refresh();
         if (!changed.changed) markViewportDirty();
         if (pendingWheelTop !== null && !hasPaintableViewport()) {
           cancelWheelScrollFrame();

--- a/src/vue/components/TVirtualList.ts
+++ b/src/vue/components/TVirtualList.ts
@@ -99,6 +99,10 @@ export const TVirtualList = defineComponent({
     style: { type: Object as PropType<Style>, default: undefined },
     activeStyle: { type: Object as PropType<Style>, default: undefined },
     autoFocus: { type: Boolean, default: false },
+    selectionText: {
+      type: Function as PropType<(item: unknown, index: number) => string>,
+      default: undefined,
+    },
     selectable: { type: Boolean, default: false },
     rowScrollMode: {
       type: String as PropType<RowScrollMode>,
@@ -417,8 +421,15 @@ export const TVirtualList = defineComponent({
 
     function itemText(index: number): string {
       const item = props.getItem(index);
+
+      if (props.selectionText) {
+        return String(props.selectionText(item, index) ?? "");
+      }
+
       const raw = props.renderItem ? props.renderItem(item, index) : item;
-      return String(raw ?? "");
+      return typeof raw === "string" || typeof raw === "number" || typeof raw === "boolean"
+        ? String(raw)
+        : "";
     }
 
     function commit(index: number): void {

--- a/src/vue/components/TVirtualMarkdown.ts
+++ b/src/vue/components/TVirtualMarkdown.ts
@@ -279,6 +279,7 @@ export const TVirtualMarkdown = defineComponent({
         emit("update:scrollTop", clamped);
         emit("scroll", clamped);
       }
+      selection.refresh();
     }
 
     watch(
@@ -287,11 +288,13 @@ export const TVirtualMarkdown = defineComponent({
         if (!hasControlledScrollTop()) return;
         const desired = Math.floor(Number(props.scrollTop) || 0);
         const clamped = clamp(desired, 0, maxScrollTop());
+        if (internalScrollTop.value === clamped) return;
         internalScrollTop.value = clamped;
         if (desired !== clamped) {
           emit("update:scrollTop", clamped);
           emit("scroll", clamped);
         }
+        selection.refresh();
       },
     );
 
@@ -402,31 +405,37 @@ export const TVirtualMarkdown = defineComponent({
       if (event.key === "ArrowUp") {
         event.preventDefault();
         setScrollTop(internalScrollTop.value - 1);
+        selection.refresh();
         return;
       }
       if (event.key === "ArrowDown") {
         event.preventDefault();
         setScrollTop(internalScrollTop.value + 1);
+        selection.refresh();
         return;
       }
       if (event.key === "PageUp") {
         event.preventDefault();
         setScrollTop(internalScrollTop.value - page);
+        selection.refresh();
         return;
       }
       if (event.key === "PageDown") {
         event.preventDefault();
         setScrollTop(internalScrollTop.value + page);
+        selection.refresh();
         return;
       }
       if (event.key === "Home") {
         event.preventDefault();
         setScrollTop(0);
+        selection.refresh();
         return;
       }
       if (event.key === "End") {
         event.preventDefault();
         setScrollTop(maxScrollTop());
+        selection.refresh();
       }
     }
 
@@ -473,6 +482,7 @@ export const TVirtualMarkdown = defineComponent({
           if (!dir || nextTop === internalScrollTop.value) return;
           event.preventDefault?.();
           setScrollTop(nextTop);
+          selection.refresh();
         },
         focus: () => {
           emit("focus");

--- a/src/vue/components/TVirtualMarkdown.ts
+++ b/src/vue/components/TVirtualMarkdown.ts
@@ -262,6 +262,28 @@ export const TVirtualMarkdown = defineComponent({
       return Object.prototype.hasOwnProperty.call(instance?.vnode.props ?? {}, "scrollTop");
     }
 
+    function applyControlledScrollTop(next: number, remapSelectionFocus = false): void {
+      const desired = Math.floor(Number(next) || 0);
+      const clamped = clamp(desired, 0, maxScrollTop());
+      const changed = internalScrollTop.value !== clamped;
+
+      if (changed) {
+        internalScrollTop.value = clamped;
+      }
+
+      // When a controlled prop changes, only emit if the parent supplied an
+      // out-of-range value so it can correct its state.  Do NOT emit on
+      // legitimate prop changes — that would create a feedback loop.
+      if (desired !== clamped) {
+        emit("update:scrollTop", clamped);
+        emit("scroll", clamped);
+      }
+
+      if (changed || remapSelectionFocus) {
+        selection.refresh(remapSelectionFocus ? { remapFocus: true } : undefined);
+      }
+    }
+
     function setScrollTop(
       next: number,
       emitChange = true,
@@ -312,10 +334,7 @@ export const TVirtualMarkdown = defineComponent({
         const remap = pendingSelectionScrollFocusRemap;
         pendingSelectionScrollFocusRemap = false;
 
-        setScrollTop(props.scrollTop, true, {
-          emitClampEvenIfUnchanged: true,
-          remapSelectionFocus: remap,
-        });
+        applyControlledScrollTop(props.scrollTop, remap);
       },
     );
 

--- a/src/vue/components/TVirtualMarkdown.ts
+++ b/src/vue/components/TVirtualMarkdown.ts
@@ -177,7 +177,10 @@ export const TVirtualMarkdown = defineComponent({
       const visibleChanged =
         prevVisibleRows.length !== nextVisibleRows.length ||
         prevVisibleRows.some((row, index) => row !== nextVisibleRows[index]);
-      if (!builtOnce || prevScrollTop !== nextScrollTop || visibleChanged) documentVersion.value++;
+      if (!builtOnce || prevScrollTop !== nextScrollTop || visibleChanged) {
+        documentVersion.value++;
+        selection.refresh();
+      }
     }
 
     function scheduleRebuild(): void {

--- a/src/vue/components/TVirtualMarkdown.ts
+++ b/src/vue/components/TVirtualMarkdown.ts
@@ -132,6 +132,7 @@ export const TVirtualMarkdown = defineComponent({
     const internalScrollTop = ref(0);
     const documentVersion = ref(0);
     const rows = shallowRef<readonly TuiMarkdownVisualRow[]>(markRaw([]));
+    let pendingSelectionScrollFocusRemap = false;
     const wheelState = createWheelScrollState();
     let builtOnce = false;
     let rebuildVersion = 0;
@@ -307,8 +308,13 @@ export const TVirtualMarkdown = defineComponent({
       () => props.scrollTop,
       () => {
         if (!hasControlledScrollTop()) return;
+
+        const remap = pendingSelectionScrollFocusRemap;
+        pendingSelectionScrollFocusRemap = false;
+
         setScrollTop(props.scrollTop, true, {
           emitClampEvenIfUnchanged: true,
+          remapSelectionFocus: remap,
         });
       },
     );
@@ -349,6 +355,20 @@ export const TVirtualMarkdown = defineComponent({
     function scrollSelectionBy(delta: number): boolean {
       const n = Math.trunc(Number(delta));
       if (!Number.isFinite(n) || n === 0) return false;
+
+      if (hasControlledScrollTop()) {
+        const nextTop = clamp(internalScrollTop.value + n, 0, maxScrollTop());
+        if (nextTop === internalScrollTop.value) return false;
+
+        // Do not spam update:scrollTop while waiting for parent-controlled prop.
+        if (pendingSelectionScrollFocusRemap) return false;
+
+        pendingSelectionScrollFocusRemap = true;
+        emit("update:scrollTop", nextTop);
+        emit("scroll", nextTop);
+        return true;
+      }
+
       const before = internalScrollTop.value;
       setScrollTop(before + n, true, { remapSelectionFocus: true });
       return internalScrollTop.value !== before;

--- a/src/vue/components/TVirtualMarkdown.ts
+++ b/src/vue/components/TVirtualMarkdown.ts
@@ -264,18 +264,29 @@ export const TVirtualMarkdown = defineComponent({
     function setScrollTop(
       next: number,
       emitChange = true,
-      refreshOptions?: { remapSelectionFocus?: boolean },
+      refreshOptions?: { remapSelectionFocus?: boolean; emitClampEvenIfUnchanged?: boolean },
     ): void {
-      const clamped = clamp(Math.floor(Number(next) || 0), 0, maxScrollTop());
-      if (internalScrollTop.value === clamped) return;
-      internalScrollTop.value = clamped;
-      if (emitChange) {
+      const desired = Math.floor(Number(next) || 0);
+      const clamped = clamp(desired, 0, maxScrollTop());
+      const changed = internalScrollTop.value !== clamped;
+
+      if (changed) {
+        internalScrollTop.value = clamped;
+      }
+
+      if (
+        emitChange &&
+        (changed || (refreshOptions?.emitClampEvenIfUnchanged && desired !== clamped))
+      ) {
         emit("update:scrollTop", clamped);
         emit("scroll", clamped);
       }
-      selection.refresh(
-        refreshOptions?.remapSelectionFocus ? { remapFocus: true } : undefined,
-      );
+
+      if (changed || refreshOptions?.remapSelectionFocus) {
+        selection.refresh(
+          refreshOptions?.remapSelectionFocus ? { remapFocus: true } : undefined,
+        );
+      }
     }
 
     function reconcileScrollTop(): void {
@@ -296,7 +307,9 @@ export const TVirtualMarkdown = defineComponent({
       () => props.scrollTop,
       () => {
         if (!hasControlledScrollTop()) return;
-        setScrollTop(props.scrollTop);
+        setScrollTop(props.scrollTop, true, {
+          emitClampEvenIfUnchanged: true,
+        });
       },
     );
 

--- a/src/vue/components/TVirtualMarkdown.ts
+++ b/src/vue/components/TVirtualMarkdown.ts
@@ -261,7 +261,11 @@ export const TVirtualMarkdown = defineComponent({
       return Object.prototype.hasOwnProperty.call(instance?.vnode.props ?? {}, "scrollTop");
     }
 
-    function setScrollTop(next: number, emitChange = true): void {
+    function setScrollTop(
+      next: number,
+      emitChange = true,
+      refreshOptions?: { remapSelectionFocus?: boolean },
+    ): void {
       const clamped = clamp(Math.floor(Number(next) || 0), 0, maxScrollTop());
       if (internalScrollTop.value === clamped) return;
       internalScrollTop.value = clamped;
@@ -269,6 +273,9 @@ export const TVirtualMarkdown = defineComponent({
         emit("update:scrollTop", clamped);
         emit("scroll", clamped);
       }
+      selection.refresh(
+        refreshOptions?.remapSelectionFocus ? { remapFocus: true } : undefined,
+      );
     }
 
     function reconcileScrollTop(): void {
@@ -289,15 +296,7 @@ export const TVirtualMarkdown = defineComponent({
       () => props.scrollTop,
       () => {
         if (!hasControlledScrollTop()) return;
-        const desired = Math.floor(Number(props.scrollTop) || 0);
-        const clamped = clamp(desired, 0, maxScrollTop());
-        if (internalScrollTop.value === clamped) return;
-        internalScrollTop.value = clamped;
-        if (desired !== clamped) {
-          emit("update:scrollTop", clamped);
-          emit("scroll", clamped);
-        }
-        selection.refresh();
+        setScrollTop(props.scrollTop);
       },
     );
 
@@ -338,7 +337,7 @@ export const TVirtualMarkdown = defineComponent({
       const n = Math.trunc(Number(delta));
       if (!Number.isFinite(n) || n === 0) return false;
       const before = internalScrollTop.value;
-      setScrollTop(before + n);
+      setScrollTop(before + n, true, { remapSelectionFocus: true });
       return internalScrollTop.value !== before;
     }
 
@@ -408,37 +407,31 @@ export const TVirtualMarkdown = defineComponent({
       if (event.key === "ArrowUp") {
         event.preventDefault();
         setScrollTop(internalScrollTop.value - 1);
-        selection.refresh();
         return;
       }
       if (event.key === "ArrowDown") {
         event.preventDefault();
         setScrollTop(internalScrollTop.value + 1);
-        selection.refresh();
         return;
       }
       if (event.key === "PageUp") {
         event.preventDefault();
         setScrollTop(internalScrollTop.value - page);
-        selection.refresh();
         return;
       }
       if (event.key === "PageDown") {
         event.preventDefault();
         setScrollTop(internalScrollTop.value + page);
-        selection.refresh();
         return;
       }
       if (event.key === "Home") {
         event.preventDefault();
         setScrollTop(0);
-        selection.refresh();
         return;
       }
       if (event.key === "End") {
         event.preventDefault();
         setScrollTop(maxScrollTop());
-        selection.refresh();
       }
     }
 
@@ -485,7 +478,6 @@ export const TVirtualMarkdown = defineComponent({
           if (!dir || nextTop === internalScrollTop.value) return;
           event.preventDefault?.();
           setScrollTop(nextTop);
-          selection.refresh();
         },
         focus: () => {
           emit("focus");

--- a/src/vue/components/TVirtualMarkdown.ts
+++ b/src/vue/components/TVirtualMarkdown.ts
@@ -2,6 +2,7 @@ import type { PropType } from "vue";
 import type { Style } from "../../core/types.js";
 import type { Rect, TerminalKeyboardEvent, TerminalPointerEvent } from "../../events/index.js";
 import type {
+  SelectedRowSpan,
   SelectionTextProvider,
   TerminalSelectionPoint,
   TerminalSelectionRange,
@@ -363,6 +364,35 @@ export const TVirtualMarkdown = defineComponent({
         .join("\n");
     }
 
+    function visibleSpansForSelectionRange(
+      providerRange: TerminalSelectionRange,
+      _screenRange: TerminalSelectionRange,
+    ): readonly SelectedRowSpan[] {
+      const r = normalizedRect();
+      const { x: clipX, y: clipY } = clipOffsets();
+      const cols = Math.max(1, Math.floor(props.w));
+      const top = internalScrollTop.value + clipY;
+      const bottom = top + r.h;
+      // Compute spans in provider (visual row) space
+      const providerSpans = terminalSelectionRowSpans(providerRange, cols, rows.value.length);
+      const result: SelectedRowSpan[] = [];
+      for (const span of providerSpans) {
+        // Only include rows that are currently visible
+        if (span.y < top || span.y >= bottom) continue;
+        const screenY = r.y + (span.y - top);
+        const screenX0 = r.x + span.x0 - clipX;
+        const screenX1 = r.x + span.x1 - clipX;
+        if (screenY >= r.y && screenY < r.y + r.h && screenX1 > screenX0) {
+          result.push({
+            y: screenY,
+            x0: Math.max(r.x, screenX0),
+            x1: Math.min(r.x + r.w, screenX1),
+          });
+        }
+      }
+      return result;
+    }
+
     function onKeydown(event: TerminalKeyboardEvent): void {
       emit("keydown", event);
       const page = Math.max(1, normalizedRect().h);
@@ -405,6 +435,7 @@ export const TVirtualMarkdown = defineComponent({
       canHandle: canHandleSelectionRange,
       pointForCell: selectionPointForCell,
       getText: textForSelectionRange,
+      getVisibleSpans: visibleSpansForSelectionRange,
     };
     const unregisterSelectionTextProvider = selection.registerTextProvider(selectionTextProvider);
     onBeforeUnmount(unregisterSelectionTextProvider);

--- a/src/vue/components/TVirtualMarkdown.ts
+++ b/src/vue/components/TVirtualMarkdown.ts
@@ -21,7 +21,10 @@ import {
   watchEffect,
 } from "vue";
 import { buildMarkdownBlocks } from "../markdown/document.js";
-import { terminalSelectionRowSpans, terminalSelectionVisibleRowSpans } from "../../selection/terminal-selection.js";
+import {
+  terminalSelectionRowSpans,
+  terminalSelectionVisibleRowSpans,
+} from "../../selection/terminal-selection.js";
 import { layoutMarkdownBlocksCached, type TuiMarkdownLayoutCache } from "../markdown/layout.js";
 import { createTuiMarkdownParser } from "../markdown/parser.js";
 import { paintMarkdownVisualRow } from "../markdown/render.js";
@@ -306,9 +309,7 @@ export const TVirtualMarkdown = defineComponent({
       }
 
       if (changed || refreshOptions?.remapSelectionFocus) {
-        selection.refresh(
-          refreshOptions?.remapSelectionFocus ? { remapFocus: true } : undefined,
-        );
+        selection.refresh(refreshOptions?.remapSelectionFocus ? { remapFocus: true } : undefined);
       }
     }
 

--- a/src/vue/components/TVirtualMarkdown.ts
+++ b/src/vue/components/TVirtualMarkdown.ts
@@ -21,7 +21,7 @@ import {
   watchEffect,
 } from "vue";
 import { buildMarkdownBlocks } from "../markdown/document.js";
-import { terminalSelectionRowSpans } from "../../selection/terminal-selection.js";
+import { terminalSelectionRowSpans, terminalSelectionVisibleRowSpans } from "../../selection/terminal-selection.js";
 import { layoutMarkdownBlocksCached, type TuiMarkdownLayoutCache } from "../markdown/layout.js";
 import { createTuiMarkdownParser } from "../markdown/parser.js";
 import { paintMarkdownVisualRow } from "../markdown/render.js";
@@ -373,21 +373,24 @@ export const TVirtualMarkdown = defineComponent({
       const cols = Math.max(1, Math.floor(props.w));
       const top = internalScrollTop.value + clipY;
       const bottom = top + r.h;
-      // Compute spans in provider (visual row) space
-      const providerSpans = terminalSelectionRowSpans(providerRange, cols, rows.value.length);
+
+      const providerSpans = terminalSelectionVisibleRowSpans(
+        providerRange,
+        cols,
+        rows.value.length,
+        top,
+        bottom,
+      );
+
       const result: SelectedRowSpan[] = [];
       for (const span of providerSpans) {
-        // Only include rows that are currently visible
-        if (span.y < top || span.y >= bottom) continue;
         const screenY = r.y + (span.y - top);
         const screenX0 = r.x + span.x0 - clipX;
         const screenX1 = r.x + span.x1 - clipX;
-        if (screenY >= r.y && screenY < r.y + r.h && screenX1 > screenX0) {
-          result.push({
-            y: screenY,
-            x0: Math.max(r.x, screenX0),
-            x1: Math.min(r.x + r.w, screenX1),
-          });
+        const x0 = Math.max(r.x, screenX0);
+        const x1 = Math.min(r.x + r.w, screenX1);
+        if (screenY >= r.y && screenY < r.y + r.h && x1 > x0) {
+          result.push({ y: screenY, x0, x1 });
         }
       }
       return result;

--- a/src/vue/components/TerminalProvider.ts
+++ b/src/vue/components/TerminalProvider.ts
@@ -1526,6 +1526,14 @@ export const TerminalProvider = defineComponent({
         el.addEventListener("dblclick", onSelectionClickCapture, true);
         el.addEventListener("contextmenu", onSelectionClickCapture, true);
         doc.addEventListener("keydown", onSelectionKeydown, true);
+
+        // Attach DOM listeners *after* selection capture listeners so that
+        // selection's pointerdown/move handlers run first (setting suppress
+        // flags) before the EventManager's handlers check them.  This is
+        // critical at AT_TARGET where capture/bubble ordering is determined
+        // by registration order, not by phase.
+        m.attach();
+
         onScopeDispose(() => {
           el.removeEventListener("pointerdown", onSelectionPointerDown, true);
           el.removeEventListener("pointermove", onSelectionPointerMove, true);

--- a/src/vue/components/TerminalProvider.ts
+++ b/src/vue/components/TerminalProvider.ts
@@ -1086,6 +1086,7 @@ export const TerminalProvider = defineComponent({
 
         const disarmDocumentActivationSuppression = () => {
           suppressDocumentActivation = false;
+          suppressNextSelectionClick = false;
           lastSelectionActivationSource = null;
           if (suppressDocumentActivationTimer != null) {
             clearTimeout(suppressDocumentActivationTimer);
@@ -1188,9 +1189,9 @@ export const TerminalProvider = defineComponent({
             return;
           }
 
-          // Suppress exactly the first same-source activation event after drag-selection.
-          disarmDocumentActivationSuppression();
-
+          // Suppress all same-source activation events (click, dblclick,
+          // contextmenu) within the short window. Do not disarm early —
+          // the timer will expire and clean up automatically.
           event.preventDefault();
           event.stopPropagation();
           event.stopImmediatePropagation?.();
@@ -1434,8 +1435,9 @@ export const TerminalProvider = defineComponent({
 
         const onSelectionClickCapture = (event: MouseEvent) => {
           if (!selectionEnabled()) return;
-          if (!suppressNextSelectionClick) return;
-          suppressNextSelectionClick = false;
+          // Suppress all activation events (click, dblclick, contextmenu) during
+          // the suppression window, not just the first one.
+          if (!suppressNextSelectionClick && !suppressDocumentActivation) return;
           ignoreCompatibilityMouseSelectionEvents = false;
           clearCompatibilityMouseReset();
           event.preventDefault();

--- a/src/vue/components/TerminalProvider.ts
+++ b/src/vue/components/TerminalProvider.ts
@@ -1066,9 +1066,23 @@ export const TerminalProvider = defineComponent({
         let ignoreCompatibilityMouseSelectionEvents = false;
         let compatibilityMouseResetTimer: ReturnType<typeof setTimeout> | null = null;
         let activeSelectionPointerId: number | null = null;
+        let selectionPreviousUserSelect: string | null = null;
 
         let suppressDocumentActivation = false;
         let suppressDocumentActivationTimer: ReturnType<typeof setTimeout> | null = null;
+
+        const beginSelectionUserSelect = () => {
+          if (selectionPreviousUserSelect == null) {
+            selectionPreviousUserSelect = el.style.userSelect;
+          }
+          el.style.userSelect = "none";
+        };
+
+        const restoreSelectionUserSelect = () => {
+          if (selectionPreviousUserSelect == null) return;
+          el.style.userSelect = selectionPreviousUserSelect;
+          selectionPreviousUserSelect = null;
+        };
 
         const isPointerSelectionEvent = (event: MouseEvent | PointerEvent): event is PointerEvent =>
           "pointerId" in event && typeof event.pointerId === "number";
@@ -1224,7 +1238,7 @@ export const TerminalProvider = defineComponent({
           selectionStartPoint = point;
           selectionScrollOrigin = point;
           selectionLastPoint = point;
-          el.style.userSelect = "none";
+          beginSelectionUserSelect();
           if (isPointerSelectionEvent(event)) {
             activeSelectionPointerId = event.pointerId;
             addSelectionDocPointerListeners();
@@ -1282,7 +1296,7 @@ export const TerminalProvider = defineComponent({
             suppressNextSelectionClick = true;
             armDocumentActivationSuppression();
             (event as any)[SUPPRESS_TERMINAL_POINTER_UP] = true;
-            event.preventDefault();
+            suppressNativeSelectionEvent(event);
           }
           finishSelection();
         };
@@ -1293,6 +1307,7 @@ export const TerminalProvider = defineComponent({
           selectionStartPoint = null;
           selectionScrollOrigin = null;
           selectionLastPoint = null;
+          restoreSelectionUserSelect();
           clearSelectionAutoScroll();
           removeSelectionDocPointerListeners();
           removeSelectionDocListeners();
@@ -1339,17 +1354,21 @@ export const TerminalProvider = defineComponent({
             selection.update(point);
           }
           const suppressActivation = selectionDragStarted || selection.state.value.hasRange;
+          const outsideTerminal = !isEventInsideTerminal(event);
           if (suppressActivation) {
             suppressNextSelectionClick = true;
             armDocumentActivationSuppression();
             (event as any)[SUPPRESS_TERMINAL_POINTER_UP] = true;
-            event.preventDefault();
+
+            if (outsideTerminal) suppressNativeSelectionEvent(event);
+            else event.preventDefault();
           }
           selecting = false;
           activeSelectionPointerId = null;
           selectionStartPoint = null;
           selectionScrollOrigin = null;
           selectionLastPoint = null;
+          restoreSelectionUserSelect();
           clearSelectionAutoScroll();
           removeSelectionDocPointerListeners();
           if (isPointerSelectionEvent(event)) {
@@ -1392,6 +1411,7 @@ export const TerminalProvider = defineComponent({
         };
 
         const cleanupSelectionListeners = () => {
+          restoreSelectionUserSelect();
           clearSelectionAutoScroll();
           clearCompatibilityMouseReset();
           clearSuppressDocumentActivationTimer();

--- a/src/vue/components/TerminalProvider.ts
+++ b/src/vue/components/TerminalProvider.ts
@@ -1144,8 +1144,66 @@ export const TerminalProvider = defineComponent({
               // Pointer capture is best-effort; selection still works inside the terminal.
             }
           }
+          // Install document-level listeners so dragging outside the terminal
+          // element still produces mousemove/mouseup events. Pointer capture
+          // handles this for pointer events, but the mouse fallback needs
+          // explicit document listeners.
+          doc.addEventListener("mousemove", onSelectionDocMouseMove, true);
+          doc.addEventListener("mouseup", onSelectionDocMouseUp, true);
           scheduleSelectionAutoScroll();
           event.preventDefault();
+        };
+
+        const onSelectionDocMouseMove = (event: MouseEvent) => {
+          if (!selecting) return;
+          if (ignoreCompatibilityMouseSelectionEvents) return;
+          const point = cellPointFromClient(event);
+          selectionLastPoint = point;
+          if (
+            selectionStartPoint &&
+            (point.x !== selectionStartPoint.x || point.y !== selectionStartPoint.y)
+          ) {
+            selectionDragStarted = true;
+          }
+          selection.update(point);
+          scheduleSelectionAutoScroll();
+          event.preventDefault();
+        };
+
+        const onSelectionDocMouseUp = (event: MouseEvent) => {
+          if (!selecting) return;
+          if (ignoreCompatibilityMouseSelectionEvents) return;
+          const point = cellPointFromClient(event);
+          if (
+            !selectionStartPoint ||
+            point.x !== selectionStartPoint.x ||
+            point.y !== selectionStartPoint.y
+          ) {
+            selection.update(point);
+          }
+          const suppressActivation = selectionDragStarted || selection.state.value.hasRange;
+          if (suppressActivation) {
+            suppressNextSelectionClick = true;
+            (event as any)[SUPPRESS_TERMINAL_POINTER_UP] = true;
+            event.preventDefault();
+          }
+          finishSelection();
+        };
+
+        const finishSelection = () => {
+          selecting = false;
+          selectionStartPoint = null;
+          selectionScrollOrigin = null;
+          selectionLastPoint = null;
+          clearSelectionAutoScroll();
+          removeSelectionDocListeners();
+          ignoreCompatibilityMouseSelectionEvents = false;
+          void selection.finish();
+        };
+
+        const removeSelectionDocListeners = () => {
+          doc.removeEventListener("mousemove", onSelectionDocMouseMove, true);
+          doc.removeEventListener("mouseup", onSelectionDocMouseUp, true);
         };
 
         const onSelectionPointerMove = (event: MouseEvent | PointerEvent) => {
@@ -1202,6 +1260,7 @@ export const TerminalProvider = defineComponent({
           } else {
             ignoreCompatibilityMouseSelectionEvents = false;
           }
+          removeSelectionDocListeners();
           void selection.finish();
         };
 
@@ -1230,6 +1289,12 @@ export const TerminalProvider = defineComponent({
           selectionStartPoint = null;
         };
 
+        const cleanupSelectionListeners = () => {
+          clearSelectionAutoScroll();
+          clearCompatibilityMouseReset();
+          removeSelectionDocListeners();
+        };
+
         el.addEventListener("pointerdown", onSelectionPointerDown, true);
         el.addEventListener("pointermove", onSelectionPointerMove, true);
         el.addEventListener("pointerup", onSelectionPointerUp, true);
@@ -1253,8 +1318,7 @@ export const TerminalProvider = defineComponent({
           el.removeEventListener("dblclick", onSelectionClickCapture, true);
           el.removeEventListener("contextmenu", onSelectionClickCapture, true);
           doc.removeEventListener("keydown", onSelectionKeydown, true);
-          clearSelectionAutoScroll();
-          clearCompatibilityMouseReset();
+          cleanupSelectionListeners();
         });
 
         const input = imeRef.value;

--- a/src/vue/components/TerminalProvider.ts
+++ b/src/vue/components/TerminalProvider.ts
@@ -1116,6 +1116,25 @@ export const TerminalProvider = defineComponent({
           return target instanceof Node && el.contains(target);
         };
 
+        const onSelectionPointerCancel = (event: PointerEvent) => {
+          if (!selecting) return;
+          if (activeSelectionPointerId != null && event.pointerId !== activeSelectionPointerId) return;
+
+          resetSelectionGesture({ clearSelection: true });
+          event.preventDefault();
+          event.stopPropagation();
+          event.stopImmediatePropagation?.();
+        };
+
+        const onSelectionLostPointerCapture = (event: PointerEvent) => {
+          if (!selecting) return;
+          if (activeSelectionPointerId != null && event.pointerId !== activeSelectionPointerId) return;
+
+          // lostpointercapture can fire after a normal pointerup; if the gesture
+          // already finished (selecting === false), we skip. Otherwise clean up.
+          resetSelectionGesture({ clearSelection: true });
+        };
+
         // Document-level pointer listeners ensure selection continues even when
         // the pointer drags outside the terminal and setPointerCapture is
         // unavailable or unreliable.
@@ -1142,11 +1161,13 @@ export const TerminalProvider = defineComponent({
         const addSelectionDocPointerListeners = () => {
           doc.addEventListener("pointermove", onSelectionDocPointerMove, true);
           doc.addEventListener("pointerup", onSelectionDocPointerUp, true);
+          doc.addEventListener("pointercancel", onSelectionPointerCancel, true);
         };
 
         const removeSelectionDocPointerListeners = () => {
           doc.removeEventListener("pointermove", onSelectionDocPointerMove, true);
           doc.removeEventListener("pointerup", onSelectionDocPointerUp, true);
+          doc.removeEventListener("pointercancel", onSelectionPointerCancel, true);
         };
 
         const suppressNativeSelectionEvent = (event: MouseEvent | PointerEvent) => {
@@ -1526,6 +1547,8 @@ export const TerminalProvider = defineComponent({
         el.addEventListener("pointerdown", onSelectionPointerDown, true);
         el.addEventListener("pointermove", onSelectionPointerMove, true);
         el.addEventListener("pointerup", onSelectionPointerUp, true);
+        el.addEventListener("pointercancel", onSelectionPointerCancel, true);
+        el.addEventListener("lostpointercapture", onSelectionLostPointerCapture as any, true);
         el.addEventListener("mousedown", onSelectionPointerDown, true);
         el.addEventListener("mousemove", onSelectionPointerMove, true);
         el.addEventListener("mouseup", onSelectionPointerUp, true);
@@ -1546,6 +1569,8 @@ export const TerminalProvider = defineComponent({
           el.removeEventListener("pointerdown", onSelectionPointerDown, true);
           el.removeEventListener("pointermove", onSelectionPointerMove, true);
           el.removeEventListener("pointerup", onSelectionPointerUp, true);
+          el.removeEventListener("pointercancel", onSelectionPointerCancel, true);
+          el.removeEventListener("lostpointercapture", onSelectionLostPointerCapture as any, true);
           el.removeEventListener("mousedown", onSelectionPointerDown, true);
           el.removeEventListener("mousemove", onSelectionPointerMove, true);
           el.removeEventListener("mouseup", onSelectionPointerUp, true);

--- a/src/vue/components/TerminalProvider.ts
+++ b/src/vue/components/TerminalProvider.ts
@@ -365,9 +365,7 @@ export const TerminalProvider = defineComponent({
     });
     selectionRenderNodeId = selectionRenderNode.id;
 
-    watchEffect(() => {
-      if (!resolveSelectionConfig(props.selection).enabled) selection.clear();
-    });
+
 
     function queueInvalidatePlane(plane?: TerminalRenderPlane): void {
       if (!plane) {
@@ -1448,10 +1446,11 @@ export const TerminalProvider = defineComponent({
         const onSelectionKeydown = (event: KeyboardEvent) => {
           if (!selectionEnabled()) return;
           if (event.key !== "Escape") return;
-          if (!selection.state.value.active) return;
-          selection.clear();
+          if (!selection.state.value.active && !selecting) return;
+          resetSelectionGesture({ clearSelection: true });
           event.preventDefault();
           event.stopPropagation();
+          event.stopImmediatePropagation?.();
         };
 
         const onSelectionMouseLeave = () => {
@@ -1460,13 +1459,50 @@ export const TerminalProvider = defineComponent({
         };
 
         const cleanupSelectionListeners = () => {
+          resetSelectionGesture({ clearSelection: false });
+        };
+
+        const releaseSelectionPointerCapture = (): void => {
+          if (activeSelectionPointerId == null) return;
+          try {
+            el.releasePointerCapture?.(activeSelectionPointerId);
+          } catch {
+            // best-effort
+          }
+        };
+
+        type SelectionGestureCleanupOptions = Readonly<{
+          clearSelection?: boolean;
+          suppressActivation?: boolean;
+        }>;
+
+        const resetSelectionGesture = (
+          options: SelectionGestureCleanupOptions = {},
+        ): void => {
+          selecting = false;
+          selectionStartPoint = null;
+          selectionScrollOrigin = null;
+          selectionLastPoint = null;
+          selectionDragStarted = false;
+          activeSelectionPointerId = null;
+
           restoreSelectionUserSelect();
           clearSelectionAutoScroll();
           clearCompatibilityMouseReset();
-          disarmDocumentActivationSuppression();
-          activeSelectionPointerId = null;
+          releaseSelectionPointerCapture();
           removeSelectionDocPointerListeners();
           removeSelectionDocListeners();
+
+          ignoreCompatibilityMouseSelectionEvents = false;
+
+          if (!options.suppressActivation) {
+            suppressNextSelectionClick = false;
+            disarmDocumentActivationSuppression();
+          }
+
+          if (options.clearSelection ?? true) {
+            selection.clear();
+          }
         };
 
         el.addEventListener("pointerdown", onSelectionPointerDown, true);
@@ -1494,6 +1530,32 @@ export const TerminalProvider = defineComponent({
           doc.removeEventListener("keydown", onSelectionKeydown, true);
           cleanupSelectionListeners();
         });
+
+        // Watch for selection being dynamically disabled — clean up active drag gestures.
+        const stopSelectionEnabledWatch = watchEffect(() => {
+          if (selectionEnabled()) return;
+
+          if (selecting) {
+            resetSelectionGesture({ clearSelection: true });
+            return;
+          }
+
+          selection.clear();
+        });
+
+        onScopeDispose(stopSelectionEnabledWatch);
+
+        // Watch for selection becoming inactive while a drag is in progress
+        // (e.g. provider unregisters mid-drag). Clean up gesture state only;
+        // the controller already cleared the selection.
+        const stopSelectionActiveWatch = watchEffect(() => {
+          if (!selecting) return;
+          if (selection.state.value.active) return;
+
+          resetSelectionGesture({ clearSelection: false });
+        });
+
+        onScopeDispose(stopSelectionActiveWatch);
 
         const input = imeRef.value;
         const onImeFocus = () => {

--- a/src/vue/components/TerminalProvider.ts
+++ b/src/vue/components/TerminalProvider.ts
@@ -1,5 +1,6 @@
 import type { Component, PropType } from "vue";
 import type { PathPickerProvider } from "../../cli/path-provider.js";
+import { TERMINAL_RENDER_PLANES } from "../../core/render-plane.js";
 import type { TerminalRenderPlane, TerminalRenderPlanes } from "../../core/render-plane.js";
 import type { Style, Terminal } from "../../core/types.js";
 import type { EventManager, TerminalEventRecord } from "../../events/index.js";
@@ -372,6 +373,13 @@ export const TerminalProvider = defineComponent({
       pendingInvalidatePlanes.add(plane);
     }
 
+    const sortRenderPlanes = (planes: TerminalRenderPlanes): TerminalRenderPlanes => {
+      const order = new Map<TerminalRenderPlane, number>(
+        TERMINAL_RENDER_PLANES.map((plane, index) => [plane, index]),
+      );
+      return [...planes].sort((a, b) => (order.get(a) ?? 999) - (order.get(b) ?? 999));
+    };
+
     function takeActivePlanes(): TerminalRenderPlanes | null {
       if (pendingInvalidateAllPlanes) {
         pendingInvalidateAllPlanes = false;
@@ -379,7 +387,7 @@ export const TerminalProvider = defineComponent({
         return null;
       }
       if (pendingInvalidatePlanes.size === 0) return null;
-      const activePlanes = Array.from(pendingInvalidatePlanes);
+      const activePlanes = sortRenderPlanes(Array.from(pendingInvalidatePlanes));
       pendingInvalidatePlanes.clear();
       return activePlanes;
     }
@@ -1065,18 +1073,30 @@ export const TerminalProvider = defineComponent({
         const isPointerSelectionEvent = (event: MouseEvent | PointerEvent): event is PointerEvent =>
           "pointerId" in event && typeof event.pointerId === "number";
 
+        const isEventInsideTerminal = (event: Event): boolean => {
+          const target = event.target;
+          return target instanceof Node && el.contains(target);
+        };
+
         // Document-level pointer listeners ensure selection continues even when
         // the pointer drags outside the terminal and setPointerCapture is
         // unavailable or unreliable.
         const onSelectionDocPointerMove = (event: PointerEvent) => {
           if (!selecting) return;
           if (activeSelectionPointerId != null && event.pointerId !== activeSelectionPointerId) return;
+
+          // Inside terminal: container listener will handle it.
+          if (isEventInsideTerminal(event)) return;
+
           onSelectionPointerMove(event);
         };
 
         const onSelectionDocPointerUp = (event: PointerEvent) => {
           if (!selecting) return;
           if (activeSelectionPointerId != null && event.pointerId !== activeSelectionPointerId) return;
+
+          if (isEventInsideTerminal(event)) return;
+
           onSelectionPointerUp(event);
         };
 
@@ -1229,6 +1249,8 @@ export const TerminalProvider = defineComponent({
         const onSelectionDocMouseMove = (event: MouseEvent) => {
           if (!selecting) return;
           if (ignoreCompatibilityMouseSelectionEvents) return;
+          if (isEventInsideTerminal(event)) return;
+
           const point = cellPointFromClient(event);
           selectionLastPoint = point;
           if (
@@ -1245,6 +1267,8 @@ export const TerminalProvider = defineComponent({
         const onSelectionDocMouseUp = (event: MouseEvent) => {
           if (!selecting) return;
           if (ignoreCompatibilityMouseSelectionEvents) return;
+          if (isEventInsideTerminal(event)) return;
+
           const point = cellPointFromClient(event);
           if (
             !selectionStartPoint ||

--- a/src/vue/components/TerminalProvider.ts
+++ b/src/vue/components/TerminalProvider.ts
@@ -1074,6 +1074,17 @@ export const TerminalProvider = defineComponent({
         let suppressDocumentActivation = false;
         let suppressDocumentActivationTimer: ReturnType<typeof setTimeout> | null = null;
 
+        const DOCUMENT_ACTIVATION_SUPPRESSION_MS = 250;
+
+        const disarmDocumentActivationSuppression = () => {
+          suppressDocumentActivation = false;
+          if (suppressDocumentActivationTimer != null) {
+            clearTimeout(suppressDocumentActivationTimer);
+            suppressDocumentActivationTimer = null;
+          }
+          removeSelectionDocActivationListeners();
+        };
+
         const beginSelectionUserSelect = () => {
           if (selectionPreviousUserSelect == null) {
             selectionPreviousUserSelect = el.style.userSelect;
@@ -1147,17 +1158,12 @@ export const TerminalProvider = defineComponent({
           }, 0);
         };
 
-        const clearSuppressDocumentActivationTimer = () => {
-          if (suppressDocumentActivationTimer == null) return;
-          clearTimeout(suppressDocumentActivationTimer);
-          suppressDocumentActivationTimer = null;
-        };
-
         const onSelectionDocActivationCapture = (event: MouseEvent) => {
           if (!suppressDocumentActivation) return;
-          suppressDocumentActivation = false;
-          clearSuppressDocumentActivationTimer();
-          removeSelectionDocActivationListeners();
+
+          // Suppress exactly the first activation event after drag-selection.
+          disarmDocumentActivationSuppression();
+
           event.preventDefault();
           event.stopPropagation();
           event.stopImmediatePropagation?.();
@@ -1171,15 +1177,18 @@ export const TerminalProvider = defineComponent({
 
         const armDocumentActivationSuppression = () => {
           suppressDocumentActivation = true;
+
           doc.addEventListener("click", onSelectionDocActivationCapture, true);
           doc.addEventListener("dblclick", onSelectionDocActivationCapture, true);
           doc.addEventListener("contextmenu", onSelectionDocActivationCapture, true);
-          clearSuppressDocumentActivationTimer();
+
+          if (suppressDocumentActivationTimer != null) {
+            clearTimeout(suppressDocumentActivationTimer);
+          }
+
           suppressDocumentActivationTimer = setTimeout(() => {
-            suppressDocumentActivation = false;
-            removeSelectionDocActivationListeners();
-            suppressDocumentActivationTimer = null;
-          }, 0);
+            disarmDocumentActivationSuppression();
+          }, DOCUMENT_ACTIVATION_SUPPRESSION_MS);
         };
 
         const clearSelectionAutoScroll = () => {
@@ -1417,12 +1426,10 @@ export const TerminalProvider = defineComponent({
           restoreSelectionUserSelect();
           clearSelectionAutoScroll();
           clearCompatibilityMouseReset();
-          clearSuppressDocumentActivationTimer();
+          disarmDocumentActivationSuppression();
           activeSelectionPointerId = null;
           removeSelectionDocPointerListeners();
           removeSelectionDocListeners();
-          removeSelectionDocActivationListeners();
-          suppressDocumentActivation = false;
         };
 
         el.addEventListener("pointerdown", onSelectionPointerDown, true);

--- a/src/vue/components/TerminalProvider.ts
+++ b/src/vue/components/TerminalProvider.ts
@@ -10,6 +10,7 @@ import type {
   SelectionTextProvider,
   TerminalSelectionCopyPayload,
   TerminalSelectionOptions,
+  TerminalSelectionRefreshOptions,
 } from "../../selection/terminal-selection.js";
 import type {
   ImeAnchor,
@@ -189,7 +190,9 @@ export const TerminalProvider = defineComponent({
       default: false,
     },
   },
-  emits: ["selectionCopy"],
+  emits: {
+    selectionCopy: (_payload: TerminalSelectionCopyPayload) => true,
+  },
   setup(props, { slots, emit }) {
     const terminal: Terminal = createTerminal({
       cols: props.cols,
@@ -302,8 +305,8 @@ export const TerminalProvider = defineComponent({
         selectionCopyHandlers.add(handler);
         return () => selectionCopyHandlers.delete(handler);
       },
-      refresh() {
-        selection.refresh();
+      refresh(options) {
+        selection.refresh(options);
       },
       clear() {
         selection.clear();

--- a/src/vue/components/TerminalProvider.ts
+++ b/src/vue/components/TerminalProvider.ts
@@ -67,6 +67,11 @@ import {
 import { clearTextCaches } from "../utils/text.js";
 import { defaultTInputHostPlugin } from "./input/plugins/hostPlugin.js";
 import { TRenderPlane } from "./TRenderPlane.js";
+import {
+  SUPPRESS_TERMINAL_POINTER_DOWN,
+  SUPPRESS_TERMINAL_POINTER_MOVE,
+  SUPPRESS_TERMINAL_POINTER_UP,
+} from "../../events/manager/selection-suppression.js";
 
 interface Portal {
   id: string;
@@ -107,10 +112,6 @@ function shallowEqualRecord(a: Record<string, unknown>, b: Record<string, unknow
 }
 
 let portalId = 0;
-
-const SUPPRESS_TERMINAL_POINTER_UP = "__vueTuiSuppressTerminalPointerUp";
-const SUPPRESS_TERMINAL_POINTER_DOWN = "__vueTuiSuppressTerminalPointerDown";
-const SUPPRESS_TERMINAL_POINTER_MOVE = "__vueTuiSuppressTerminalPointerMove";
 
 type ResolvedTerminalSelectionConfig = Readonly<{
   enabled: boolean;
@@ -1125,7 +1126,7 @@ export const TerminalProvider = defineComponent({
           // Inside terminal: container listener will handle it.
           if (isEventInsideTerminal(event)) return;
 
-          (event as any).__vueTuiSuppressTerminalPointerMove = true;
+          (event as any)[SUPPRESS_TERMINAL_POINTER_MOVE] = true;
           onSelectionPointerMove(event);
         };
 
@@ -1301,7 +1302,7 @@ export const TerminalProvider = defineComponent({
           doc.addEventListener("mousemove", onSelectionDocMouseMove, true);
           doc.addEventListener("mouseup", onSelectionDocMouseUp, true);
           scheduleSelectionAutoScroll();
-          (event as any).__vueTuiSuppressTerminalPointerDown = true;
+          (event as any)[SUPPRESS_TERMINAL_POINTER_DOWN] = true;
           event.preventDefault();
         };
 
@@ -1320,7 +1321,7 @@ export const TerminalProvider = defineComponent({
           }
           selection.update(point);
           scheduleSelectionAutoScroll();
-          (event as any).__vueTuiSuppressTerminalPointerMove = true;
+          (event as any)[SUPPRESS_TERMINAL_POINTER_MOVE] = true;
           event.preventDefault();
         };
 
@@ -1382,7 +1383,7 @@ export const TerminalProvider = defineComponent({
           }
           selection.update(point);
           scheduleSelectionAutoScroll();
-          (event as any).__vueTuiSuppressTerminalPointerMove = true;
+          (event as any)[SUPPRESS_TERMINAL_POINTER_MOVE] = true;
           event.preventDefault();
         };
 

--- a/src/vue/components/TerminalProvider.ts
+++ b/src/vue/components/TerminalProvider.ts
@@ -719,6 +719,7 @@ export const TerminalProvider = defineComponent({
           },
           textInputTarget: imeRef.value,
           debugIme: props.debugIme,
+          deferAttach: true,
         });
         events.value = m;
 

--- a/src/vue/components/TerminalProvider.ts
+++ b/src/vue/components/TerminalProvider.ts
@@ -297,8 +297,9 @@ export const TerminalProvider = defineComponent({
       registerTextProvider(provider: SelectionTextProvider) {
         selectionTextProviders.set(provider.id, provider);
         return () => {
-          if (selectionTextProviders.get(provider.id) === provider)
-            selectionTextProviders.delete(provider.id);
+          if (selectionTextProviders.get(provider.id) !== provider) return;
+          selectionTextProviders.delete(provider.id);
+          selection.clearProvider(provider.id);
         };
       },
       onCopy(handler: (payload: TerminalSelectionCopyPayload) => void) {

--- a/src/vue/components/TerminalProvider.ts
+++ b/src/vue/components/TerminalProvider.ts
@@ -10,7 +10,6 @@ import type {
   SelectionTextProvider,
   TerminalSelectionCopyPayload,
   TerminalSelectionOptions,
-  TerminalSelectionRefreshOptions,
 } from "../../selection/terminal-selection.js";
 import type {
   ImeAnchor,
@@ -365,8 +364,6 @@ export const TerminalProvider = defineComponent({
       paint: selection.paint,
     });
     selectionRenderNodeId = selectionRenderNode.id;
-
-
 
     function queueInvalidatePlane(plane?: TerminalRenderPlane): void {
       if (!plane) {
@@ -1080,9 +1077,8 @@ export const TerminalProvider = defineComponent({
         const ACTIVATION_SUPPRESS_WINDOW_MS = 250;
         const ACTIVATION_SUPPRESS_DISTANCE_PX = 4;
 
-        let lastSelectionActivationSource:
-          | { clientX: number; clientY: number; at: number }
-          | null = null;
+        let lastSelectionActivationSource: { clientX: number; clientY: number; at: number } | null =
+          null;
 
         const disarmDocumentActivationSuppression = () => {
           suppressDocumentActivation = false;
@@ -1118,7 +1114,8 @@ export const TerminalProvider = defineComponent({
 
         const onSelectionPointerCancel = (event: PointerEvent) => {
           if (!selecting) return;
-          if (activeSelectionPointerId != null && event.pointerId !== activeSelectionPointerId) return;
+          if (activeSelectionPointerId != null && event.pointerId !== activeSelectionPointerId)
+            return;
 
           resetSelectionGesture({ clearSelection: true });
           event.preventDefault();
@@ -1128,7 +1125,8 @@ export const TerminalProvider = defineComponent({
 
         const onSelectionLostPointerCapture = (event: PointerEvent) => {
           if (!selecting) return;
-          if (activeSelectionPointerId != null && event.pointerId !== activeSelectionPointerId) return;
+          if (activeSelectionPointerId != null && event.pointerId !== activeSelectionPointerId)
+            return;
 
           // lostpointercapture can fire after a normal pointerup; if the gesture
           // already finished (selecting === false), we skip. Otherwise clean up.
@@ -1140,7 +1138,8 @@ export const TerminalProvider = defineComponent({
         // unavailable or unreliable.
         const onSelectionDocPointerMove = (event: PointerEvent) => {
           if (!selecting) return;
-          if (activeSelectionPointerId != null && event.pointerId !== activeSelectionPointerId) return;
+          if (activeSelectionPointerId != null && event.pointerId !== activeSelectionPointerId)
+            return;
 
           // Inside terminal: container listener will handle it.
           if (isEventInsideTerminal(event)) return;
@@ -1151,7 +1150,8 @@ export const TerminalProvider = defineComponent({
 
         const onSelectionDocPointerUp = (event: PointerEvent) => {
           if (!selecting) return;
-          if (activeSelectionPointerId != null && event.pointerId !== activeSelectionPointerId) return;
+          if (activeSelectionPointerId != null && event.pointerId !== activeSelectionPointerId)
+            return;
 
           if (isEventInsideTerminal(event)) return;
 
@@ -1495,7 +1495,9 @@ export const TerminalProvider = defineComponent({
           resetSelectionGesture({ clearSelection: false });
         };
 
-        const releaseSelectionPointerCapture = (pointerId: number | null = activeSelectionPointerId): void => {
+        const releaseSelectionPointerCapture = (
+          pointerId: number | null = activeSelectionPointerId,
+        ): void => {
           if (pointerId == null) return;
           try {
             el.releasePointerCapture?.(pointerId);
@@ -1509,9 +1511,7 @@ export const TerminalProvider = defineComponent({
           suppressActivation?: boolean;
         }>;
 
-        const resetSelectionGesture = (
-          options: SelectionGestureCleanupOptions = {},
-        ): void => {
+        const resetSelectionGesture = (options: SelectionGestureCleanupOptions = {}): void => {
           const pointerId = activeSelectionPointerId;
 
           selecting = false;

--- a/src/vue/components/TerminalProvider.ts
+++ b/src/vue/components/TerminalProvider.ts
@@ -1473,10 +1473,10 @@ export const TerminalProvider = defineComponent({
           resetSelectionGesture({ clearSelection: false });
         };
 
-        const releaseSelectionPointerCapture = (): void => {
-          if (activeSelectionPointerId == null) return;
+        const releaseSelectionPointerCapture = (pointerId: number | null = activeSelectionPointerId): void => {
+          if (pointerId == null) return;
           try {
-            el.releasePointerCapture?.(activeSelectionPointerId);
+            el.releasePointerCapture?.(pointerId);
           } catch {
             // best-effort
           }
@@ -1490,17 +1490,23 @@ export const TerminalProvider = defineComponent({
         const resetSelectionGesture = (
           options: SelectionGestureCleanupOptions = {},
         ): void => {
+          const pointerId = activeSelectionPointerId;
+
           selecting = false;
           selectionStartPoint = null;
           selectionScrollOrigin = null;
           selectionLastPoint = null;
           selectionDragStarted = false;
+
+          // Release pointer capture before clearing activeSelectionPointerId
+          // so the correct pointerId is used even when cleanup is triggered
+          // by Escape, selection being disabled, or component unmount.
+          releaseSelectionPointerCapture(pointerId);
           activeSelectionPointerId = null;
 
           restoreSelectionUserSelect();
           clearSelectionAutoScroll();
           clearCompatibilityMouseReset();
-          releaseSelectionPointerCapture();
           removeSelectionDocPointerListeners();
           removeSelectionDocListeners();
 

--- a/src/vue/components/TerminalProvider.ts
+++ b/src/vue/components/TerminalProvider.ts
@@ -109,6 +109,8 @@ function shallowEqualRecord(a: Record<string, unknown>, b: Record<string, unknow
 let portalId = 0;
 
 const SUPPRESS_TERMINAL_POINTER_UP = "__vueTuiSuppressTerminalPointerUp";
+const SUPPRESS_TERMINAL_POINTER_DOWN = "__vueTuiSuppressTerminalPointerDown";
+const SUPPRESS_TERMINAL_POINTER_MOVE = "__vueTuiSuppressTerminalPointerMove";
 
 type ResolvedTerminalSelectionConfig = Readonly<{
   enabled: boolean;
@@ -1075,10 +1077,16 @@ export const TerminalProvider = defineComponent({
         let suppressDocumentActivation = false;
         let suppressDocumentActivationTimer: ReturnType<typeof setTimeout> | null = null;
 
-        const DOCUMENT_ACTIVATION_SUPPRESSION_MS = 250;
+        const ACTIVATION_SUPPRESS_WINDOW_MS = 250;
+        const ACTIVATION_SUPPRESS_DISTANCE_PX = 4;
+
+        let lastSelectionActivationSource:
+          | { clientX: number; clientY: number; at: number }
+          | null = null;
 
         const disarmDocumentActivationSuppression = () => {
           suppressDocumentActivation = false;
+          lastSelectionActivationSource = null;
           if (suppressDocumentActivationTimer != null) {
             clearTimeout(suppressDocumentActivationTimer);
             suppressDocumentActivationTimer = null;
@@ -1117,6 +1125,7 @@ export const TerminalProvider = defineComponent({
           // Inside terminal: container listener will handle it.
           if (isEventInsideTerminal(event)) return;
 
+          (event as any).__vueTuiSuppressTerminalPointerMove = true;
           onSelectionPointerMove(event);
         };
 
@@ -1159,10 +1168,27 @@ export const TerminalProvider = defineComponent({
           }, 0);
         };
 
-        const onSelectionDocActivationCapture = (event: MouseEvent) => {
-          if (!suppressDocumentActivation) return;
+        const shouldSuppressSelectionActivation = (event: MouseEvent): boolean => {
+          if (!suppressDocumentActivation || !lastSelectionActivationSource) return false;
 
-          // Suppress exactly the first activation event after drag-selection.
+          const dt = Date.now() - lastSelectionActivationSource.at;
+          const dx = Math.abs(event.clientX - lastSelectionActivationSource.clientX);
+          const dy = Math.abs(event.clientY - lastSelectionActivationSource.clientY);
+
+          return (
+            dt <= ACTIVATION_SUPPRESS_WINDOW_MS &&
+            dx <= ACTIVATION_SUPPRESS_DISTANCE_PX &&
+            dy <= ACTIVATION_SUPPRESS_DISTANCE_PX
+          );
+        };
+
+        const onSelectionDocActivationCapture = (event: MouseEvent) => {
+          if (!shouldSuppressSelectionActivation(event)) {
+            disarmDocumentActivationSuppression();
+            return;
+          }
+
+          // Suppress exactly the first same-source activation event after drag-selection.
           disarmDocumentActivationSuppression();
 
           event.preventDefault();
@@ -1176,8 +1202,13 @@ export const TerminalProvider = defineComponent({
           doc.removeEventListener("contextmenu", onSelectionDocActivationCapture, true);
         };
 
-        const armDocumentActivationSuppression = () => {
+        const armDocumentActivationSuppression = (event: MouseEvent | PointerEvent) => {
           suppressDocumentActivation = true;
+          lastSelectionActivationSource = {
+            clientX: event.clientX,
+            clientY: event.clientY,
+            at: Date.now(),
+          };
 
           doc.addEventListener("click", onSelectionDocActivationCapture, true);
           doc.addEventListener("dblclick", onSelectionDocActivationCapture, true);
@@ -1189,7 +1220,7 @@ export const TerminalProvider = defineComponent({
 
           suppressDocumentActivationTimer = setTimeout(() => {
             disarmDocumentActivationSuppression();
-          }, DOCUMENT_ACTIVATION_SUPPRESSION_MS);
+          }, ACTIVATION_SUPPRESS_WINDOW_MS);
         };
 
         const clearSelectionAutoScroll = () => {
@@ -1270,6 +1301,7 @@ export const TerminalProvider = defineComponent({
           doc.addEventListener("mousemove", onSelectionDocMouseMove, true);
           doc.addEventListener("mouseup", onSelectionDocMouseUp, true);
           scheduleSelectionAutoScroll();
+          (event as any).__vueTuiSuppressTerminalPointerDown = true;
           event.preventDefault();
         };
 
@@ -1288,6 +1320,7 @@ export const TerminalProvider = defineComponent({
           }
           selection.update(point);
           scheduleSelectionAutoScroll();
+          (event as any).__vueTuiSuppressTerminalPointerMove = true;
           event.preventDefault();
         };
 
@@ -1307,7 +1340,7 @@ export const TerminalProvider = defineComponent({
           const suppressActivation = selectionDragStarted || selection.state.value.hasRange;
           if (suppressActivation) {
             suppressNextSelectionClick = true;
-            armDocumentActivationSuppression();
+            armDocumentActivationSuppression(event);
             (event as any)[SUPPRESS_TERMINAL_POINTER_UP] = true;
             suppressNativeSelectionEvent(event);
           }
@@ -1349,6 +1382,7 @@ export const TerminalProvider = defineComponent({
           }
           selection.update(point);
           scheduleSelectionAutoScroll();
+          (event as any).__vueTuiSuppressTerminalPointerMove = true;
           event.preventDefault();
         };
 
@@ -1370,7 +1404,7 @@ export const TerminalProvider = defineComponent({
           const outsideTerminal = !isEventInsideTerminal(event);
           if (suppressActivation) {
             suppressNextSelectionClick = true;
-            armDocumentActivationSuppression();
+            armDocumentActivationSuppression(event);
             (event as any)[SUPPRESS_TERMINAL_POINTER_UP] = true;
 
             if (outsideTerminal) suppressNativeSelectionEvent(event);

--- a/src/vue/components/TerminalProvider.ts
+++ b/src/vue/components/TerminalProvider.ts
@@ -1052,6 +1052,9 @@ export const TerminalProvider = defineComponent({
         let ignoreCompatibilityMouseSelectionEvents = false;
         let compatibilityMouseResetTimer: ReturnType<typeof setTimeout> | null = null;
 
+        let suppressDocumentActivation = false;
+        let suppressDocumentActivationTimer: ReturnType<typeof setTimeout> | null = null;
+
         const isPointerSelectionEvent = (event: MouseEvent | PointerEvent): event is PointerEvent =>
           "pointerId" in event && typeof event.pointerId === "number";
 
@@ -1072,6 +1075,41 @@ export const TerminalProvider = defineComponent({
           compatibilityMouseResetTimer = setTimeout(() => {
             ignoreCompatibilityMouseSelectionEvents = false;
             compatibilityMouseResetTimer = null;
+          }, 0);
+        };
+
+        const clearSuppressDocumentActivationTimer = () => {
+          if (suppressDocumentActivationTimer == null) return;
+          clearTimeout(suppressDocumentActivationTimer);
+          suppressDocumentActivationTimer = null;
+        };
+
+        const onSelectionDocActivationCapture = (event: MouseEvent) => {
+          if (!suppressDocumentActivation) return;
+          suppressDocumentActivation = false;
+          clearSuppressDocumentActivationTimer();
+          removeSelectionDocActivationListeners();
+          event.preventDefault();
+          event.stopPropagation();
+          event.stopImmediatePropagation?.();
+        };
+
+        const removeSelectionDocActivationListeners = () => {
+          doc.removeEventListener("click", onSelectionDocActivationCapture, true);
+          doc.removeEventListener("dblclick", onSelectionDocActivationCapture, true);
+          doc.removeEventListener("contextmenu", onSelectionDocActivationCapture, true);
+        };
+
+        const armDocumentActivationSuppression = () => {
+          suppressDocumentActivation = true;
+          doc.addEventListener("click", onSelectionDocActivationCapture, true);
+          doc.addEventListener("dblclick", onSelectionDocActivationCapture, true);
+          doc.addEventListener("contextmenu", onSelectionDocActivationCapture, true);
+          clearSuppressDocumentActivationTimer();
+          suppressDocumentActivationTimer = setTimeout(() => {
+            suppressDocumentActivation = false;
+            removeSelectionDocActivationListeners();
+            suppressDocumentActivationTimer = null;
           }, 0);
         };
 
@@ -1184,6 +1222,7 @@ export const TerminalProvider = defineComponent({
           const suppressActivation = selectionDragStarted || selection.state.value.hasRange;
           if (suppressActivation) {
             suppressNextSelectionClick = true;
+            armDocumentActivationSuppression();
             (event as any)[SUPPRESS_TERMINAL_POINTER_UP] = true;
             event.preventDefault();
           }
@@ -1242,6 +1281,7 @@ export const TerminalProvider = defineComponent({
           const suppressActivation = selectionDragStarted || selection.state.value.hasRange;
           if (suppressActivation) {
             suppressNextSelectionClick = true;
+            armDocumentActivationSuppression();
             (event as any)[SUPPRESS_TERMINAL_POINTER_UP] = true;
             event.preventDefault();
           }
@@ -1292,7 +1332,10 @@ export const TerminalProvider = defineComponent({
         const cleanupSelectionListeners = () => {
           clearSelectionAutoScroll();
           clearCompatibilityMouseReset();
+          clearSuppressDocumentActivationTimer();
           removeSelectionDocListeners();
+          removeSelectionDocActivationListeners();
+          suppressDocumentActivation = false;
         };
 
         el.addEventListener("pointerdown", onSelectionPointerDown, true);

--- a/src/vue/components/TerminalProvider.ts
+++ b/src/vue/components/TerminalProvider.ts
@@ -1436,6 +1436,16 @@ export const TerminalProvider = defineComponent({
           // Suppress all activation events (click, dblclick, contextmenu) during
           // the suppression window, not just the first one.
           if (!suppressNextSelectionClick && !suppressDocumentActivation) return;
+
+          // If the click is at a different location from the selection source,
+          // it is an unrelated terminal-internal click — don't suppress it.
+          if (lastSelectionActivationSource && !shouldSuppressSelectionActivation(event)) {
+            disarmDocumentActivationSuppression();
+            ignoreCompatibilityMouseSelectionEvents = false;
+            clearCompatibilityMouseReset();
+            return;
+          }
+
           ignoreCompatibilityMouseSelectionEvents = false;
           clearCompatibilityMouseReset();
           event.preventDefault();

--- a/src/vue/components/TerminalProvider.ts
+++ b/src/vue/components/TerminalProvider.ts
@@ -301,6 +301,12 @@ export const TerminalProvider = defineComponent({
         selectionCopyHandlers.add(handler);
         return () => selectionCopyHandlers.delete(handler);
       },
+      refresh() {
+        selection.refresh();
+      },
+      clear() {
+        selection.clear();
+      },
     } as const;
     const selectionOverlay = getPlaneTerminal(terminal, "overlay");
     let selectionRenderNodeId: string | null = null;
@@ -1051,12 +1057,38 @@ export const TerminalProvider = defineComponent({
         let suppressNextSelectionClick = false;
         let ignoreCompatibilityMouseSelectionEvents = false;
         let compatibilityMouseResetTimer: ReturnType<typeof setTimeout> | null = null;
+        let activeSelectionPointerId: number | null = null;
 
         let suppressDocumentActivation = false;
         let suppressDocumentActivationTimer: ReturnType<typeof setTimeout> | null = null;
 
         const isPointerSelectionEvent = (event: MouseEvent | PointerEvent): event is PointerEvent =>
           "pointerId" in event && typeof event.pointerId === "number";
+
+        // Document-level pointer listeners ensure selection continues even when
+        // the pointer drags outside the terminal and setPointerCapture is
+        // unavailable or unreliable.
+        const onSelectionDocPointerMove = (event: PointerEvent) => {
+          if (!selecting) return;
+          if (activeSelectionPointerId != null && event.pointerId !== activeSelectionPointerId) return;
+          onSelectionPointerMove(event);
+        };
+
+        const onSelectionDocPointerUp = (event: PointerEvent) => {
+          if (!selecting) return;
+          if (activeSelectionPointerId != null && event.pointerId !== activeSelectionPointerId) return;
+          onSelectionPointerUp(event);
+        };
+
+        const addSelectionDocPointerListeners = () => {
+          doc.addEventListener("pointermove", onSelectionDocPointerMove, true);
+          doc.addEventListener("pointerup", onSelectionDocPointerUp, true);
+        };
+
+        const removeSelectionDocPointerListeners = () => {
+          doc.removeEventListener("pointermove", onSelectionDocPointerMove, true);
+          doc.removeEventListener("pointerup", onSelectionDocPointerUp, true);
+        };
 
         const suppressNativeSelectionEvent = (event: MouseEvent | PointerEvent) => {
           event.preventDefault();
@@ -1174,12 +1206,14 @@ export const TerminalProvider = defineComponent({
           selectionLastPoint = point;
           el.style.userSelect = "none";
           if (isPointerSelectionEvent(event)) {
+            activeSelectionPointerId = event.pointerId;
+            addSelectionDocPointerListeners();
             ignoreCompatibilityMouseSelectionEvents = true;
             clearCompatibilityMouseReset();
             try {
               el.setPointerCapture?.(event.pointerId);
             } catch {
-              // Pointer capture is best-effort; selection still works inside the terminal.
+              // Document-level pointer listeners are the fallback.
             }
           }
           // Install document-level listeners so dragging outside the terminal
@@ -1231,10 +1265,12 @@ export const TerminalProvider = defineComponent({
 
         const finishSelection = () => {
           selecting = false;
+          activeSelectionPointerId = null;
           selectionStartPoint = null;
           selectionScrollOrigin = null;
           selectionLastPoint = null;
           clearSelectionAutoScroll();
+          removeSelectionDocPointerListeners();
           removeSelectionDocListeners();
           ignoreCompatibilityMouseSelectionEvents = false;
           void selection.finish();
@@ -1286,10 +1322,12 @@ export const TerminalProvider = defineComponent({
             event.preventDefault();
           }
           selecting = false;
+          activeSelectionPointerId = null;
           selectionStartPoint = null;
           selectionScrollOrigin = null;
           selectionLastPoint = null;
           clearSelectionAutoScroll();
+          removeSelectionDocPointerListeners();
           if (isPointerSelectionEvent(event)) {
             try {
               el.releasePointerCapture?.(event.pointerId);
@@ -1333,6 +1371,8 @@ export const TerminalProvider = defineComponent({
           clearSelectionAutoScroll();
           clearCompatibilityMouseReset();
           clearSuppressDocumentActivationTimer();
+          activeSelectionPointerId = null;
+          removeSelectionDocPointerListeners();
           removeSelectionDocListeners();
           removeSelectionDocActivationListeners();
           suppressDocumentActivation = false;

--- a/src/vue/context.ts
+++ b/src/vue/context.ts
@@ -6,6 +6,7 @@ import type { EventManager, Rect } from "../events/index.js";
 import type {
   SelectionTextProvider,
   TerminalSelectionCopyPayload,
+  TerminalSelectionRefreshOptions,
 } from "../selection/terminal-selection.js";
 import type { RendererCapabilities, TerminalRendererLike } from "../renderer/index.js";
 import type { TraceStore } from "../observability/trace.js";
@@ -107,7 +108,7 @@ export type TerminalRuntime = Readonly<{
 export type TerminalSelectionContext = Readonly<{
   registerTextProvider: (provider: SelectionTextProvider) => () => void;
   onCopy: (handler: (payload: TerminalSelectionCopyPayload) => void) => () => void;
-  refresh: () => void;
+  refresh: (options?: TerminalSelectionRefreshOptions) => void;
   clear: () => void;
 }>;
 

--- a/src/vue/context.ts
+++ b/src/vue/context.ts
@@ -107,6 +107,8 @@ export type TerminalRuntime = Readonly<{
 export type TerminalSelectionContext = Readonly<{
   registerTextProvider: (provider: SelectionTextProvider) => () => void;
   onCopy: (handler: (payload: TerminalSelectionCopyPayload) => void) => () => void;
+  refresh: () => void;
+  clear: () => void;
 }>;
 
 export type ImeAnchor = Readonly<{

--- a/test/package-exports.test.ts
+++ b/test/package-exports.test.ts
@@ -75,6 +75,7 @@ describe("package exports", () => {
     expect(root.createOsc52ClipboardProvider).toBeTruthy();
     expect(root.createFramePerfStore).toBeTruthy();
     expect(root.framePerfNow).toBeTruthy();
+    expect(root.terminalSelectionVisibleRowSpans).toBeTruthy();
     expect("TMarkdownText" in experimental).toBe(false);
     expect(experimental.TVirtualList).toBeTruthy();
     expect("TVirtualMarkdown" in experimental).toBe(false);

--- a/test/terminal-selection-cli.test.ts
+++ b/test/terminal-selection-cli.test.ts
@@ -75,7 +75,7 @@ describe("createTerminalApp selection", () => {
       expect(writes).toEqual(["select"]);
       expect(copies).toMatchObject([{ text: "select", rows: 1, ok: true }]);
       expect(contextCopies).toMatchObject([{ text: "select", rows: 1, ok: true }]);
-      expect(onPointerdown).toHaveBeenCalledTimes(1);
+      expect(onPointerdown).not.toHaveBeenCalled();
       expect(onPointerup).not.toHaveBeenCalled();
       expect(onClick).not.toHaveBeenCalled();
       expect(app.terminal.getCell(0, 0).style.inverse).toBe(true);
@@ -179,6 +179,56 @@ describe("createTerminalApp selection", () => {
     } finally {
       app.dispose();
       vi.useRealTimers();
+    }
+  });
+
+  it("does not dispatch pointerdown/pointermove to node when selection starts a drag", async () => {
+    const onPointerdown = vi.fn();
+    const onPointermove = vi.fn();
+    const onClick = vi.fn();
+    const App = defineComponent({
+      name: "CliPointerSuppressProbe",
+      setup() {
+        return () =>
+          h(
+            TView,
+            {
+              x: 0,
+              y: 0,
+              w: 10,
+              h: 1,
+              selectable: true,
+              onPointerdown,
+              onPointermove,
+              onClick,
+            },
+            () => h(TText, { x: 0, y: 0, value: "select me", style: { fg: "whiteBright" } }),
+          );
+      },
+    });
+    const app = createTerminalApp({
+      cols: 12,
+      rows: 2,
+      component: App,
+      selection: { autoCopy: false },
+    });
+
+    try {
+      app.mount();
+      await settle();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "pointerdown", cellX: 0, cellY: 0, button: 0 });
+      app.events.dispatch({ type: "pointermove", cellX: 5, cellY: 0, button: 0 });
+      app.events.dispatch({ type: "pointerup", cellX: 5, cellY: 0, button: 0 });
+      app.events.dispatch({ type: "click", cellX: 5, cellY: 0, button: 0 });
+      await settle();
+
+      expect(onPointerdown).not.toHaveBeenCalled();
+      expect(onPointermove).not.toHaveBeenCalled();
+      expect(onClick).not.toHaveBeenCalled();
+    } finally {
+      app.dispose();
     }
   });
 });

--- a/test/terminal-selection-provider.test.ts
+++ b/test/terminal-selection-provider.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import { TLogView } from "../src/experimental.js";
 import { TVirtualMarkdown } from "../src/markdown.js";
-import { defineComponent, h, mountTerminal, nextTick, ref, TInputBox, TText } from "./ui-regressions-support";
-import { TView, TVirtualList } from "./ui-regressions-support";
+import { defineComponent, h, mountTerminal, nextTick, ref, TInputBox, TText, watchEffect } from "./ui-regressions-support";
+import { createApp, TerminalProvider, TView, TVirtualList, useTerminal } from "./ui-regressions-support";
 
 function installNavigatorClipboard(writes: string[]) {
   const previous = (navigator as any).clipboard;
@@ -1240,6 +1240,262 @@ describe("TerminalProvider selection", () => {
     } finally {
       mounted.unmount();
       restore();
+    }
+  });
+
+  it("cleans up gesture state when Escape is pressed during drag", async () => {
+    const mounted = await mountTerminal(
+      () => h(TText, { x: 0, y: 0, value: "abcdef", style: { fg: "whiteBright" } }),
+      8,
+      2,
+      { selection: { autoCopy: false } },
+    );
+
+    try {
+      const container = mounted.container()!;
+      // Start drag — do not release
+      container.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 1, clientY: 0, bubbles: true }),
+      );
+      container.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 4, clientY: 0, bubbles: true }),
+      );
+
+      // Press Escape mid-drag
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", code: "Escape", bubbles: true }),
+      );
+      await nextTick();
+
+      // After Escape, the element's user-select should be restored (not "none")
+      expect(container.style.userSelect).not.toBe("none");
+
+      // A subsequent plain click on a selectable view should still work
+      const onClick = vi.fn();
+      const mounted2 = await mountTerminal(
+        () =>
+          h(
+            TView,
+            { x: 0, y: 0, w: 10, h: 1, selectable: true, onClick },
+            () => h(TText, { x: 0, y: 0, value: "click me" }),
+          ),
+        12,
+        2,
+        { selection: true },
+      );
+
+      try {
+        const c2 = mounted2.container()!;
+        c2.dispatchEvent(new MouseEvent("mousedown", { clientX: 2, clientY: 0, bubbles: true }));
+        c2.dispatchEvent(new MouseEvent("mouseup", { clientX: 2, clientY: 0, bubbles: true }));
+        c2.dispatchEvent(new MouseEvent("click", { clientX: 2, clientY: 0, bubbles: true }));
+        await settleClipboard();
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+      } finally {
+        mounted2.unmount();
+      }
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("cleans up gesture state when selection is disabled during drag", async () => {
+    const selectionProp = ref<true | false>(true);
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+
+    const exposed = {
+      terminal: null as any,
+      container: null as HTMLElement | null,
+    };
+
+    const App = defineComponent({
+      setup() {
+        return () =>
+          h(
+            TerminalProvider,
+            { cols: 8, rows: 2, selection: selectionProp.value },
+            {
+              default: () => [
+                h(
+                  defineComponent({
+                    name: "ExposeTerminal",
+                    setup() {
+                      const ctx = useTerminal();
+                      exposed.terminal = ctx.terminal;
+                      watchEffect(() => {
+                        exposed.container = ctx.renderer.value?.container ?? null;
+                      });
+                      return () =>
+                        h(TText, {
+                          x: 0,
+                          y: 0,
+                          value: "abcdef",
+                          style: { fg: "whiteBright" },
+                        });
+                    },
+                  }),
+                ),
+              ],
+            },
+          );
+      },
+    });
+
+    const app = createApp(App);
+    app.mount(root);
+    await nextTick();
+    await nextTick();
+
+    try {
+      const container = exposed.container!;
+      // Start drag
+      container.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 1, clientY: 0, bubbles: true }),
+      );
+      container.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 4, clientY: 0, bubbles: true }),
+      );
+
+      // Disable selection mid-drag
+      selectionProp.value = false;
+      await nextTick();
+      await nextTick();
+
+      // user-select should be restored
+      expect(container.style.userSelect).not.toBe("none");
+
+      // Verify a new mount with selection works without leftover state
+      const mounted2 = await mountTerminal(
+        () => h(TText, { x: 0, y: 0, value: "test", style: { fg: "whiteBright" } }),
+        8,
+        2,
+        { selection: true },
+      );
+
+      try {
+        const c2 = mounted2.container()!;
+        c2.dispatchEvent(new MouseEvent("mousedown", { clientX: 0, clientY: 0, bubbles: true }));
+        c2.dispatchEvent(new MouseEvent("mousemove", { clientX: 3, clientY: 0, bubbles: true }));
+        c2.dispatchEvent(new MouseEvent("mouseup", { clientX: 3, clientY: 0, bubbles: true }));
+        await settleClipboard();
+
+        // Should be able to select in the new mount without leftover state
+        expect(mounted2.terminal.getCell(0, 0).style.inverse).toBe(true);
+      } finally {
+        mounted2.unmount();
+      }
+    } finally {
+      app.unmount();
+      root.remove();
+    }
+  });
+
+  it("cleans up document listeners on unmount during drag", async () => {
+    let mounted = await mountTerminal(
+      () => h(TText, { x: 0, y: 0, value: "abcdef", style: { fg: "whiteBright" } }),
+      8,
+      2,
+      { selection: { autoCopy: false } },
+    );
+
+    const container = mounted.container()!;
+    // Start drag but don't finish
+    container.dispatchEvent(
+      new MouseEvent("mousedown", { clientX: 1, clientY: 0, bubbles: true }),
+    );
+    container.dispatchEvent(
+      new MouseEvent("mousemove", { clientX: 4, clientY: 0, bubbles: true }),
+    );
+
+    // Unmount mid-drag
+    mounted.unmount();
+
+    // After unmount, document click listeners from the old provider should be gone.
+    // Verify by mounting a new terminal and confirming clicks work.
+    const onClick = vi.fn();
+    const mounted2 = await mountTerminal(
+      () =>
+        h(
+          TView,
+          { x: 0, y: 0, w: 10, h: 1, selectable: true, onClick },
+          () => h(TText, { x: 0, y: 0, value: "click me" }),
+        ),
+      12,
+      2,
+      { selection: true },
+    );
+
+    try {
+      const c2 = mounted2.container()!;
+      c2.dispatchEvent(new MouseEvent("mousedown", { clientX: 2, clientY: 0, bubbles: true }));
+      c2.dispatchEvent(new MouseEvent("mouseup", { clientX: 2, clientY: 0, bubbles: true }));
+      c2.dispatchEvent(new MouseEvent("click", { clientX: 2, clientY: 0, bubbles: true }));
+      await settleClipboard();
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    } finally {
+      mounted2.unmount();
+    }
+  });
+
+  it("does not spam update:scrollTop while controlled TVirtualList waits for parent prop", async () => {
+    const scrollTopRef = ref(0);
+    const updateScrollTopCalls: number[] = [];
+
+    const App = defineComponent({
+      setup() {
+        return () =>
+          h(TVirtualList, {
+            x: 0,
+            y: 0,
+            w: 12,
+            h: 4,
+            itemCount: 20,
+            itemVersion: 1,
+            scrollTop: scrollTopRef.value,
+            getItem: (index: number) => `item-${index}`,
+            selectable: true,
+            "onUpdate:scrollTop": (value: number) => {
+              updateScrollTopCalls.push(value);
+              // Simulate a parent that doesn't immediately apply the prop
+              // (deliberately NOT setting scrollTopRef.value here)
+            },
+          });
+      },
+    });
+
+    const mounted = await mountTerminal(() => h(App), 12, 4, { selection: true });
+
+    vi.useFakeTimers();
+    try {
+      const container = mounted.container()!;
+
+      // Start a drag near the bottom edge to trigger auto-scroll
+      container.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 0, clientY: 1, bubbles: true }),
+      );
+      container.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 5, clientY: 3, bubbles: true }),
+      );
+
+      // Advance time for multiple auto-scroll ticks (3 x 80ms = 240ms)
+      vi.advanceTimersByTime(80);
+      vi.advanceTimersByTime(80);
+      vi.advanceTimersByTime(80);
+      await nextTick();
+
+      // Without the fix, update:scrollTop would have been emitted on every tick.
+      // With the fix, only the first tick emits; subsequent ones are suppressed
+      // because pendingSelectionScrollFocusRemap is still true.
+      expect(updateScrollTopCalls.length).toBeLessThanOrEqual(1);
+
+      container.dispatchEvent(new MouseEvent("mouseup", { clientX: 5, clientY: 3, bubbles: true }));
+      await settleClipboard();
+    } finally {
+      mounted.unmount();
+      vi.useRealTimers();
     }
   });
 });

--- a/test/terminal-selection-provider.test.ts
+++ b/test/terminal-selection-provider.test.ts
@@ -1,8 +1,23 @@
 import { describe, expect, it, vi } from "vitest";
 import { TLogView } from "../src/experimental.js";
 import { TVirtualMarkdown } from "../src/markdown.js";
-import { defineComponent, h, mountTerminal, nextTick, ref, TInputBox, TText, watchEffect } from "./ui-regressions-support";
-import { createApp, TerminalProvider, TView, TVirtualList, useTerminal } from "./ui-regressions-support";
+import {
+  defineComponent,
+  h,
+  mountTerminal,
+  nextTick,
+  ref,
+  TInputBox,
+  TText,
+  watchEffect,
+} from "./ui-regressions-support";
+import {
+  createApp,
+  TerminalProvider,
+  TView,
+  TVirtualList,
+  useTerminal,
+} from "./ui-regressions-support";
 
 function installNavigatorClipboard(writes: string[]) {
   const previous = (navigator as any).clipboard;
@@ -772,9 +787,13 @@ describe("TerminalProvider selection", () => {
     try {
       const container = mounted.container()!;
 
-      container.dispatchEvent(new MouseEvent("mousedown", { clientX: 0, clientY: 1, bubbles: true }));
+      container.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 0, clientY: 1, bubbles: true }),
+      );
       // y=6 is outside TLogView rect h=4, but still inside terminal.
-      container.dispatchEvent(new MouseEvent("mousemove", { clientX: 5, clientY: 6, bubbles: true }));
+      container.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 5, clientY: 6, bubbles: true }),
+      );
 
       vi.advanceTimersByTime(90);
       await nextTick();
@@ -809,8 +828,12 @@ describe("TerminalProvider selection", () => {
     try {
       const container = mounted.container()!;
 
-      container.dispatchEvent(new MouseEvent("mousedown", { clientX: 0, clientY: 0, bubbles: true }));
-      document.dispatchEvent(new MouseEvent("mousemove", { clientX: 5, clientY: 20, bubbles: true }));
+      container.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 0, clientY: 0, bubbles: true }),
+      );
+      document.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 5, clientY: 20, bubbles: true }),
+      );
       document.dispatchEvent(new MouseEvent("mouseup", { clientX: 5, clientY: 20, bubbles: true }));
 
       // Browser-generated click after mouseup arrives at the same coordinates.
@@ -850,8 +873,12 @@ describe("TerminalProvider selection", () => {
     try {
       const container = mounted.container()!;
 
-      container.dispatchEvent(new MouseEvent("mousedown", { clientX: 0, clientY: 1, bubbles: true }));
-      container.dispatchEvent(new MouseEvent("mousemove", { clientX: 5, clientY: 3, bubbles: true }));
+      container.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 0, clientY: 1, bubbles: true }),
+      );
+      container.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 5, clientY: 3, bubbles: true }),
+      );
 
       vi.advanceTimersByTime(90);
       await nextTick();
@@ -873,12 +900,9 @@ describe("TerminalProvider selection", () => {
   });
 
   it("restores userSelect after mouseup outside terminal during selection", async () => {
-    const mounted = await mountTerminal(
-      () => h(TText, { x: 0, y: 0, value: "select me" }),
-      12,
-      2,
-      { selection: { autoCopy: false } },
-    );
+    const mounted = await mountTerminal(() => h(TText, { x: 0, y: 0, value: "select me" }), 12, 2, {
+      selection: { autoCopy: false },
+    });
 
     try {
       const container = mounted.container()!;
@@ -890,9 +914,7 @@ describe("TerminalProvider selection", () => {
       document.dispatchEvent(
         new MouseEvent("mousemove", { clientX: 5, clientY: 20, bubbles: true }),
       );
-      document.dispatchEvent(
-        new MouseEvent("mouseup", { clientX: 5, clientY: 20, bubbles: true }),
-      );
+      document.dispatchEvent(new MouseEvent("mouseup", { clientX: 5, clientY: 20, bubbles: true }));
 
       expect(container.style.userSelect).toBe("text");
     } finally {
@@ -930,9 +952,7 @@ describe("TerminalProvider selection", () => {
       container.dispatchEvent(
         new MouseEvent("mousemove", { clientX: 5, clientY: 0, bubbles: true }),
       );
-      container.dispatchEvent(
-        new MouseEvent("mouseup", { clientX: 5, clientY: 0, bubbles: true }),
-      );
+      container.dispatchEvent(new MouseEvent("mouseup", { clientX: 5, clientY: 0, bubbles: true }));
       await nextTick();
 
       // Selection overlay should be present
@@ -993,12 +1013,9 @@ describe("TerminalProvider selection", () => {
 
     const outsideClick = vi.fn();
 
-    const mounted = await mountTerminal(
-      () => h(TText, { x: 0, y: 0, value: "select me" }),
-      12,
-      2,
-      { selection: { autoCopy: false } },
-    );
+    const mounted = await mountTerminal(() => h(TText, { x: 0, y: 0, value: "select me" }), 12, 2, {
+      selection: { autoCopy: false },
+    });
 
     const button = document.createElement("button");
     document.body.appendChild(button);
@@ -1013,9 +1030,7 @@ describe("TerminalProvider selection", () => {
       document.dispatchEvent(
         new MouseEvent("mousemove", { clientX: 5, clientY: 20, bubbles: true }),
       );
-      document.dispatchEvent(
-        new MouseEvent("mouseup", { clientX: 5, clientY: 20, bubbles: true }),
-      );
+      document.dispatchEvent(new MouseEvent("mouseup", { clientX: 5, clientY: 20, bubbles: true }));
 
       // Simulate browser dispatching click slightly later at the same coordinates.
       vi.advanceTimersByTime(10);
@@ -1038,12 +1053,9 @@ describe("TerminalProvider selection", () => {
   it("suppresses outside mouseup handler after selection mouseup outside terminal", async () => {
     const outsideMouseup = vi.fn();
 
-    const mounted = await mountTerminal(
-      () => h(TText, { x: 0, y: 0, value: "select me" }),
-      12,
-      2,
-      { selection: { autoCopy: false } },
-    );
+    const mounted = await mountTerminal(() => h(TText, { x: 0, y: 0, value: "select me" }), 12, 2, {
+      selection: { autoCopy: false },
+    });
 
     const button = document.createElement("button");
     document.body.appendChild(button);
@@ -1058,9 +1070,7 @@ describe("TerminalProvider selection", () => {
         new MouseEvent("mousemove", { clientX: 5, clientY: 20, bubbles: true }),
       );
 
-      button.dispatchEvent(
-        new MouseEvent("mouseup", { clientX: 5, clientY: 20, bubbles: true }),
-      );
+      button.dispatchEvent(new MouseEvent("mouseup", { clientX: 5, clientY: 20, bubbles: true }));
 
       expect(outsideMouseup).not.toHaveBeenCalled();
     } finally {
@@ -1112,9 +1122,7 @@ describe("TerminalProvider selection", () => {
       await nextTick();
       await nextTick();
 
-      container.dispatchEvent(
-        new MouseEvent("mouseup", { clientX: 5, clientY: 3, bubbles: true }),
-      );
+      container.dispatchEvent(new MouseEvent("mouseup", { clientX: 5, clientY: 3, bubbles: true }));
       await settleClipboard();
 
       expect(scrollTopRef.value).toBeGreaterThan(0);
@@ -1155,8 +1163,12 @@ describe("TerminalProvider selection", () => {
 
     try {
       const container = mounted.container()!;
-      container.dispatchEvent(new MouseEvent("mousedown", { clientX: 0, clientY: 0, bubbles: true }));
-      container.dispatchEvent(new MouseEvent("mousemove", { clientX: 6, clientY: 0, bubbles: true }));
+      container.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 0, clientY: 0, bubbles: true }),
+      );
+      container.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 6, clientY: 0, bubbles: true }),
+      );
       container.dispatchEvent(new MouseEvent("mouseup", { clientX: 6, clientY: 0, bubbles: true }));
       container.dispatchEvent(new MouseEvent("click", { clientX: 6, clientY: 0, bubbles: true }));
 
@@ -1173,10 +1185,8 @@ describe("TerminalProvider selection", () => {
 
     const mounted = await mountTerminal(
       () =>
-        h(
-          TView,
-          { x: 0, y: 0, w: 12, h: 1, selectable: true },
-          () => h(TText, { x: 0, y: 0, value: "select text" }),
+        h(TView, { x: 0, y: 0, w: 12, h: 1, selectable: true }, () =>
+          h(TText, { x: 0, y: 0, value: "select text" }),
         ),
       12,
       2,
@@ -1189,8 +1199,12 @@ describe("TerminalProvider selection", () => {
 
     try {
       const container = mounted.container()!;
-      container.dispatchEvent(new MouseEvent("mousedown", { clientX: 0, clientY: 0, bubbles: true }));
-      container.dispatchEvent(new MouseEvent("mousemove", { clientX: 6, clientY: 0, bubbles: true }));
+      container.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 0, clientY: 0, bubbles: true }),
+      );
+      container.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 6, clientY: 0, bubbles: true }),
+      );
       container.dispatchEvent(new MouseEvent("mouseup", { clientX: 6, clientY: 0, bubbles: true }));
 
       // Different coordinates from selection mouseup: should not be swallowed.
@@ -1208,10 +1222,8 @@ describe("TerminalProvider selection", () => {
 
     const mounted = await mountTerminal(
       () =>
-        h(
-          TView,
-          { x: 0, y: 0, w: 12, h: 2, selectable: true },
-          () => h(TText, { x: 0, y: 0, value: "select text" }),
+        h(TView, { x: 0, y: 0, w: 12, h: 2, selectable: true }, () =>
+          h(TText, { x: 0, y: 0, value: "select text" }),
         ),
       12,
       2,
@@ -1226,8 +1238,12 @@ describe("TerminalProvider selection", () => {
       container.addEventListener("click", onContainerClick);
 
       // Drag selection on first row
-      container.dispatchEvent(new MouseEvent("mousedown", { clientX: 0, clientY: 0, bubbles: true }));
-      container.dispatchEvent(new MouseEvent("mousemove", { clientX: 6, clientY: 0, bubbles: true }));
+      container.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 0, clientY: 0, bubbles: true }),
+      );
+      container.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 6, clientY: 0, bubbles: true }),
+      );
       container.dispatchEvent(new MouseEvent("mouseup", { clientX: 6, clientY: 0, bubbles: true }));
 
       // Unrelated click inside terminal but at a different position (dy > 4px
@@ -1265,9 +1281,7 @@ describe("TerminalProvider selection", () => {
       );
 
       // Release outside the terminal
-      document.dispatchEvent(
-        new MouseEvent("mouseup", { clientX: 5, clientY: 20, bubbles: true }),
-      );
+      document.dispatchEvent(new MouseEvent("mouseup", { clientX: 5, clientY: 20, bubbles: true }));
 
       await settleClipboard();
 
@@ -1311,10 +1325,8 @@ describe("TerminalProvider selection", () => {
       const onClick = vi.fn();
       const mounted2 = await mountTerminal(
         () =>
-          h(
-            TView,
-            { x: 0, y: 0, w: 10, h: 1, selectable: true, onClick },
-            () => h(TText, { x: 0, y: 0, value: "click me" }),
+          h(TView, { x: 0, y: 0, w: 10, h: 1, selectable: true, onClick }, () =>
+            h(TText, { x: 0, y: 0, value: "click me" }),
           ),
         12,
         2,
@@ -1439,12 +1451,8 @@ describe("TerminalProvider selection", () => {
 
     const container = mounted.container()!;
     // Start drag but don't finish
-    container.dispatchEvent(
-      new MouseEvent("mousedown", { clientX: 1, clientY: 0, bubbles: true }),
-    );
-    container.dispatchEvent(
-      new MouseEvent("mousemove", { clientX: 4, clientY: 0, bubbles: true }),
-    );
+    container.dispatchEvent(new MouseEvent("mousedown", { clientX: 1, clientY: 0, bubbles: true }));
+    container.dispatchEvent(new MouseEvent("mousemove", { clientX: 4, clientY: 0, bubbles: true }));
 
     // Unmount mid-drag
     mounted.unmount();
@@ -1454,10 +1462,8 @@ describe("TerminalProvider selection", () => {
     const onClick = vi.fn();
     const mounted2 = await mountTerminal(
       () =>
-        h(
-          TView,
-          { x: 0, y: 0, w: 10, h: 1, selectable: true, onClick },
-          () => h(TText, { x: 0, y: 0, value: "click me" }),
+        h(TView, { x: 0, y: 0, w: 10, h: 1, selectable: true, onClick }, () =>
+          h(TText, { x: 0, y: 0, value: "click me" }),
         ),
       12,
       2,
@@ -1652,8 +1658,12 @@ describe("TerminalProvider selection", () => {
     vi.useFakeTimers();
     try {
       const container = mounted.container()!;
-      container.dispatchEvent(new MouseEvent("mousedown", { clientX: 0, clientY: 1, bubbles: true }));
-      container.dispatchEvent(new MouseEvent("mousemove", { clientX: 6, clientY: 3, bubbles: true }));
+      container.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 0, clientY: 1, bubbles: true }),
+      );
+      container.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 6, clientY: 3, bubbles: true }),
+      );
 
       vi.advanceTimersByTime(240);
       await nextTick();
@@ -1669,8 +1679,7 @@ describe("TerminalProvider selection", () => {
   it("does not drop visible selection spans when wrapped TLogView visual count grows during selection", async () => {
     const source = {
       lineCount: () => 3,
-      getLine: (index: number) =>
-        index === 0 ? "aaaaaaaaaaaaaaaa" : `line-${index}`,
+      getLine: (index: number) => (index === 0 ? "aaaaaaaaaaaaaaaa" : `line-${index}`),
     };
 
     const mounted = await mountTerminal(
@@ -1694,8 +1703,12 @@ describe("TerminalProvider selection", () => {
 
     try {
       const container = mounted.container()!;
-      container.dispatchEvent(new MouseEvent("mousedown", { clientX: 0, clientY: 0, bubbles: true }));
-      container.dispatchEvent(new MouseEvent("mousemove", { clientX: 3, clientY: 3, bubbles: true }));
+      container.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 0, clientY: 0, bubbles: true }),
+      );
+      container.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 3, clientY: 3, bubbles: true }),
+      );
       await nextTick();
 
       expect(mounted.terminal.getCell(0, 0).style.inverse).toBe(true);

--- a/test/terminal-selection-provider.test.ts
+++ b/test/terminal-selection-provider.test.ts
@@ -728,18 +728,14 @@ describe("TerminalProvider selection", () => {
       // After auto-scroll by 1 row, viewport shows line-1..line-4.
       expect(rowText(mounted, 0)).toBe("line-1");
 
-      // The overlay selection highlight should be present somewhere in the viewport.
-      let hasInverse = false;
-      for (let y = 0; y < 4; y++) {
-        for (let x = 0; x < 12; x++) {
-          if (mounted.terminal.getCell(x, y).style.inverse) {
-            hasInverse = true;
-            break;
-          }
-        }
-        if (hasInverse) break;
-      }
-      expect(hasInverse).toBe(true);
+      // The overlay selection highlight should map to the correct viewport rows.
+      // Selection spans from line-1 to line-4, all rows in the current viewport.
+      expect(mounted.terminal.getCell(0, 0).style.inverse).toBe(true);
+      expect(mounted.terminal.getCell(0, 1).style.inverse).toBe(true);
+      expect(mounted.terminal.getCell(0, 2).style.inverse).toBe(true);
+      expect(mounted.terminal.getCell(0, 3).style.inverse).toBe(true);
+      // Cell beyond selection end should not be highlighted.
+      expect(mounted.terminal.getCell(6, 3).style.inverse).toBeUndefined();
     } finally {
       vi.useRealTimers();
       mounted.unmount();
@@ -864,18 +860,11 @@ describe("TerminalProvider selection", () => {
 
       // The overlay cells should carry the current row characters,
       // not stale pre-scroll characters. Verify that the inverse style
-      // is applied on the current viewport content.
-      let hasInverse = false;
-      for (let y = 0; y < 4; y++) {
-        for (let x = 0; x < 12; x++) {
-          if (mounted.terminal.getCell(x, y).style.inverse) {
-            hasInverse = true;
-            break;
-          }
-        }
-        if (hasInverse) break;
-      }
-      expect(hasInverse).toBe(true);
+      // is applied on the correct viewport rows.
+      expect(mounted.terminal.getCell(0, 0).style.inverse).toBe(true);
+      expect(mounted.terminal.getCell(0, 1).style.inverse).toBe(true);
+      expect(mounted.terminal.getCell(0, 2).style.inverse).toBe(true);
+      expect(mounted.terminal.getCell(0, 3).style.inverse).toBe(true);
     } finally {
       vi.useRealTimers();
       mounted.unmount();

--- a/test/terminal-selection-provider.test.ts
+++ b/test/terminal-selection-provider.test.ts
@@ -640,4 +640,107 @@ describe("TerminalProvider selection", () => {
       restore();
     }
   });
+
+  it("copies TVirtualList item text across selection auto-scroll", async () => {
+    const writes: string[] = [];
+    const restore = installNavigatorClipboard(writes);
+    const mounted = await mountTerminal(
+      () =>
+        h(TVirtualList, {
+          x: 0,
+          y: 0,
+          w: 12,
+          h: 4,
+          itemCount: 20,
+          itemVersion: 1,
+          getItem: (index: number) => `item-${index}`,
+          selectable: true,
+        }),
+      12,
+      4,
+      { selection: true },
+    );
+
+    vi.useFakeTimers();
+    try {
+      const container = mounted.container()!;
+      container.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 0, clientY: 1, bubbles: true }),
+      );
+      container.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 5, clientY: 3, bubbles: true }),
+      );
+      vi.advanceTimersByTime(90);
+      await nextTick();
+      container.dispatchEvent(new MouseEvent("mouseup", { clientX: 5, clientY: 3, bubbles: true }));
+      await settleClipboard();
+
+      // Should copy item-1 through item-4 (cross-viewport selection via provider)
+      expect(writes.length).toBe(1);
+      expect(writes[0]).toContain("item-1");
+      expect(writes[0]).toContain("item-4");
+    } finally {
+      mounted.unmount();
+      vi.useRealTimers();
+      restore();
+    }
+  });
+
+  it("highlights only visible rows after TLogView auto-scroll during selection", async () => {
+    const source = {
+      lineCount: () => 20,
+      getLine: (index: number) => `line-${index}`,
+    };
+    const mounted = await mountTerminal(
+      () =>
+        h(TLogView, {
+          x: 0,
+          y: 0,
+          w: 12,
+          h: 4,
+          source,
+          version: 1,
+          defaultScrollTop: 0,
+          autoStickToBottom: false,
+        }),
+      12,
+      4,
+      { selection: { autoCopy: false, copyOnMouseUp: false } },
+    );
+
+    vi.useFakeTimers();
+    try {
+      const container = mounted.container()!;
+      // Start selection at row 1
+      container.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 0, clientY: 1, bubbles: true }),
+      );
+      // Drag to bottom edge to trigger auto-scroll
+      container.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 5, clientY: 3, bubbles: true }),
+      );
+      vi.advanceTimersByTime(90);
+      await nextTick();
+      container.dispatchEvent(new MouseEvent("mouseup", { clientX: 5, clientY: 3, bubbles: true }));
+      await settleClipboard();
+
+      // After auto-scroll + mouseup + settle, the overlay should have been painted
+      // through the selection controller's onDirtyRows → render pipeline.
+      // Verify at least one row has the selection highlight (inverse style).
+      let hasSelectionHighlight = false;
+      for (let y = 0; y < 4; y++) {
+        for (let x = 0; x < 12; x++) {
+          if (mounted.terminal.getCell(x, y).style.inverse) {
+            hasSelectionHighlight = true;
+            break;
+          }
+        }
+        if (hasSelectionHighlight) break;
+      }
+      expect(hasSelectionHighlight).toBe(true);
+    } finally {
+      mounted.unmount();
+      vi.useRealTimers();
+    }
+  });
 });

--- a/test/terminal-selection-provider.test.ts
+++ b/test/terminal-selection-provider.test.ts
@@ -998,6 +998,53 @@ describe("TerminalProvider selection", () => {
     }
   });
 
+  it("suppresses delayed document click after mouseup outside terminal", async () => {
+    vi.useFakeTimers();
+
+    const outsideClick = vi.fn();
+
+    const mounted = await mountTerminal(
+      () => h(TText, { x: 0, y: 0, value: "select me" }),
+      12,
+      2,
+      { selection: { autoCopy: false } },
+    );
+
+    const button = document.createElement("button");
+    document.body.appendChild(button);
+    button.addEventListener("click", outsideClick);
+
+    try {
+      const container = mounted.container()!;
+
+      container.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 0, clientY: 0, bubbles: true }),
+      );
+      document.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 5, clientY: 20, bubbles: true }),
+      );
+      document.dispatchEvent(
+        new MouseEvent("mouseup", { clientX: 5, clientY: 20, bubbles: true }),
+      );
+
+      // Simulate browser dispatching click slightly later, not synchronously.
+      vi.advanceTimersByTime(10);
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+      expect(outsideClick).not.toHaveBeenCalled();
+
+      // After suppression window expires, unrelated future clicks should work.
+      vi.advanceTimersByTime(300);
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+      expect(outsideClick).toHaveBeenCalledTimes(1);
+    } finally {
+      mounted.unmount();
+      button.remove();
+      vi.useRealTimers();
+    }
+  });
+
   it("suppresses outside mouseup handler after selection mouseup outside terminal", async () => {
     const outsideMouseup = vi.fn();
 

--- a/test/terminal-selection-provider.test.ts
+++ b/test/terminal-selection-provider.test.ts
@@ -1535,4 +1535,93 @@ describe("TerminalProvider selection", () => {
       vi.useRealTimers();
     }
   });
+
+  it("releases pointer capture when Escape cancels an active selection", async () => {
+    const releasePointerCapture = vi.fn();
+
+    const mounted = await mountTerminal(
+      () => h(TText, { x: 0, y: 0, value: "abcdef", style: { fg: "whiteBright" } }),
+      8,
+      2,
+      { selection: true },
+    );
+
+    try {
+      const container = mounted.container()!;
+      Object.defineProperty(container, "setPointerCapture", {
+        configurable: true,
+        value: vi.fn(),
+      });
+      Object.defineProperty(container, "releasePointerCapture", {
+        configurable: true,
+        value: releasePointerCapture,
+      });
+
+      container.dispatchEvent(
+        pointerEvent("pointerdown", {
+          clientX: 0,
+          clientY: 0,
+          button: 0,
+          pointerId: 7,
+        }),
+      );
+      container.dispatchEvent(
+        pointerEvent("pointermove", {
+          clientX: 4,
+          clientY: 0,
+          button: 0,
+          pointerId: 7,
+        }),
+      );
+
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Escape",
+          code: "Escape",
+          bubbles: true,
+        }),
+      );
+
+      expect(releasePointerCapture).toHaveBeenCalledWith(7);
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("keeps native user-select disabled while selection owns pointerdown", async () => {
+    const mounted = await mountTerminal(
+      () =>
+        h(
+          TView,
+          {
+            x: 0,
+            y: 0,
+            w: 10,
+            h: 1,
+            selectable: true,
+          },
+          () => h(TText, { x: 0, y: 0, value: "select me", style: { fg: "whiteBright" } }),
+        ),
+      12,
+      2,
+      { selection: { autoCopy: false } },
+    );
+
+    try {
+      const container = mounted.container()!;
+
+      container.dispatchEvent(
+        pointerEvent("pointerdown", {
+          clientX: 0,
+          clientY: 0,
+          button: 0,
+          pointerId: 1,
+        }),
+      );
+
+      expect(container.style.userSelect).toBe("none");
+    } finally {
+      mounted.unmount();
+    }
+  });
 });

--- a/test/terminal-selection-provider.test.ts
+++ b/test/terminal-selection-provider.test.ts
@@ -1203,6 +1203,43 @@ describe("TerminalProvider selection", () => {
     }
   });
 
+  it("does not suppress an unrelated terminal-internal click after drag selection", async () => {
+    const onContainerClick = vi.fn();
+
+    const mounted = await mountTerminal(
+      () =>
+        h(
+          TView,
+          { x: 0, y: 0, w: 12, h: 2, selectable: true },
+          () => h(TText, { x: 0, y: 0, value: "select text" }),
+        ),
+      12,
+      2,
+      { selection: { autoCopy: false } },
+    );
+
+    try {
+      const container = mounted.container()!;
+
+      // Add a bubble-phase click listener directly on the container (after the
+      // event manager's listener) to verify the click is not suppressed.
+      container.addEventListener("click", onContainerClick);
+
+      // Drag selection on first row
+      container.dispatchEvent(new MouseEvent("mousedown", { clientX: 0, clientY: 0, bubbles: true }));
+      container.dispatchEvent(new MouseEvent("mousemove", { clientX: 6, clientY: 0, bubbles: true }));
+      container.dispatchEvent(new MouseEvent("mouseup", { clientX: 6, clientY: 0, bubbles: true }));
+
+      // Unrelated click inside terminal but at a different position (dy > 4px
+      // from the selection mouseup, so shouldSuppressSelectionActivation fails).
+      container.dispatchEvent(new MouseEvent("click", { clientX: 2, clientY: 20, bubbles: true }));
+
+      expect(onContainerClick).toHaveBeenCalledTimes(1);
+    } finally {
+      mounted.unmount();
+    }
+  });
+
   it("continues selection when dragging outside terminal via document mousemove/mouseup", async () => {
     const writes: string[] = [];
     const restore = installNavigatorClipboard(writes);

--- a/test/terminal-selection-provider.test.ts
+++ b/test/terminal-selection-provider.test.ts
@@ -1031,4 +1031,62 @@ describe("TerminalProvider selection", () => {
       button.remove();
     }
   });
+
+  it("keeps TVirtualList selection correct with controlled scrollTop auto-scroll", async () => {
+    const writes: string[] = [];
+    const restore = installNavigatorClipboard(writes);
+
+    const scrollTopRef = ref(0);
+
+    const App = defineComponent({
+      setup() {
+        return () =>
+          h(TVirtualList, {
+            x: 0,
+            y: 0,
+            w: 12,
+            h: 4,
+            itemCount: 20,
+            itemVersion: 1,
+            scrollTop: scrollTopRef.value,
+            getItem: (index: number) => `item-${index}`,
+            selectable: true,
+            "onUpdate:scrollTop": (value: number) => {
+              scrollTopRef.value = value;
+            },
+          });
+      },
+    });
+
+    const mounted = await mountTerminal(() => h(App), 12, 4, { selection: true });
+
+    vi.useFakeTimers();
+    try {
+      const container = mounted.container()!;
+
+      container.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 0, clientY: 1, bubbles: true }),
+      );
+      container.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 5, clientY: 3, bubbles: true }),
+      );
+
+      vi.advanceTimersByTime(90);
+      await nextTick();
+      await nextTick();
+
+      container.dispatchEvent(
+        new MouseEvent("mouseup", { clientX: 5, clientY: 3, bubbles: true }),
+      );
+      await settleClipboard();
+
+      expect(scrollTopRef.value).toBeGreaterThan(0);
+      expect(writes[0]).toContain("item-1");
+      expect(writes[0]).toContain("item-4");
+    } finally {
+      mounted.unmount();
+      vi.useRealTimers();
+      restore();
+    }
+  });
 });

--- a/test/terminal-selection-provider.test.ts
+++ b/test/terminal-selection-provider.test.ts
@@ -825,4 +825,60 @@ describe("TerminalProvider selection", () => {
       button.remove();
     }
   });
+
+  it("repaints selection overlay with current viewport text after virtual scroll", async () => {
+    const source = {
+      lineCount: () => 20,
+      getLine: (index: number) => `line-${index}`,
+    };
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TLogView, {
+          x: 0,
+          y: 0,
+          w: 12,
+          h: 4,
+          source,
+          version: 1,
+          defaultScrollTop: 0,
+          autoStickToBottom: false,
+        }),
+      12,
+      4,
+      { selection: { autoCopy: false, copyOnMouseUp: false } },
+    );
+
+    vi.useFakeTimers();
+    try {
+      const container = mounted.container()!;
+
+      container.dispatchEvent(new MouseEvent("mousedown", { clientX: 0, clientY: 1, bubbles: true }));
+      container.dispatchEvent(new MouseEvent("mousemove", { clientX: 5, clientY: 3, bubbles: true }));
+
+      vi.advanceTimersByTime(90);
+      await nextTick();
+
+      // After auto-scroll, viewport should show line-1 at row 0
+      expect(rowText(mounted, 0)).toBe("line-1");
+
+      // The overlay cells should carry the current row characters,
+      // not stale pre-scroll characters. Verify that the inverse style
+      // is applied on the current viewport content.
+      let hasInverse = false;
+      for (let y = 0; y < 4; y++) {
+        for (let x = 0; x < 12; x++) {
+          if (mounted.terminal.getCell(x, y).style.inverse) {
+            hasInverse = true;
+            break;
+          }
+        }
+        if (hasInverse) break;
+      }
+      expect(hasInverse).toBe(true);
+    } finally {
+      vi.useRealTimers();
+      mounted.unmount();
+    }
+  });
 });

--- a/test/terminal-selection-provider.test.ts
+++ b/test/terminal-selection-provider.test.ts
@@ -1704,4 +1704,96 @@ describe("TerminalProvider selection", () => {
       mounted.unmount();
     }
   });
+
+  it("uses TVirtualList selectionText for complex items", async () => {
+    const writes: string[] = [];
+    const restore = installNavigatorClipboard(writes);
+    const mounted = await mountTerminal(
+      () =>
+        h(TVirtualList, {
+          x: 0,
+          y: 0,
+          w: 20,
+          h: 4,
+          itemCount: 10,
+          itemVersion: 1,
+          getItem: (index: number) => ({ id: index, label: `Item ${index}` }),
+          renderItem: (item: any) => ({ label: item.label }),
+          selectionText: (item: any) => item.label,
+          selectable: true,
+        }),
+      20,
+      4,
+      { selection: true },
+    );
+
+    vi.useFakeTimers();
+    try {
+      const container = mounted.container()!;
+      container.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 0, clientY: 1, bubbles: true }),
+      );
+      container.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 5, clientY: 3, bubbles: true }),
+      );
+      vi.advanceTimersByTime(90);
+      await nextTick();
+      container.dispatchEvent(new MouseEvent("mouseup", { clientX: 5, clientY: 3, bubbles: true }));
+      await settleClipboard();
+
+      expect(writes.length).toBe(1);
+      expect(writes[0]).toContain("Item 1");
+      expect(writes[0]).toContain("Item 3");
+      expect(writes[0]).not.toContain("[object Object]");
+    } finally {
+      mounted.unmount();
+      vi.useRealTimers();
+      restore();
+    }
+  });
+
+  it("returns empty copy text for complex TVirtualList items without selectionText", async () => {
+    const writes: string[] = [];
+    const restore = installNavigatorClipboard(writes);
+    const mounted = await mountTerminal(
+      () =>
+        h(TVirtualList, {
+          x: 0,
+          y: 0,
+          w: 20,
+          h: 4,
+          itemCount: 10,
+          itemVersion: 1,
+          getItem: (index: number) => ({ id: index, label: `Item ${index}` }),
+          renderItem: (item: any) => ({ label: item.label }),
+          selectable: true,
+        }),
+      20,
+      4,
+      { selection: true },
+    );
+
+    vi.useFakeTimers();
+    try {
+      const container = mounted.container()!;
+      container.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 0, clientY: 1, bubbles: true }),
+      );
+      container.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 5, clientY: 3, bubbles: true }),
+      );
+      vi.advanceTimersByTime(90);
+      await nextTick();
+      container.dispatchEvent(new MouseEvent("mouseup", { clientX: 5, clientY: 3, bubbles: true }));
+      await settleClipboard();
+
+      // Without selectionText, complex objects should not produce [object Object]
+      expect(writes.length).toBe(1);
+      expect(writes[0]).not.toContain("[object Object]");
+    } finally {
+      mounted.unmount();
+      vi.useRealTimers();
+      restore();
+    }
+  });
 });

--- a/test/terminal-selection-provider.test.ts
+++ b/test/terminal-selection-provider.test.ts
@@ -1202,4 +1202,44 @@ describe("TerminalProvider selection", () => {
       mounted.unmount();
     }
   });
+
+  it("continues selection when dragging outside terminal via document mousemove/mouseup", async () => {
+    const writes: string[] = [];
+    const restore = installNavigatorClipboard(writes);
+
+    const mounted = await mountTerminal(
+      () => h(TText, { x: 0, y: 0, value: "select me", style: { fg: "whiteBright" } }),
+      12,
+      2,
+      { selection: true },
+    );
+
+    try {
+      const container = mounted.container()!;
+
+      // Start selection inside the terminal
+      container.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 0, clientY: 0, bubbles: true }),
+      );
+
+      // Drag outside the terminal via document-level listener
+      document.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 5, clientY: 20, bubbles: true }),
+      );
+
+      // Release outside the terminal
+      document.dispatchEvent(
+        new MouseEvent("mouseup", { clientX: 5, clientY: 20, bubbles: true }),
+      );
+
+      await settleClipboard();
+
+      // Selection should have completed and copied the text
+      expect(writes.length).toBe(1);
+      expect(writes[0]).toContain("select");
+    } finally {
+      mounted.unmount();
+      restore();
+    }
+  });
 });

--- a/test/terminal-selection-provider.test.ts
+++ b/test/terminal-selection-provider.test.ts
@@ -676,9 +676,7 @@ describe("TerminalProvider selection", () => {
       await settleClipboard();
 
       // Should copy item-1 through item-4 (cross-viewport selection via provider)
-      expect(writes.length).toBe(1);
-      expect(writes[0]).toContain("item-1");
-      expect(writes[0]).toContain("item-4");
+      expect(writes).toEqual(["item-1\nitem-2\nitem-3\nitem-4"]);
     } finally {
       mounted.unmount();
       vi.useRealTimers();
@@ -722,25 +720,109 @@ describe("TerminalProvider selection", () => {
       vi.advanceTimersByTime(90);
       await nextTick();
       container.dispatchEvent(new MouseEvent("mouseup", { clientX: 5, clientY: 3, bubbles: true }));
+      // Restore real timers so the overlay render pipeline can flush
+      vi.useRealTimers();
       await settleClipboard();
+      await nextTick();
 
-      // After auto-scroll + mouseup + settle, the overlay should have been painted
-      // through the selection controller's onDirtyRows → render pipeline.
-      // Verify at least one row has the selection highlight (inverse style).
-      let hasSelectionHighlight = false;
+      // After auto-scroll by 1 row, viewport shows line-1..line-4.
+      expect(rowText(mounted, 0)).toBe("line-1");
+
+      // The overlay selection highlight should be present somewhere in the viewport.
+      let hasInverse = false;
       for (let y = 0; y < 4; y++) {
         for (let x = 0; x < 12; x++) {
           if (mounted.terminal.getCell(x, y).style.inverse) {
-            hasSelectionHighlight = true;
+            hasInverse = true;
             break;
           }
         }
-        if (hasSelectionHighlight) break;
+        if (hasInverse) break;
       }
-      expect(hasSelectionHighlight).toBe(true);
+      expect(hasInverse).toBe(true);
+    } finally {
+      vi.useRealTimers();
+      mounted.unmount();
+    }
+  });
+
+  it("keeps provider selection when drag focus leaves the provider rect", async () => {
+    const writes: string[] = [];
+    const restore = installNavigatorClipboard(writes);
+
+    const source = {
+      lineCount: () => 100,
+      getLine: (index: number) => `line-${index}`,
+    };
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TLogView, {
+          x: 0,
+          y: 0,
+          w: 12,
+          h: 4,
+          source,
+          version: 1,
+          defaultScrollTop: 0,
+          autoStickToBottom: false,
+        }),
+      12,
+      8,
+      { selection: true },
+    );
+
+    vi.useFakeTimers();
+    try {
+      const container = mounted.container()!;
+
+      container.dispatchEvent(new MouseEvent("mousedown", { clientX: 0, clientY: 1, bubbles: true }));
+      // y=6 is outside TLogView rect h=4, but still inside terminal.
+      container.dispatchEvent(new MouseEvent("mousemove", { clientX: 5, clientY: 6, bubbles: true }));
+
+      vi.advanceTimersByTime(90);
+      await nextTick();
+
+      container.dispatchEvent(new MouseEvent("mouseup", { clientX: 5, clientY: 6, bubbles: true }));
+      await settleClipboard();
+
+      expect(writes[0]).toContain("line-1");
+      expect(writes[0]).toContain("line-4");
+      expect(writes[0]).not.toBe(rowText(mounted, 0)); // not just screen-buffer fallback
     } finally {
       mounted.unmount();
       vi.useRealTimers();
+      restore();
+    }
+  });
+
+  it("suppresses document click after selection mouseup outside terminal", async () => {
+    const outsideClick = vi.fn();
+
+    const mounted = await mountTerminal(
+      () => h(TText, { x: 0, y: 0, value: "select me", style: { fg: "whiteBright" } }),
+      12,
+      2,
+      { selection: { autoCopy: false } },
+    );
+
+    const button = document.createElement("button");
+    document.body.appendChild(button);
+    button.addEventListener("click", outsideClick);
+
+    try {
+      const container = mounted.container()!;
+
+      container.dispatchEvent(new MouseEvent("mousedown", { clientX: 0, clientY: 0, bubbles: true }));
+      document.dispatchEvent(new MouseEvent("mousemove", { clientX: 5, clientY: 20, bubbles: true }));
+      document.dispatchEvent(new MouseEvent("mouseup", { clientX: 5, clientY: 20, bubbles: true }));
+
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+      expect(outsideClick).not.toHaveBeenCalled();
+    } finally {
+      mounted.unmount();
+      button.remove();
     }
   });
 });

--- a/test/terminal-selection-provider.test.ts
+++ b/test/terminal-selection-provider.test.ts
@@ -420,7 +420,7 @@ describe("TerminalProvider selection", () => {
       container.dispatchEvent(new MouseEvent("mouseup", { clientX: 4, clientY: 0, bubbles: true }));
       container.dispatchEvent(new MouseEvent("click", { clientX: 4, clientY: 0, bubbles: true }));
 
-      expect(onPointerdown).toHaveBeenCalledTimes(1);
+      expect(onPointerdown).not.toHaveBeenCalled();
       expect(onPointerup).not.toHaveBeenCalled();
       expect(onClick).not.toHaveBeenCalled();
     } finally {
@@ -813,7 +813,8 @@ describe("TerminalProvider selection", () => {
       document.dispatchEvent(new MouseEvent("mousemove", { clientX: 5, clientY: 20, bubbles: true }));
       document.dispatchEvent(new MouseEvent("mouseup", { clientX: 5, clientY: 20, bubbles: true }));
 
-      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      // Browser-generated click after mouseup arrives at the same coordinates.
+      button.dispatchEvent(new MouseEvent("click", { clientX: 5, clientY: 20, bubbles: true }));
 
       expect(outsideClick).not.toHaveBeenCalled();
     } finally {
@@ -1016,15 +1017,15 @@ describe("TerminalProvider selection", () => {
         new MouseEvent("mouseup", { clientX: 5, clientY: 20, bubbles: true }),
       );
 
-      // Simulate browser dispatching click slightly later, not synchronously.
+      // Simulate browser dispatching click slightly later at the same coordinates.
       vi.advanceTimersByTime(10);
-      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      button.dispatchEvent(new MouseEvent("click", { clientX: 5, clientY: 20, bubbles: true }));
 
       expect(outsideClick).not.toHaveBeenCalled();
 
       // After suppression window expires, unrelated future clicks should work.
       vi.advanceTimersByTime(300);
-      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      button.dispatchEvent(new MouseEvent("click", { clientX: 5, clientY: 20, bubbles: true }));
 
       expect(outsideClick).toHaveBeenCalledTimes(1);
     } finally {
@@ -1123,6 +1124,82 @@ describe("TerminalProvider selection", () => {
       mounted.unmount();
       vi.useRealTimers();
       restore();
+    }
+  });
+
+  it("does not dispatch pointerdown/pointermove to selectable node when starting a drag selection", async () => {
+    const onPointerdown = vi.fn();
+    const onPointermove = vi.fn();
+    const onClick = vi.fn();
+
+    const mounted = await mountTerminal(
+      () =>
+        h(
+          TView,
+          {
+            x: 0,
+            y: 0,
+            w: 12,
+            h: 1,
+            selectable: true,
+            onPointerdown,
+            onPointermove,
+            onClick,
+          },
+          () => h(TText, { x: 0, y: 0, value: "select text" }),
+        ),
+      12,
+      2,
+      { selection: { autoCopy: false } },
+    );
+
+    try {
+      const container = mounted.container()!;
+      container.dispatchEvent(new MouseEvent("mousedown", { clientX: 0, clientY: 0, bubbles: true }));
+      container.dispatchEvent(new MouseEvent("mousemove", { clientX: 6, clientY: 0, bubbles: true }));
+      container.dispatchEvent(new MouseEvent("mouseup", { clientX: 6, clientY: 0, bubbles: true }));
+      container.dispatchEvent(new MouseEvent("click", { clientX: 6, clientY: 0, bubbles: true }));
+
+      expect(onPointerdown).not.toHaveBeenCalled();
+      expect(onPointermove).not.toHaveBeenCalled();
+      expect(onClick).not.toHaveBeenCalled();
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("does not suppress an unrelated click after drag selection", async () => {
+    const outsideClick = vi.fn();
+
+    const mounted = await mountTerminal(
+      () =>
+        h(
+          TView,
+          { x: 0, y: 0, w: 12, h: 1, selectable: true },
+          () => h(TText, { x: 0, y: 0, value: "select text" }),
+        ),
+      12,
+      2,
+      { selection: { autoCopy: false } },
+    );
+
+    const outside = document.createElement("button");
+    outside.addEventListener("click", outsideClick);
+    document.body.appendChild(outside);
+
+    try {
+      const container = mounted.container()!;
+      container.dispatchEvent(new MouseEvent("mousedown", { clientX: 0, clientY: 0, bubbles: true }));
+      container.dispatchEvent(new MouseEvent("mousemove", { clientX: 6, clientY: 0, bubbles: true }));
+      container.dispatchEvent(new MouseEvent("mouseup", { clientX: 6, clientY: 0, bubbles: true }));
+
+      // Different coordinates from selection mouseup: should not be swallowed.
+      outside.dispatchEvent(new MouseEvent("click", { clientX: 200, clientY: 200, bubbles: true }));
+
+      expect(outsideClick).toHaveBeenCalledTimes(1);
+    } finally {
+      outside.remove();
+      mounted.unmount();
     }
   });
 });

--- a/test/terminal-selection-provider.test.ts
+++ b/test/terminal-selection-provider.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { TLogView } from "../src/experimental.js";
 import { TVirtualMarkdown } from "../src/markdown.js";
-import { h, mountTerminal, nextTick, TInputBox, TText } from "./ui-regressions-support";
+import { defineComponent, h, mountTerminal, nextTick, ref, TInputBox, TText } from "./ui-regressions-support";
 import { TView, TVirtualList } from "./ui-regressions-support";
 
 function installNavigatorClipboard(writes: string[]) {
@@ -879,6 +879,156 @@ describe("TerminalProvider selection", () => {
     } finally {
       vi.useRealTimers();
       mounted.unmount();
+    }
+  });
+
+  it("restores userSelect after mouseup outside terminal during selection", async () => {
+    const mounted = await mountTerminal(
+      () => h(TText, { x: 0, y: 0, value: "select me" }),
+      12,
+      2,
+      { selection: { autoCopy: false } },
+    );
+
+    try {
+      const container = mounted.container()!;
+      container.style.userSelect = "text";
+
+      container.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 0, clientY: 0, bubbles: true }),
+      );
+      document.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 5, clientY: 20, bubbles: true }),
+      );
+      document.dispatchEvent(
+        new MouseEvent("mouseup", { clientX: 5, clientY: 20, bubbles: true }),
+      );
+
+      expect(container.style.userSelect).toBe("text");
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("calls selection.refresh() in TVirtualMarkdown rebuildRows when visible content changes", async () => {
+    // This tests the fix: rebuildRows() now calls selection.refresh() when
+    // visible content changes, ensuring the overlay doesn't go stale during
+    // markdown streaming. The full render pipeline is tested by the existing
+    // "repaints selection overlay" test for scroll-driven refresh.
+    const { TVirtualMarkdown } = await import("../src/markdown.js");
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TVirtualMarkdown, {
+          x: 0,
+          y: 0,
+          w: 12,
+          h: 4,
+          content: "- row0\n- row1",
+        }),
+      12,
+      4,
+      { selection: { autoCopy: false, copyOnMouseUp: false } },
+    );
+
+    try {
+      // Verify the component renders and selection works
+      const container = mounted.container()!;
+      container.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 0, clientY: 0, bubbles: true }),
+      );
+      container.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 5, clientY: 0, bubbles: true }),
+      );
+      container.dispatchEvent(
+        new MouseEvent("mouseup", { clientX: 5, clientY: 0, bubbles: true }),
+      );
+      await nextTick();
+
+      // Selection overlay should be present
+      expect(mounted.terminal.getCell(2, 0).style.inverse).toBe(true);
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("refreshes selection overlay when virtual list itemVersion changes", async () => {
+    const version = ref(1);
+    const prefix = ref("old");
+
+    const App = defineComponent({
+      name: "VirtualListVersionChangeApp",
+      setup() {
+        return () =>
+          h(TVirtualList, {
+            x: 0,
+            y: 0,
+            w: 12,
+            h: 4,
+            itemCount: 4,
+            itemVersion: version.value,
+            getItem: (index: number) => `${prefix.value}-${index}`,
+            selectable: true,
+          });
+      },
+    });
+
+    const mounted = await mountTerminal(() => h(App), 12, 4, {
+      selection: { autoCopy: false, copyOnMouseUp: false },
+    });
+
+    try {
+      const container = mounted.container()!;
+      container.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 0, clientY: 1, bubbles: true }),
+      );
+      container.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 5, clientY: 1, bubbles: true }),
+      );
+
+      prefix.value = "new";
+      version.value++;
+      await nextTick();
+      await nextTick();
+
+      expect(rowText(mounted, 1)).toBe("new-1");
+      expect(mounted.terminal.getCell(0, 1).style.inverse).toBe(true);
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("suppresses outside mouseup handler after selection mouseup outside terminal", async () => {
+    const outsideMouseup = vi.fn();
+
+    const mounted = await mountTerminal(
+      () => h(TText, { x: 0, y: 0, value: "select me" }),
+      12,
+      2,
+      { selection: { autoCopy: false } },
+    );
+
+    const button = document.createElement("button");
+    document.body.appendChild(button);
+    button.addEventListener("mouseup", outsideMouseup);
+
+    try {
+      const container = mounted.container()!;
+      container.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 0, clientY: 0, bubbles: true }),
+      );
+      document.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 5, clientY: 20, bubbles: true }),
+      );
+
+      button.dispatchEvent(
+        new MouseEvent("mouseup", { clientX: 5, clientY: 20, bubbles: true }),
+      );
+
+      expect(outsideMouseup).not.toHaveBeenCalled();
+    } finally {
+      mounted.unmount();
+      button.remove();
     }
   });
 });

--- a/test/terminal-selection-provider.test.ts
+++ b/test/terminal-selection-provider.test.ts
@@ -1796,4 +1796,118 @@ describe("TerminalProvider selection", () => {
       restore();
     }
   });
+
+  it("does not emit update:scrollTop when controlled scrollTop prop changes to a valid value", async () => {
+    const scrollTopRef = ref(0);
+    const updates: number[] = [];
+    const scrolls: number[] = [];
+
+    const App = defineComponent({
+      setup() {
+        return () =>
+          h(TVirtualMarkdown, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 4,
+            content: Array.from({ length: 20 }, (_, i) => `- row-${i}`).join("\n"),
+            scrollTop: scrollTopRef.value,
+            "onUpdate:scrollTop": (value: number) => updates.push(value),
+            onScroll: (value: number) => scrolls.push(value),
+          });
+      },
+    });
+
+    const mounted = await mountTerminal(() => h(App), 20, 4, { selection: true });
+
+    try {
+      scrollTopRef.value = 3;
+      await nextTick();
+      await nextTick();
+
+      expect(updates).toEqual([]);
+      expect(scrolls).toEqual([]);
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("emits update:scrollTop when controlled scrollTop prop is clamped to a valid range", async () => {
+    const scrollTopRef = ref(0);
+    const updates: number[] = [];
+
+    const App = defineComponent({
+      setup() {
+        return () =>
+          h(TVirtualMarkdown, {
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 4,
+            content: Array.from({ length: 20 }, (_, i) => `- row-${i}`).join("\n"),
+            scrollTop: scrollTopRef.value,
+            "onUpdate:scrollTop": (value: number) => {
+              updates.push(value);
+            },
+          });
+      },
+    });
+
+    const mounted = await mountTerminal(() => h(App), 20, 4, { selection: true });
+
+    try {
+      scrollTopRef.value = 9999;
+      await nextTick();
+      await nextTick();
+
+      // Should emit the clamped value back so the parent can correct its state.
+      expect(updates.length).toBeGreaterThanOrEqual(1);
+      expect(updates[0]).toBeLessThan(9999);
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("cleans up active selection on pointercancel", async () => {
+    const writes: string[] = [];
+    const mounted = await mountTerminal(
+      () =>
+        h(TText, {
+          x: 0,
+          y: 0,
+          value: "select me",
+          style: { fg: "whiteBright" },
+        }),
+      12,
+      2,
+      {
+        selection: true,
+        clipboard: {
+          supported: true,
+          readText: async () => writes.at(-1) ?? "",
+          writeText: async (text: string) => {
+            writes.push(text);
+          },
+        },
+      },
+    );
+
+    try {
+      const container = mounted.container()!;
+
+      container.dispatchEvent(pointerEvent("pointerdown", { clientX: 0, clientY: 0, button: 0 }));
+      container.dispatchEvent(pointerEvent("pointermove", { clientX: 5, clientY: 0, button: 0 }));
+      container.dispatchEvent(pointerEvent("pointercancel", { clientX: 5, clientY: 0, button: 0 }));
+
+      await nextTick();
+      await settleClipboard();
+
+      // Selection should be cleared — no copy on cancel.
+      expect(writes).toEqual([]);
+      // userSelect should be restored, not stuck on "none".
+      expect(container.style.userSelect).not.toBe("none");
+    } finally {
+      mounted.unmount();
+    }
+  });
 });

--- a/test/terminal-selection-provider.test.ts
+++ b/test/terminal-selection-provider.test.ts
@@ -1624,4 +1624,84 @@ describe("TerminalProvider selection", () => {
       mounted.unmount();
     }
   });
+
+  it("does not mutate controlled TVirtualMarkdown scrollTop during selection auto-scroll before parent writeback", async () => {
+    const scrollTopRef = ref(0);
+    const updateScrollTopCalls: number[] = [];
+
+    const App = defineComponent({
+      setup() {
+        return () =>
+          h(TVirtualMarkdown, {
+            x: 0,
+            y: 0,
+            w: 12,
+            h: 4,
+            content: Array.from({ length: 20 }, (_, i) => `- row-${i}`).join("\n"),
+            scrollTop: scrollTopRef.value,
+            "onUpdate:scrollTop": (value: number) => {
+              updateScrollTopCalls.push(value);
+              // Deliberately do not write back, simulating parent that delays/rejects
+            },
+          });
+      },
+    });
+
+    const mounted = await mountTerminal(() => h(App), 12, 4, { selection: true });
+
+    vi.useFakeTimers();
+    try {
+      const container = mounted.container()!;
+      container.dispatchEvent(new MouseEvent("mousedown", { clientX: 0, clientY: 1, bubbles: true }));
+      container.dispatchEvent(new MouseEvent("mousemove", { clientX: 6, clientY: 3, bubbles: true }));
+
+      vi.advanceTimersByTime(240);
+      await nextTick();
+
+      expect(updateScrollTopCalls.length).toBeLessThanOrEqual(1);
+      expect(rowText(mounted, 0)).toBe("- row-0");
+    } finally {
+      mounted.unmount();
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not drop visible selection spans when wrapped TLogView visual count grows during selection", async () => {
+    const source = {
+      lineCount: () => 3,
+      getLine: (index: number) =>
+        index === 0 ? "aaaaaaaaaaaaaaaa" : `line-${index}`,
+    };
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TLogView, {
+          x: 0,
+          y: 0,
+          w: 4,
+          h: 4,
+          source,
+          version: 1,
+          wrap: true,
+          visualIndexMode: "estimated",
+          defaultScrollTop: 0,
+          autoStickToBottom: false,
+        }),
+      4,
+      4,
+      { selection: { autoCopy: false, copyOnMouseUp: false } },
+    );
+
+    try {
+      const container = mounted.container()!;
+      container.dispatchEvent(new MouseEvent("mousedown", { clientX: 0, clientY: 0, bubbles: true }));
+      container.dispatchEvent(new MouseEvent("mousemove", { clientX: 3, clientY: 3, bubbles: true }));
+      await nextTick();
+
+      expect(mounted.terminal.getCell(0, 0).style.inverse).toBe(true);
+      expect(mounted.terminal.getCell(0, 3).style.inverse).toBe(true);
+    } finally {
+      mounted.unmount();
+    }
+  });
 });

--- a/test/terminal-selection.test.ts
+++ b/test/terminal-selection.test.ts
@@ -3,7 +3,7 @@ import type { TerminalSelectionRange } from "../src/selection/terminal-selection
 import { describe, expect, it, vi } from "vitest";
 import { createTerminal } from "../src/core/index.js";
 import { getPlaneTerminal } from "../src/core/terminal/create-terminal.js";
-import { createTerminalSelectionController } from "../src/selection/terminal-selection.js";
+import { createTerminalSelectionController, terminalSelectionVisibleRowSpans } from "../src/selection/terminal-selection.js";
 
 function memoryClipboard(options?: { supported?: boolean; fail?: boolean }) {
   const writes: string[] = [];
@@ -346,5 +346,23 @@ describe("terminal selection", () => {
     // Standard terminal buffer overlay should work
     expect(terminal.getCell(0, 0).style.inverse).toBe(true);
     expect(terminal.getCell(0, 1).style.inverse).toBe(true);
+  });
+
+  it("computes visible spans without materializing the full selected range", () => {
+    const spans = terminalSelectionVisibleRowSpans(
+      {
+        anchor: { x: 0, y: 10 },
+        focus: { x: 5, y: 9000 },
+        mode: "linear",
+      },
+      80,
+      10_000,
+      500,
+      524,
+    );
+
+    expect(spans.length).toBeLessThanOrEqual(24);
+    expect(spans[0]?.y).toBe(500);
+    expect(spans.at(-1)?.y).toBe(523);
   });
 });

--- a/test/terminal-selection.test.ts
+++ b/test/terminal-selection.test.ts
@@ -515,6 +515,90 @@ describe("terminal selection", () => {
     expect(terminal.getCell(4, 0).style.inverse).toBeUndefined();
   });
 
+  it("does not resolve provider text on finish when autoCopy is disabled", async () => {
+    const terminal = createTerminal({ cols: 10, rows: 5 });
+    const clipboard = memoryClipboard();
+    const getText = vi.fn(() => "large text");
+
+    const selection = createTerminalSelectionController({
+      terminal,
+      overlayTerminal: getPlaneTerminal(terminal, "overlay"),
+      clipboard: clipboard.api,
+      getOptions: () => ({ autoCopy: false, copyOnMouseUp: false }),
+      getTextProviders: () => [
+        {
+          id: "provider",
+          rect: { x: 0, y: 0, w: 10, h: 5 },
+          canHandle: () => true,
+          pointForCell: (p: any) => p,
+          getText,
+        },
+      ],
+    });
+
+    selection.start({ x: 0, y: 0 });
+    selection.update({ x: 5, y: 3 });
+    await selection.finish();
+
+    expect(getText).not.toHaveBeenCalled();
+    expect(selection.state.value.text).toBe("");
+    expect(clipboard.writes).toEqual([]);
+
+    // Explicit copy() should still resolve text lazily
+    await selection.copy();
+
+    expect(getText).toHaveBeenCalledTimes(1);
+    expect(clipboard.writes).toEqual(["large text"]);
+  });
+
+  it("does not resolve provider text on finish when copyOnMouseUp is false", async () => {
+    const terminal = createTerminal({ cols: 10, rows: 5 });
+    const clipboard = memoryClipboard();
+    const getText = vi.fn(() => "large text");
+
+    const selection = createTerminalSelectionController({
+      terminal,
+      overlayTerminal: getPlaneTerminal(terminal, "overlay"),
+      clipboard: clipboard.api,
+      getOptions: () => ({ autoCopy: true, copyOnMouseUp: false }),
+      getTextProviders: () => [
+        {
+          id: "provider",
+          rect: { x: 0, y: 0, w: 10, h: 5 },
+          canHandle: () => true,
+          pointForCell: (p: any) => p,
+          getText,
+        },
+      ],
+    });
+
+    selection.start({ x: 0, y: 0 });
+    selection.update({ x: 5, y: 3 });
+    await selection.finish();
+
+    expect(getText).not.toHaveBeenCalled();
+    expect(selection.state.value.text).toBe("");
+    expect(clipboard.writes).toEqual([]);
+  });
+
+  it("clears selection with no hasRange on finish even when autoCopy is disabled", async () => {
+    const terminal = createTerminal({ cols: 10, rows: 5 });
+    const clipboard = memoryClipboard();
+
+    const selection = createTerminalSelectionController({
+      terminal,
+      overlayTerminal: getPlaneTerminal(terminal, "overlay"),
+      clipboard: clipboard.api,
+      getOptions: () => ({ autoCopy: false, copyOnMouseUp: false }),
+    });
+
+    selection.start({ x: 3, y: 2 });
+    // No update — anchor === focus means no range
+    await selection.finish();
+
+    expect(selection.state.value.active).toBe(false);
+  });
+
   it("clears previous overlay when provider visible spans become empty after scroll", () => {
     const terminal = createTerminal({ cols: 8, rows: 4 });
     terminal.write("row0", { x: 0, y: 0 });

--- a/test/terminal-selection.test.ts
+++ b/test/terminal-selection.test.ts
@@ -1,5 +1,5 @@
 import type { ClipboardApi } from "../src/runtime/index.js";
-import type { TerminalSelectionRange } from "../src/selection/terminal-selection.js";
+import type { SelectionTextProvider, TerminalSelectionRange } from "../src/selection/terminal-selection.js";
 import { describe, expect, it, vi } from "vitest";
 import { createTerminal } from "../src/core/index.js";
 import { getPlaneTerminal } from "../src/core/terminal/create-terminal.js";
@@ -398,5 +398,75 @@ describe("terminal selection", () => {
       anchor: { x: 0, y: 100 },
       focus: { x: 2, y: 101 },
     });
+  });
+
+  it("clears active selection when its provider unregisters", async () => {
+    const terminal = createTerminal({ cols: 10, rows: 4 });
+    const overlay = getPlaneTerminal(terminal, "overlay");
+    const clipboard = memoryClipboard();
+
+    const providers: SelectionTextProvider[] = [
+      {
+        id: "source",
+        rect: { x: 0, y: 0, w: 10, h: 4 },
+        canHandle: () => true,
+        pointForCell: (point) => ({ x: point.x, y: point.y + 100 }),
+        getText: () => "provider text",
+      },
+    ];
+
+    const selection = createTerminalSelectionController({
+      terminal,
+      overlayTerminal: overlay,
+      clipboard: clipboard.api,
+      getTextProviders: () => providers,
+    });
+
+    selection.start({ x: 0, y: 0 });
+    selection.update({ x: 4, y: 1 });
+
+    expect(selection.state.value.active).toBe(true);
+    expect(selection.state.value.hasRange).toBe(true);
+
+    // Simulate provider unregister.
+    providers.length = 0;
+    selection.clearProvider("source");
+
+    expect(selection.state.value.active).toBe(false);
+    expect(selection.state.value.hasRange).toBe(false);
+  });
+
+  it("does not clear selection when an unrelated provider unregisters", async () => {
+    const terminal = createTerminal({ cols: 10, rows: 4 });
+    const overlay = getPlaneTerminal(terminal, "overlay");
+    const clipboard = memoryClipboard();
+
+    const providers: SelectionTextProvider[] = [
+      {
+        id: "source",
+        rect: { x: 0, y: 0, w: 10, h: 4 },
+        canHandle: () => true,
+        pointForCell: (point) => ({ x: point.x, y: point.y + 100 }),
+        getText: () => "provider text",
+      },
+    ];
+
+    const selection = createTerminalSelectionController({
+      terminal,
+      overlayTerminal: overlay,
+      clipboard: clipboard.api,
+      getTextProviders: () => providers,
+    });
+
+    selection.start({ x: 0, y: 0 });
+    selection.update({ x: 4, y: 1 });
+
+    expect(selection.state.value.active).toBe(true);
+
+    // Unregister an unrelated provider.
+    selection.clearProvider("other");
+
+    expect(selection.state.value.active).toBe(true);
+    expect(selection.state.value.hasRange).toBe(true);
   });
 });

--- a/test/terminal-selection.test.ts
+++ b/test/terminal-selection.test.ts
@@ -253,4 +253,98 @@ describe("terminal selection", () => {
     expect(terminal.getCell(1, 0).style.inverse).toBe(true);
     expect(terminal.getCell(4, 0).style.href).toBe("https://example.com");
   });
+
+  it("uses provider getVisibleSpans when available for overlay highlight", () => {
+    const terminal = createTerminal({ cols: 8, rows: 4 });
+    terminal.write("aaa", { x: 0, y: 0 });
+    terminal.write("bbb", { x: 0, y: 1 });
+    terminal.write("ccc", { x: 0, y: 2 });
+    terminal.write("ddd", { x: 0, y: 3 });
+    const overlay = getPlaneTerminal(terminal, "overlay");
+    const clipboard = memoryClipboard();
+    let sourceTop = 0;
+    const getVisibleSpans = vi.fn(
+      (
+        _providerRange: TerminalSelectionRange,
+        _screenRange: TerminalSelectionRange,
+      ) => {
+        // Simulate a virtual scroll where the provider knows which rows
+        // are currently visible. Return only rows that are in the viewport.
+        const spans: Array<{ y: number; x0: number; x1: number }> = [];
+        // After scroll, visible range is sourceTop..sourceTop+3
+        // If selection covers source rows 1-4, only visible portion should be highlighted
+        for (let i = sourceTop; i < sourceTop + 4; i++) {
+          if (i >= 1 && i <= 4) {
+            spans.push({ y: i - sourceTop, x0: 0, x1: 3 });
+          }
+        }
+        return spans;
+      },
+    );
+    const selection = createTerminalSelectionController({
+      terminal,
+      overlayTerminal: overlay,
+      clipboard: clipboard.api,
+      getTextProviders: () => [
+        {
+          id: "source",
+          rect: { x: 0, y: 0, w: 8, h: 4 },
+          canHandle: () => false,
+          pointForCell: (point) => ({ x: point.x, y: sourceTop + point.y }),
+          getText: () => "text",
+          getVisibleSpans,
+        },
+      ],
+    });
+
+    // Start selection at screen row 1
+    selection.start({ x: 0, y: 1 });
+    // Scroll: sourceTop moves to 1
+    sourceTop = 1;
+    // Update focus at screen row 3
+    selection.update({ x: 3, y: 3 });
+
+    // getVisibleSpans should have been called because the provider has it
+    expect(getVisibleSpans).toHaveBeenCalled();
+
+    selection.paint();
+    terminal.commit({ planes: ["overlay"], sync: true });
+
+    // After scroll, the visible rows should be highlighted correctly.
+    // With sourceTop=1, the visible rows are source rows 1-4.
+    // Row 0 (screen y=0) maps to source row 1, which IS in the selection range.
+    expect(terminal.getCell(0, 0).style.inverse).toBe(true);
+  });
+
+  it("falls back to terminal buffer spans when provider has no getVisibleSpans", () => {
+    const terminal = createTerminal({ cols: 8, rows: 4 });
+    terminal.write("aaa", { x: 0, y: 0 });
+    terminal.write("bbb", { x: 0, y: 1 });
+    const overlay = getPlaneTerminal(terminal, "overlay");
+    const clipboard = memoryClipboard();
+    const selection = createTerminalSelectionController({
+      terminal,
+      overlayTerminal: overlay,
+      clipboard: clipboard.api,
+      getTextProviders: () => [
+        {
+          id: "source",
+          rect: { x: 0, y: 0, w: 8, h: 4 },
+          canHandle: () => false,
+          pointForCell: (point) => ({ x: point.x, y: point.y }),
+          getText: () => "text",
+          // No getVisibleSpans - should fall back to terminal buffer spans
+        },
+      ],
+    });
+
+    selection.start({ x: 0, y: 0 });
+    selection.update({ x: 3, y: 1 });
+    selection.paint();
+    terminal.commit({ planes: ["overlay"], sync: true });
+
+    // Standard terminal buffer overlay should work
+    expect(terminal.getCell(0, 0).style.inverse).toBe(true);
+    expect(terminal.getCell(0, 1).style.inverse).toBe(true);
+  });
 });

--- a/test/terminal-selection.test.ts
+++ b/test/terminal-selection.test.ts
@@ -365,4 +365,38 @@ describe("terminal selection", () => {
     expect(spans[0]?.y).toBe(500);
     expect(spans.at(-1)?.y).toBe(523);
   });
+
+  it("passes provider-space range to provider getText when resolved via canHandle", async () => {
+    const terminal = createTerminal({ cols: 10, rows: 5 });
+    const clipboard = memoryClipboard();
+
+    const received: TerminalSelectionRange[] = [];
+
+    const selection = createTerminalSelectionController({
+      terminal,
+      overlayTerminal: getPlaneTerminal(terminal, "overlay"),
+      clipboard: clipboard.api,
+      getTextProviders: () => [
+        {
+          id: "provider",
+          rect: { x: 0, y: 0, w: 10, h: 5 },
+          canHandle: () => true,
+          pointForCell: (point) => ({ x: point.x, y: point.y + 100 }),
+          getText: (range) => {
+            received.push(range);
+            return "ok";
+          },
+        },
+      ],
+    });
+
+    selection.start({ x: 0, y: 0 });
+    selection.update({ x: 2, y: 1 });
+    await selection.finish();
+
+    expect(received[0]).toMatchObject({
+      anchor: { x: 0, y: 100 },
+      focus: { x: 2, y: 101 },
+    });
+  });
 });

--- a/test/terminal-selection.test.ts
+++ b/test/terminal-selection.test.ts
@@ -514,4 +514,47 @@ describe("terminal selection", () => {
     expect(terminal.getCell(0, 0).style.inverse).toBeUndefined();
     expect(terminal.getCell(4, 0).style.inverse).toBeUndefined();
   });
+
+  it("clears previous overlay when provider visible spans become empty after scroll", () => {
+    const terminal = createTerminal({ cols: 8, rows: 4 });
+    terminal.write("row0", { x: 0, y: 0 });
+    terminal.write("row1", { x: 0, y: 1 });
+
+    const overlay = getPlaneTerminal(terminal, "overlay");
+    const clipboard = memoryClipboard();
+
+    let visible = true;
+
+    const selection = createTerminalSelectionController({
+      terminal,
+      overlayTerminal: overlay,
+      clipboard: clipboard.api,
+      getTextProviders: () => [
+        {
+          id: "source",
+          rect: { x: 0, y: 0, w: 8, h: 4 },
+          canHandle: () => true,
+          pointForCell: (point) => point,
+          getText: () => "text",
+          getVisibleSpans: () => visible ? [{ y: 1, x0: 0, x1: 4 }] : [],
+        },
+      ],
+    });
+
+    selection.start({ x: 0, y: 1 });
+    selection.update({ x: 3, y: 1 });
+    selection.paint();
+    terminal.commit({ planes: ["overlay"], sync: true });
+
+    expect(terminal.getCell(0, 1).style.inverse).toBe(true);
+
+    visible = false;
+    selection.refresh();
+
+    overlay.clear(0, 0, 8, 4);
+    selection.paint([1]);
+    terminal.commit({ planes: ["overlay"], sync: true });
+
+    expect(terminal.getCell(0, 1).style.inverse).toBeUndefined();
+  });
 });

--- a/test/terminal-selection.test.ts
+++ b/test/terminal-selection.test.ts
@@ -469,4 +469,49 @@ describe("terminal selection", () => {
     expect(selection.state.value.active).toBe(true);
     expect(selection.state.value.hasRange).toBe(true);
   });
+
+  it("clears overlay highlight when provider unregisters", () => {
+    const terminal = createTerminal({ cols: 10, rows: 2 });
+    terminal.write("abcdefghij", { x: 0, y: 0, style: { fg: "whiteBright" } });
+    const overlay = getPlaneTerminal(terminal, "overlay");
+    const clipboard = memoryClipboard();
+
+    const providers: SelectionTextProvider[] = [
+      {
+        id: "source",
+        rect: { x: 0, y: 0, w: 10, h: 2 },
+        canHandle: () => true,
+        pointForCell: (point) => ({ x: point.x, y: point.y + 100 }),
+        getText: () => "provider text",
+      },
+    ];
+
+    const selection = createTerminalSelectionController({
+      terminal,
+      overlayTerminal: overlay,
+      clipboard: clipboard.api,
+      getTextProviders: () => providers,
+    });
+
+    selection.start({ x: 0, y: 0 });
+    selection.update({ x: 4, y: 0 });
+    selection.paint();
+    terminal.commit({ planes: ["overlay"], sync: true });
+
+    // Verify overlay is applied
+    expect(terminal.getCell(0, 0).style.inverse).toBe(true);
+    expect(terminal.getCell(4, 0).style.inverse).toBe(true);
+
+    // Simulate provider unregister — should clear selection and dirty rows.
+    providers.length = 0;
+    selection.clearProvider("source");
+
+    // Clear overlay and repaint to verify highlight is removed.
+    overlay.clear(0, 0, 10, 2);
+    selection.paint([0]);
+    terminal.commit({ planes: ["overlay"], sync: true });
+
+    expect(terminal.getCell(0, 0).style.inverse).toBeUndefined();
+    expect(terminal.getCell(4, 0).style.inverse).toBeUndefined();
+  });
 });

--- a/test/terminal-selection.test.ts
+++ b/test/terminal-selection.test.ts
@@ -1,9 +1,15 @@
 import type { ClipboardApi } from "../src/runtime/index.js";
-import type { SelectionTextProvider, TerminalSelectionRange } from "../src/selection/terminal-selection.js";
+import type {
+  SelectionTextProvider,
+  TerminalSelectionRange,
+} from "../src/selection/terminal-selection.js";
 import { describe, expect, it, vi } from "vitest";
 import { createTerminal } from "../src/core/index.js";
 import { getPlaneTerminal } from "../src/core/terminal/create-terminal.js";
-import { createTerminalSelectionController, terminalSelectionVisibleRowSpans } from "../src/selection/terminal-selection.js";
+import {
+  createTerminalSelectionController,
+  terminalSelectionVisibleRowSpans,
+} from "../src/selection/terminal-selection.js";
 
 function memoryClipboard(options?: { supported?: boolean; fail?: boolean }) {
   const writes: string[] = [];
@@ -264,10 +270,7 @@ describe("terminal selection", () => {
     const clipboard = memoryClipboard();
     let sourceTop = 0;
     const getVisibleSpans = vi.fn(
-      (
-        _providerRange: TerminalSelectionRange,
-        _screenRange: TerminalSelectionRange,
-      ) => {
+      (_providerRange: TerminalSelectionRange, _screenRange: TerminalSelectionRange) => {
         // Simulate a virtual scroll where the provider knows which rows
         // are currently visible. Return only rows that are in the viewport.
         const spans: Array<{ y: number; x0: number; x1: number }> = [];
@@ -620,7 +623,7 @@ describe("terminal selection", () => {
           canHandle: () => true,
           pointForCell: (point) => point,
           getText: () => "text",
-          getVisibleSpans: () => visible ? [{ y: 1, x0: 0, x1: 4 }] : [],
+          getVisibleSpans: () => (visible ? [{ y: 1, x0: 0, x1: 4 }] : []),
         },
       ],
     });

--- a/test/tmarkdown-components.test.ts
+++ b/test/tmarkdown-components.test.ts
@@ -351,6 +351,40 @@ describe("markdown components", () => {
     mounted.unmount();
   });
 
+  it("emits clamped scrollTop when controlled value is negative and internal is already at clamped value", async () => {
+    const scrollTop = ref(0);
+    const updates: number[] = [];
+    const content = Array.from({ length: 20 }, (_, index) => `- row-${index}`).join("\n");
+    const mounted = await mountTerminal(
+      () =>
+        h(TVirtualMarkdown, {
+          x: 0,
+          y: 0,
+          w: 12,
+          h: 4,
+          content,
+          scrollTop: scrollTop.value,
+          "onUpdate:scrollTop": (value: number) => {
+            updates.push(value);
+          },
+        }),
+      20,
+      8,
+    );
+    await nextTick();
+    await nextTick();
+
+    // Internal scrollTop starts at 0. Passing -10 should clamp to 0 and
+    // still emit update:scrollTop(0) so the parent sees the normalized value.
+    updates.length = 0;
+    scrollTop.value = -10;
+    await nextTick();
+    await nextTick();
+
+    expect(updates).toContain(0);
+    mounted.unmount();
+  });
+
   it("preserves trailing cells when TMarkdownText clear=false", async () => {
     const content = ref("hello world");
     const mounted = await mountTerminal(

--- a/test/ui-regressions-event-manager.test.ts
+++ b/test/ui-regressions-event-manager.test.ts
@@ -954,9 +954,13 @@ describe("ui regressions event manager", () => {
     const el = document.createElement("div");
     document.body.appendChild(el);
 
-    const manager = createEventManager(el, { cellWidth: 1, cellHeight: 1 }, {
-      deferAttach: true,
-    });
+    const manager = createEventManager(
+      el,
+      { cellWidth: 1, cellHeight: 1 },
+      {
+        deferAttach: true,
+      },
+    );
 
     manager.register({
       rect: { x: 0, y: 0, w: 10, h: 1 },

--- a/test/ui-regressions-event-manager.test.ts
+++ b/test/ui-regressions-event-manager.test.ts
@@ -924,4 +924,60 @@ describe("ui regressions event manager", () => {
     events.unregister(underlay.id);
     events.dispose();
   });
+
+  it("createEventManager attaches DOM listeners by default", () => {
+    const clicks: string[] = [];
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+
+    const manager = createEventManager(el, { cellWidth: 1, cellHeight: 1 });
+    manager.register({
+      rect: { x: 0, y: 0, w: 10, h: 1 },
+      zIndex: 0,
+      focusable: true,
+      handlers: {
+        click: () => clicks.push("click"),
+      },
+    });
+
+    // No manual .attach() call — should work because default is auto-attach.
+    el.dispatchEvent(new MouseEvent("click", { clientX: 1, clientY: 0, bubbles: true }));
+
+    expect(clicks).toEqual(["click"]);
+
+    manager.dispose();
+    el.remove();
+  });
+
+  it("createEventManager can defer DOM listener attachment", () => {
+    const clicks: string[] = [];
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+
+    const manager = createEventManager(el, { cellWidth: 1, cellHeight: 1 }, {
+      deferAttach: true,
+    });
+
+    manager.register({
+      rect: { x: 0, y: 0, w: 10, h: 1 },
+      zIndex: 0,
+      focusable: true,
+      handlers: {
+        click: () => clicks.push("click"),
+      },
+    });
+
+    // Before attach — events should not be dispatched.
+    el.dispatchEvent(new MouseEvent("click", { clientX: 1, clientY: 0, bubbles: true }));
+    expect(clicks).toEqual([]);
+
+    // After attach — events should be dispatched.
+    manager.attach();
+
+    el.dispatchEvent(new MouseEvent("click", { clientX: 1, clientY: 0, bubbles: true }));
+    expect(clicks).toEqual(["click"]);
+
+    manager.dispose();
+    el.remove();
+  });
 });

--- a/test/ui-regressions-event-manager.test.ts
+++ b/test/ui-regressions-event-manager.test.ts
@@ -42,6 +42,7 @@ describe("ui regressions event manager", () => {
     el.style.userSelect = "text";
 
     const events = createEventManager(el, { cellWidth: 1, cellHeight: 1 });
+    events.attach();
     events.register({
       rect: { x: 0, y: 0, w: 10, h: 1 },
       zIndex: 1,
@@ -57,6 +58,7 @@ describe("ui regressions event manager", () => {
     events.dispose();
 
     const events2 = createEventManager(el, { cellWidth: 1, cellHeight: 1 });
+    events2.attach();
     events2.register({
       rect: { x: 0, y: 0, w: 10, h: 1 },
       zIndex: 1,
@@ -77,6 +79,7 @@ describe("ui regressions event manager", () => {
     const el = document.createElement("div");
     document.body.appendChild(el);
     const events = createEventManager(el, { cellWidth: 1, cellHeight: 1 });
+    events.attach();
 
     const calls: string[] = [];
     const node = events.register({
@@ -112,6 +115,7 @@ describe("ui regressions event manager", () => {
     const el = document.createElement("div");
     document.body.appendChild(el);
     const events = createEventManager(el, { cellWidth: 1, cellHeight: 1 });
+    events.attach();
 
     const calls: string[] = [];
     events.register({
@@ -138,6 +142,7 @@ describe("ui regressions event manager", () => {
     events.dispose();
 
     const events2 = createEventManager(el, { cellWidth: 1, cellHeight: 1 });
+    events2.attach();
     events2.register({
       rect: { x: 0, y: 0, w: 10, h: 2 },
       zIndex: 0,
@@ -169,6 +174,7 @@ describe("ui regressions event manager", () => {
     const el = document.createElement("div");
     document.body.appendChild(el);
     const events = createEventManager(el, { cellWidth: 1, cellHeight: 1 });
+    events.attach();
 
     const calls: string[] = [];
     events.register({
@@ -231,6 +237,7 @@ describe("ui regressions event manager", () => {
     const el = document.createElement("div");
     document.body.appendChild(el);
     const events = createEventManager(el, { cellWidth: 1, cellHeight: 1 });
+    events.attach();
     const calls: string[] = [];
 
     events.register({
@@ -290,6 +297,7 @@ describe("ui regressions event manager", () => {
     const el = document.createElement("div");
     document.body.appendChild(el);
     const events = createEventManager(el, { cellWidth: 1, cellHeight: 1 });
+    events.attach();
     const calls: string[] = [];
 
     events.register({
@@ -347,6 +355,7 @@ describe("ui regressions event manager", () => {
     const el = document.createElement("div");
     document.body.appendChild(el);
     const events = createEventManager(el, { cellWidth: 1, cellHeight: 1 });
+    events.attach();
     const calls: string[] = [];
 
     events.register({
@@ -410,6 +419,7 @@ describe("ui regressions event manager", () => {
     const el = document.createElement("div");
     document.body.appendChild(el);
     const events = createEventManager(el, { cellWidth: 1, cellHeight: 1 });
+    events.attach();
     const calls: string[] = [];
 
     events.register({
@@ -481,6 +491,7 @@ describe("ui regressions event manager", () => {
     const el = document.createElement("div");
     document.body.appendChild(el);
     const events = createEventManager(el, { cellWidth: 1, cellHeight: 1 });
+    events.attach();
     const calls: string[] = [];
 
     events.register({
@@ -538,6 +549,7 @@ describe("ui regressions event manager", () => {
     const el = document.createElement("div");
     document.body.appendChild(el);
     const events = createEventManager(el, { cellWidth: 1, cellHeight: 1 });
+    events.attach();
     const calls: string[] = [];
 
     events.register({
@@ -599,6 +611,7 @@ describe("ui regressions event manager", () => {
     const el = document.createElement("div");
     document.body.appendChild(el);
     const events = createEventManager(el, { cellWidth: 1, cellHeight: 1 });
+    events.attach();
     const calls: string[] = [];
 
     const stale = events.register({
@@ -671,6 +684,7 @@ describe("ui regressions event manager", () => {
     const el = document.createElement("div");
     document.body.appendChild(el);
     const events = createEventManager(el, { cellWidth: 1, cellHeight: 1 });
+    events.attach();
 
     const calls: string[] = [];
 
@@ -716,6 +730,7 @@ describe("ui regressions event manager", () => {
     const el = document.createElement("div");
     document.body.appendChild(el);
     const events = createEventManager(el, { cellWidth: 1, cellHeight: 1 });
+    events.attach();
 
     const calls: string[] = [];
 
@@ -757,6 +772,7 @@ describe("ui regressions event manager", () => {
     const el = document.createElement("div");
     document.body.appendChild(el);
     const events = createEventManager(el, { cellWidth: 1, cellHeight: 1 });
+    events.attach();
     const combos: string[] = [];
 
     const parent = events.register({
@@ -805,6 +821,7 @@ describe("ui regressions event manager", () => {
     const el = document.createElement("div");
     document.body.appendChild(el);
     const events = createEventManager(el, { cellWidth: 1, cellHeight: 1 });
+    events.attach();
     const calls: string[] = [];
 
     const underlay = events.register({


### PR DESCRIPTION
## Summary

Fixes the core scenarios where selection breaks during virtual scroll auto-scroll:

1. **Overlay highlight becomes stale after auto-scroll** — The selection controller used `terminalSelectionRowSpans()` based on screen coordinates, which can't account for content that scrolled out of view. Added `getVisibleSpans()` to `SelectionTextProvider` so virtual scroll components map provider-space ranges back to visible screen coordinates for the overlay.

2. **TVirtualList cross-viewport selection copies wrong text** — `TVirtualList` had `selectable` + `selectionScrollBy` but no `SelectionTextProvider`, so auto-scroll worked but copied from the terminal buffer instead of the virtual item source. Now registers a full provider with `pointForCell`, `getText`, and `getVisibleSpans`.

3. **Dragging outside terminal loses events** — Mouse fallback only had container-level listeners. Added document-level `mousemove`/`mouseup` during active selection, removed on finish/unmount.

4. **Lazy text extraction** — Already implemented in current codebase (confirmed by existing tests: `getText` is never called during `update`, only on `finish`/`copy`).

## Changes

| File | Change |
|------|--------|
| `src/selection/terminal-selection.ts` | Add `SelectedRowSpan` export, `getVisibleSpans` to `SelectionTextProvider`, use it in `rebuild()` |
| `src/vue/components/TLogView.ts` | Implement `visibleSpansForSelectionRange`, register in provider |
| `src/vue/components/TVirtualMarkdown.ts` | Implement `visibleSpansForSelectionRange`, register in provider |
| `src/vue/components/TVirtualList.ts` | Full `SelectionTextProvider` registration with `pointForCell`, `getText`, `getVisibleSpans` |
| `src/vue/components/TerminalProvider.ts` | Document-level mouse listeners during active selection |
| `src/index.ts` | Export `SelectedRowSpan` type |
| `test/terminal-selection.test.ts` | 2 new tests: provider getVisibleSpans, fallback to terminal buffer spans |
| `test/terminal-selection-provider.test.ts` | 2 new tests: TVirtualList cross-viewport copy, visible highlight after auto-scroll |

## Validation

- ✅ `typecheck` passes
- ✅ `lint` passes (0 warnings, 0 errors)
- ✅ 52 selection tests pass across 4 test files

## Key scenario walkthrough

```
User starts selecting in TLogView
Drags to bottom edge → auto-scroll triggers
Content scrolls up, anchor is now above viewport
getVisibleSpans() maps provider range to visible screen rows
Overlay correctly highlights only what's visible
On mouseup, getText() returns full cross-viewport text
Clipboard gets the complete selection
```