### PR TITLE
Add experimental transcript view

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Development, release validation, and documentation builds are run on Node.js 20 
 | `@simon_he/vue-tui/observability` | Advanced     | Frame perf store, profiler hooks, and trace helpers                                                                         |
 | `@simon_he/vue-tui/cli`           | Public       | Node-only headless Vue app runtime, stdin driver, stdout renderer, path provider, recording, and terminal clipboard helpers |
 | `@simon_he/vue-tui/markdown`      | Public       | `TMarkdownText`, `TVirtualMarkdown`, markdown parser and layout helpers, streaming markdown block sources                   |
-| `@simon_he/vue-tui/experimental`  | Experimental | `TVirtualList`, `TLogView`, TLog search/link/minimap companions, append-only log store, and TLog plugins                    |
+| `@simon_he/vue-tui/experimental`  | Experimental | `TVirtualList`, `TTranscriptView`, `TLogView`, TLog search/link/minimap companions, append-only log store, and TLog plugins |
 
 The stable surface is terminal core, DOM rendering, CLI runtime, basic Vue components, and markdown APIs. High-throughput log and virtualization APIs stay under `/experimental` until their public surface settles; keep those imports isolated in application code.
 
@@ -203,7 +203,7 @@ Unhandled promise rejections stay host-owned by default. Setting `cleanupOnUnhan
 | Stable overlay | `@simon_he/vue-tui`              | `TDialog`                                                                                                                                                                  |
 | Vue extended   | `@simon_he/vue-tui/vue`          | `TAnchor`, `TFlow`, `TRenderPlane`, `TRenderLayer`, `TTransition`, `TInputBox`, `TPathPicker`, `TJsonEditor`, `TMultilineModal`, `TDebugOverlay`, composables, router APIs |
 | Markdown       | `@simon_he/vue-tui/markdown`     | `TMarkdownText`, `TVirtualMarkdown`                                                                                                                                        |
-| Experimental   | `@simon_he/vue-tui/experimental` | `TVirtualList`, `TLogView`, `TLogSearchBar`, `TLogLinksPanel`, `TLogScrollbar`, `TLogMinimap`                                                                              |
+| Experimental   | `@simon_he/vue-tui/experimental` | `TVirtualList`, `TTranscriptView`, `TLogView`, `TLogSearchBar`, `TLogLinksPanel`, `TLogScrollbar`, `TLogMinimap`                                                           |
 | Runtime        | `@simon_he/vue-tui/runtime`      | runtime, event, and selection APIs                                                                                                                                         |
 | CLI            | `@simon_he/vue-tui/cli`          | `createTerminalApp`, `createStdoutRenderer`, `createStdinDriver`, Node host adapters                                                                                       |
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -499,7 +499,7 @@ Wheel burst 通过 frame mailbox 合并；同一帧只应用最后的 `scrollTop
 
 Transcript row viewport：渲染 message / action / tool-call / approval rows，支持 row-scoped action/link hit regions、focus navigation、cell selection copy 和 wrapped visual rows。
 
-> Experimental prototype：当前从 `@simon_he/vue-tui/experimental` 导出，暂不进入 root 入口。它会在当前 layout state 中 flatten source rows 到 visual rows；适合小到中等 transcript 和交互原型，不适合作为几十万 visual rows 的高吞吐 retained transcript 视图。大规模 append-only output 继续使用 `TLogView`。
+> Experimental prototype：当前从 `@simon_he/vue-tui/experimental` 导出，暂不进入 root 入口。它会在当前 layout state 中 flatten source rows 到 visual rows；适合小到中等 transcript 和交互原型，建议控制在 few thousand visual rows 量级，不适合作为几十万 visual rows 的高吞吐 retained transcript 视图。大规模 append-only output 继续使用 `TLogView`。
 
 ### Props
 
@@ -513,6 +513,7 @@ Transcript row viewport：渲染 message / action / tool-call / approval rows，
 - `wrap` `(boolean)`
 - `style` / `hoverStyle` / `focusStyle` `(Style?)`
 - `autoFocus` / `focusable` / `wheelScroll` `(boolean)`
+- `keyboardRegions` `(boolean)`：默认 `true`，获得焦点时 `Tab` / `Shift+Tab` 在当前 viewport 的 hit regions 间循环 focus，`Enter` 激活 focused region，`Escape` 清除 focus
 
 ### Events
 
@@ -521,6 +522,8 @@ Transcript row viewport：渲染 message / action / tool-call / approval rows，
 - `hoverRegion`: region event or `null`
 - `scroll`: scroll metrics
 - `update:scrollTop`: `scrollTop`（number）
+
+`TTranscriptSegment.text` 是 inline-only 文本；显式 `\n` / `\r` / `\t` 会按 inline cell 文本规整。需要保留显式换行时，请在 source 层拆成多个 transcript rows，或拆成独立 visual row blocks。
 
 ## TMarkdownText / TVirtualMarkdown
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -8,26 +8,26 @@
 
 ## 导入入口
 
-| API maturity | Import                           | 组件                                                                                                                                                                              |
-| ------------ | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Public       | `@simon_he/vue-tui`              | `TerminalProvider` `TBox` `TDialog` `TInput` `TList` `TSelect` `TText` `TView`                                                                                                    |
-| Advanced     | `@simon_he/vue-tui/vue`          | `TAnchor` `TDebugOverlay` `TFlow` `TInputBox` `TJsonEditor` `TMultilineModal` `TPathPicker` `TRenderLayer` `TRenderPlane` `TRouterView` `TTransition`                             |
-| Public       | `@simon_he/vue-tui/markdown`     | `TMarkdownText` `TVirtualMarkdown`                                                                                                                                                |
-| Experimental | `@simon_he/vue-tui/experimental` | `TVirtualList` `TLogView` `TLogSearchBar` `TLogSearchResults` `TLogSearchPager` `TLogLinksPanel` `TLogVirtualSearchResults` `TLogVirtualLinksPanel` `TLogScrollbar` `TLogMinimap` |
+| API maturity | Import                           | 组件                                                                                                                                                                                                |
+| ------------ | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Public       | `@simon_he/vue-tui`              | `TerminalProvider` `TBox` `TDialog` `TInput` `TList` `TSelect` `TText` `TView`                                                                                                                      |
+| Advanced     | `@simon_he/vue-tui/vue`          | `TAnchor` `TDebugOverlay` `TFlow` `TInputBox` `TJsonEditor` `TMultilineModal` `TPathPicker` `TRenderLayer` `TRenderPlane` `TRouterView` `TTransition`                                               |
+| Public       | `@simon_he/vue-tui/markdown`     | `TMarkdownText` `TVirtualMarkdown`                                                                                                                                                                  |
+| Experimental | `@simon_he/vue-tui/experimental` | `TVirtualList` `TTranscriptView` `TLogView` `TLogSearchBar` `TLogSearchResults` `TLogSearchPager` `TLogLinksPanel` `TLogVirtualSearchResults` `TLogVirtualLinksPanel` `TLogScrollbar` `TLogMinimap` |
 
 下面的组件速读按用途分组，不代表 root entrypoint 导出。每个组件的 primary import 以生成的 [组件 API](/generated/components-api) 为准。
 
 ## 组件速读
 
-| 类别          | 组件                                                                                                                                                           | 典型用途                                        | 适配性判断                                         |
-| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------- |
-| Root          | `TerminalProvider`                                                                                                                                             | 创建 terminal / renderer / event manager 上下文 | 通用，适合所有宿主                                 |
-| Layout        | `TBox` `TView` `TAnchor` `TFlow` `TRenderLayer` `TRenderPlane`                                                                                                 | 布局、裁剪、层级、分层组合                      | 通用，和 CLI 业务无关                              |
-| Text / Motion | `TText` `TTransition`                                                                                                                                          | 文本渲染、状态切换、动画插值                    | 通用                                               |
-| Input         | `TInput` `TInputBox` `TJsonEditor`                                                                                                                             | prompt、表单、结构化文本编辑                    | 通用，但推荐把补全/校验放到插件层                  |
-| Pickers       | `TList` `TVirtualList` `TLogView` `TLogSearchBar` `TLogSearchResults` `TLogSearchPager` `TLogLinksPanel` `TLogScrollbar` `TLogMinimap` `TSelect` `TPathPicker` | palette、列表、日志、路径选择                   | `TPathPicker` 本体可复用，路径语义由 provider 注入 |
-| Overlay       | `TDialog` `TMultilineModal` `TDebugOverlay`                                                                                                                    | 对话框、详情查看、调试覆盖层                    | 通用，适合多种宿主                                 |
-| Navigation    | `TRouterView` + `createTerminalRouter()`                                                                                                                       | 多页面 TUI / shell                              | 通用                                               |
+| 类别          | 组件                                                                                                                                                                             | 典型用途                                        | 适配性判断                                         |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------- |
+| Root          | `TerminalProvider`                                                                                                                                                               | 创建 terminal / renderer / event manager 上下文 | 通用，适合所有宿主                                 |
+| Layout        | `TBox` `TView` `TAnchor` `TFlow` `TRenderLayer` `TRenderPlane`                                                                                                                   | 布局、裁剪、层级、分层组合                      | 通用，和 CLI 业务无关                              |
+| Text / Motion | `TText` `TTransition`                                                                                                                                                            | 文本渲染、状态切换、动画插值                    | 通用                                               |
+| Input         | `TInput` `TInputBox` `TJsonEditor`                                                                                                                                               | prompt、表单、结构化文本编辑                    | 通用，但推荐把补全/校验放到插件层                  |
+| Pickers       | `TList` `TVirtualList` `TTranscriptView` `TLogView` `TLogSearchBar` `TLogSearchResults` `TLogSearchPager` `TLogLinksPanel` `TLogScrollbar` `TLogMinimap` `TSelect` `TPathPicker` | palette、列表、transcript、日志、路径选择       | `TPathPicker` 本体可复用，路径语义由 provider 注入 |
+| Overlay       | `TDialog` `TMultilineModal` `TDebugOverlay`                                                                                                                                      | 对话框、详情查看、调试覆盖层                    | 通用，适合多种宿主                                 |
+| Navigation    | `TRouterView` + `createTerminalRouter()`                                                                                                                                         | 多页面 TUI / shell                              | 通用                                               |
 
 如果你更关心“哪些地方还应该继续做插件化”，建议配合阅读：[扩展性与插件化](./extensibility.md)。
 
@@ -494,6 +494,33 @@ Wheel burst 通过 frame mailbox 合并；同一帧只应用最后的 `scrollTop
 - `update:scrollTop`: `scrollTop`（number）
 - `scroll`: `scrollTop`（number）
 - `focus` / `blur` / `keydown`
+
+## TTranscriptView
+
+Transcript row viewport：渲染 message / action / tool-call / approval rows，支持 row-scoped action/link hit regions、focus navigation、cell selection copy 和 wrapped visual rows。
+
+> Experimental prototype：当前从 `@simon_he/vue-tui/experimental` 导出，暂不进入 root 入口。它会在当前 layout state 中 flatten source rows 到 visual rows；适合小到中等 transcript 和交互原型，不适合作为几十万 visual rows 的高吞吐 retained transcript 视图。大规模 append-only output 继续使用 `TLogView`。
+
+### Props
+
+- `x`/`y`/`w`/`h` `(number, required)`
+- `source` `(TTranscriptDataSource, required)`：提供 `rowCount()`、`getRow(index)`，可选提供 `getRowKey(index)`、`firstRowIndex()`
+- `version` `(number, required)`：数据变化版本号
+- `scrollTop` `(number?)` + `update:scrollTop`
+- `defaultScrollTop` `(number?)`
+- `autoStickToBottom` `(boolean)`
+- `selectable` `(boolean)`
+- `wrap` `(boolean)`
+- `style` / `hoverStyle` / `focusStyle` `(Style?)`
+- `autoFocus` / `focusable` / `wheelScroll` `(boolean)`
+
+### Events
+
+- `actionClick` / `linkClick` / `foldToggle` / `toolClick`: `{ region, row, rowIndex, absoluteRowIndex, event }`
+- `rowClick`: `{ row, rowIndex, absoluteRowIndex, event }`
+- `hoverRegion`: region event or `null`
+- `scroll`: scroll metrics
+- `update:scrollTop`: `scrollTop`（number）
 
 ## TMarkdownText / TVirtualMarkdown
 

--- a/docs/generated/components-api.md
+++ b/docs/generated/components-api.md
@@ -1013,6 +1013,7 @@ Import: `@simon_he/vue-tui/experimental`
 | <code>autoFocus</code>         | <code>boolean</code>               | <code>false</code>                       | 否   | —    |
 | <code>focusable</code>         | <code>boolean</code>               | <code>true</code>                        | 否   | —    |
 | <code>wheelScroll</code>       | <code>boolean</code>               | <code>true</code>                        | 否   | —    |
+| <code>keyboardRegions</code>   | <code>boolean</code>               | <code>true</code>                        | 否   | —    |
 | <code>rowScrollMode</code>     | <code>RowScrollMode</code>         | <code>&quot;unsafe-full-row&quot;</code> | 否   | —    |
 
 ### Events

--- a/docs/generated/components-api.md
+++ b/docs/generated/components-api.md
@@ -30,6 +30,7 @@
 - [TRouterView](#trouterview)
 - [TSelect](#tselect)
 - [TText](#ttext)
+- [TTranscriptView](#ttranscriptview)
 - [TTransition](#ttransition)
 - [TView](#tview)
 - [TVirtualList](#tvirtuallist)
@@ -981,6 +982,51 @@ Import: `@simon_he/vue-tui`
 ### Events
 
 —
+
+## TTranscriptView
+
+源码：`src/vue/components/TTranscriptView.ts`
+
+API maturity: **Experimental**
+
+Import: `@simon_he/vue-tui/experimental`
+
+### Props
+
+| 名称                           | 类型                               | 默认值                                   | 必填 | 说明 |
+| ------------------------------ | ---------------------------------- | ---------------------------------------- | ---- | ---- |
+| <code>x</code>                 | <code>number</code>                | —                                        | 是   | —    |
+| <code>y</code>                 | <code>number</code>                | —                                        | 是   | —    |
+| <code>w</code>                 | <code>number</code>                | —                                        | 是   | —    |
+| <code>h</code>                 | <code>number</code>                | —                                        | 是   | —    |
+| <code>zIndex</code>            | <code>number</code>                | <code>0</code>                           | 否   | —    |
+| <code>source</code>            | <code>TTranscriptDataSource</code> | —                                        | 是   | —    |
+| <code>version</code>           | <code>number</code>                | —                                        | 是   | —    |
+| <code>scrollTop</code>         | <code>number</code>                | <code>undefined</code>                   | 否   | —    |
+| <code>defaultScrollTop</code>  | <code>number</code>                | <code>0</code>                           | 否   | —    |
+| <code>autoStickToBottom</code> | <code>boolean</code>               | <code>false</code>                       | 否   | —    |
+| <code>selectable</code>        | <code>boolean</code>               | <code>true</code>                        | 否   | —    |
+| <code>wrap</code>              | <code>boolean</code>               | <code>false</code>                       | 否   | —    |
+| <code>style</code>             | <code>Style</code>                 | <code>undefined</code>                   | 否   | —    |
+| <code>hoverStyle</code>        | <code>Style</code>                 | <code>undefined</code>                   | 否   | —    |
+| <code>focusStyle</code>        | <code>Style</code>                 | <code>undefined</code>                   | 否   | —    |
+| <code>autoFocus</code>         | <code>boolean</code>               | <code>false</code>                       | 否   | —    |
+| <code>focusable</code>         | <code>boolean</code>               | <code>true</code>                        | 否   | —    |
+| <code>wheelScroll</code>       | <code>boolean</code>               | <code>true</code>                        | 否   | —    |
+| <code>rowScrollMode</code>     | <code>RowScrollMode</code>         | <code>&quot;unsafe-full-row&quot;</code> | 否   | —    |
+
+### Events
+
+| 名称                          | Payload | 说明 |
+| ----------------------------- | ------- | ---- |
+| <code>scroll</code>           | —       | —    |
+| <code>update:scrollTop</code> | —       | —    |
+| <code>rowClick</code>         | —       | —    |
+| <code>actionClick</code>      | —       | —    |
+| <code>linkClick</code>        | —       | —    |
+| <code>foldToggle</code>       | —       | —    |
+| <code>toolClick</code>        | —       | —    |
+| <code>hoverRegion</code>      | —       | —    |
 
 ## TTransition
 

--- a/src/experimental.ts
+++ b/src/experimental.ts
@@ -66,6 +66,7 @@ export type {
   TTranscriptRegionEvent,
   TTranscriptRow,
   TTranscriptRowEvent,
+  TTranscriptSelectionSegment,
   TTranscriptSegment,
   TTranscriptViewHandle,
   TTranscriptVisualRow,

--- a/src/experimental.ts
+++ b/src/experimental.ts
@@ -1,4 +1,5 @@
 export { TVirtualList } from "./vue/components/TVirtualList.js";
+export { TTranscriptView } from "./vue/components/TTranscriptView.js";
 export { TLogView } from "./vue/components/TLogView.js";
 export { TLogScrollbar } from "./vue/components/TLogScrollbar.js";
 export { TLogMinimap } from "./vue/components/TLogMinimap.js";
@@ -58,6 +59,18 @@ export {
   tlogHighContrastTheme,
 } from "./vue/log/tlog-theme.js";
 export type { RowScrollMode } from "./vue/components/TVirtualList.js";
+export type {
+  TTranscriptAction,
+  TTranscriptDataSource,
+  TTranscriptHitRegion,
+  TTranscriptRegionEvent,
+  TTranscriptRow,
+  TTranscriptRowEvent,
+  TTranscriptSegment,
+  TTranscriptViewHandle,
+  TTranscriptVisualRow,
+  TTranscriptVisualSegment,
+} from "./vue/transcript/types.js";
 export type {
   TLogLinkPanelItem,
   TLogLinksPanelSelectPayload,

--- a/src/vue/components/TTranscriptView.ts
+++ b/src/vue/components/TTranscriptView.ts
@@ -6,6 +6,7 @@ import type {
   TVirtualRowsSelectionSpanTextContext,
 } from "./TVirtualRows.js";
 import type { Style } from "../../core/types.js";
+import type { TerminalKeyboardEvent } from "../../events/manager/types.js";
 import type {
   TTranscriptDataSource,
   TTranscriptHitRegion,
@@ -153,6 +154,7 @@ export const TTranscriptView = defineComponent({
     autoFocus: { type: Boolean, default: false },
     focusable: { type: Boolean, default: true },
     wheelScroll: { type: Boolean, default: true },
+    keyboardRegions: { type: Boolean, default: true },
     rowScrollMode: {
       type: String as PropType<RowScrollMode>,
       default: "unsafe-full-row",
@@ -176,6 +178,7 @@ export const TTranscriptView = defineComponent({
     const hoveredRegion = ref<TTranscriptHitRegion | null>(null);
     const focusedRegion = ref<TTranscriptHitRegion | null>(null);
     const rowLayoutCache = new Map<number, RowLayoutCacheEntry>();
+    let warnedLargeFlattenedRows = false;
 
     function isScrollControlled(): boolean {
       return Object.prototype.hasOwnProperty.call(instance?.vnode.props ?? {}, "scrollTop");
@@ -249,6 +252,16 @@ export const TTranscriptView = defineComponent({
       }
       for (const rowIndex of rowLayoutCache.keys()) {
         if (rowIndex >= count) rowLayoutCache.delete(rowIndex);
+      }
+      if (
+        !warnedLargeFlattenedRows &&
+        (globalThis as any).__VT_DEBUG_PERF__ &&
+        visualRows.length > 5000
+      ) {
+        warnedLargeFlattenedRows = true;
+        console.warn(
+          "[vue-tui] TTranscriptView flattens all transcript rows; use TLogView or windowed source for large retained output.",
+        );
       }
       return { visualRows, rowStarts, rowEnds, regions };
     });
@@ -346,6 +359,23 @@ export const TTranscriptView = defineComponent({
       return regions;
     }
 
+    function hasVisibleRegionId(id: string): boolean {
+      const rows = layoutState.value.visualRows;
+      const top = clamp(currentScrollTop(), 0, rows.length);
+      const bottom = Math.min(rows.length, top + Math.max(0, normalizeInt(props.h)));
+      for (let i = top; i < bottom; i++) {
+        if (rows[i]?.hitRegions.some((region) => region.id === id)) return true;
+      }
+      return false;
+    }
+
+    function reconcileActiveRegions(): void {
+      const hover = hoveredRegion.value;
+      if (hover && !hasVisibleRegionId(hover.id)) setHoveredRegion(null);
+      const focus = focusedRegion.value;
+      if (focus && !hasVisibleRegionId(focus.id)) setFocusedRegion(null);
+    }
+
     function focusRegionByOffset(offset: number): boolean {
       const regions = visibleFocusableRegions();
       if (!regions.length) return false;
@@ -371,6 +401,23 @@ export const TTranscriptView = defineComponent({
       if (!visibleFocusableRegions().some((candidate) => candidate.id === region.id)) return false;
       emitRegion(region);
       return true;
+    }
+
+    function onKeydown(e: TerminalKeyboardEvent): void {
+      if (!props.keyboardRegions) return;
+      if (e.key === "Tab") {
+        const handled = e.shiftKey ? focusPreviousRegion() : focusNextRegion();
+        if (handled) e.preventDefault();
+        return;
+      }
+      if (e.key === "Enter") {
+        if (activateFocusedRegion()) e.preventDefault();
+        return;
+      }
+      if (e.key === "Escape" && focusedRegion.value) {
+        e.preventDefault();
+        setFocusedRegion(null);
+      }
     }
 
     function scrollToTop(): void {
@@ -447,6 +494,11 @@ export const TTranscriptView = defineComponent({
         rowsRef.value?.scrollTo(nextTop);
         setScrollTop(nextTop);
       },
+    );
+
+    watch(
+      () => [layoutState.value.regions, currentScrollTop(), props.h],
+      () => reconcileActiveRegions(),
     );
 
     function paintVisualRow(paintCtx: TVirtualRowsPaintContext): void {
@@ -561,6 +613,7 @@ export const TTranscriptView = defineComponent({
         selectable: props.selectable,
         wheelScroll: props.wheelScroll,
         rowScrollMode: props.rowScrollMode,
+        onKeydown,
         onScroll: (payload: any) => emit("scroll", payload),
         onItemClick: (event: { item: unknown; event?: unknown }) => {
           const visualRow = event.item as TTranscriptVisualRow | undefined;

--- a/src/vue/components/TTranscriptView.ts
+++ b/src/vue/components/TTranscriptView.ts
@@ -7,6 +7,7 @@ import type {
   TTranscriptRegionEvent,
   TTranscriptRow,
   TTranscriptRowEvent,
+  TTranscriptSegment,
   TTranscriptViewHandle,
   TTranscriptVisualRow,
 } from "../transcript/types.js";
@@ -27,6 +28,21 @@ type LayoutState = Readonly<{
   regions: readonly TTranscriptHitRegion[];
 }>;
 
+type RowLayoutCacheEntry = Readonly<{
+  version: number;
+  row: TTranscriptRow;
+  rowIndex: number;
+  rowKey: string | number;
+  width: number;
+  wrap: boolean;
+  baseStyle: Style;
+  hoverStyle?: Style;
+  focusStyle?: Style;
+  hoverRegionId: string | null;
+  focusedRegionId: string | null;
+  visualRows: readonly TTranscriptVisualRow[];
+}>;
+
 const EMPTY_LAYOUT: LayoutState = Object.freeze({
   visualRows: Object.freeze([]),
   rowStarts: new Map(),
@@ -41,6 +57,55 @@ function clamp(n: number, min: number, max: number): number {
 function normalizeInt(value: unknown): number {
   const n = Math.floor(Number(value));
   return Number.isFinite(n) ? n : 0;
+}
+
+function sourceSegmentsForRegion(row: TTranscriptRow): readonly TTranscriptSegment[] {
+  if (row.kind === "message") return row.segments;
+  if (row.kind === "approval") {
+    const description = row.description ?? [];
+    return [{ text: row.title }, ...(description.length ? [{ text: " " }] : []), ...description];
+  }
+  if (row.kind === "tool-call") {
+    const content: TTranscriptSegment[] = [
+      { text: row.collapsed ? `▸ ${row.title}` : `▾ ${row.title}` },
+    ];
+    if (row.summary?.length) content.push({ text: " " }, ...row.summary);
+    if (!row.collapsed && row.body?.length) content.push({ text: " " }, ...row.body);
+    return content;
+  }
+  return [{ text: row.label }];
+}
+
+function rowHasRegionId(row: TTranscriptRow, rowKey: string | number, id: string | null): boolean {
+  if (!id) return false;
+  if ("actions" in row && row.actions?.some((action) => action.id === id)) return true;
+  const segments = sourceSegmentsForRegion(row);
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i]!;
+    if (segment.href == null) continue;
+    if ((segment.tokenId ?? `link:${rowKey}:${i}`) === id) return true;
+  }
+  return false;
+}
+
+function sameCachedLayout(
+  entry: RowLayoutCacheEntry | undefined,
+  next: Omit<RowLayoutCacheEntry, "visualRows">,
+): boolean {
+  return (
+    Boolean(entry) &&
+    entry!.version === next.version &&
+    entry!.row === next.row &&
+    entry!.rowIndex === next.rowIndex &&
+    entry!.rowKey === next.rowKey &&
+    entry!.width === next.width &&
+    entry!.wrap === next.wrap &&
+    entry!.baseStyle === next.baseStyle &&
+    entry!.hoverStyle === next.hoverStyle &&
+    entry!.focusStyle === next.focusStyle &&
+    entry!.hoverRegionId === next.hoverRegionId &&
+    entry!.focusedRegionId === next.focusedRegionId
+  );
 }
 
 export const TTranscriptView = defineComponent({
@@ -61,7 +126,6 @@ export const TTranscriptView = defineComponent({
     autoStickToBottom: { type: Boolean, default: false },
     selectable: { type: Boolean, default: true },
     wrap: { type: Boolean, default: false },
-    overscan: { type: Number, default: 0 },
     style: { type: Object as PropType<Style>, default: undefined },
     hoverStyle: { type: Object as PropType<Style>, default: undefined },
     focusStyle: { type: Object as PropType<Style>, default: undefined },
@@ -82,9 +146,6 @@ export const TTranscriptView = defineComponent({
     "foldToggle",
     "toolClick",
     "hoverRegion",
-    "selectionHover",
-    "search",
-    "searchMatch",
   ],
   setup(props, { emit, expose }) {
     const { defaultStyle } = useTerminal();
@@ -93,7 +154,7 @@ export const TTranscriptView = defineComponent({
     const innerScrollTop = ref(normalizeInt(props.defaultScrollTop));
     const hoveredRegion = ref<TTranscriptHitRegion | null>(null);
     const focusedRegion = ref<TTranscriptHitRegion | null>(null);
-    const interactionVersion = ref(0);
+    const rowLayoutCache = new Map<number, RowLayoutCacheEntry>();
 
     function isScrollControlled(): boolean {
       return Object.prototype.hasOwnProperty.call(instance?.vnode.props ?? {}, "scrollTop");
@@ -105,37 +166,68 @@ export const TTranscriptView = defineComponent({
 
     const layoutState = computed<LayoutState>(() => {
       void props.version;
-      void interactionVersion.value;
       const width = Math.max(1, Math.floor(props.w));
       const count = Math.max(0, normalizeInt(props.source.rowCount()));
-      if (!count) return EMPTY_LAYOUT;
+      if (!count) {
+        rowLayoutCache.clear();
+        return EMPTY_LAYOUT;
+      }
 
       const visualRows: TTranscriptVisualRow[] = [];
       const rowStarts = new Map<number, number>();
       const rowEnds = new Map<number, number>();
       const regions: TTranscriptHitRegion[] = [];
       const baseStyle = props.style ?? defaultStyle.value;
+      const hoverRegionId = hoveredRegion.value?.id ?? null;
+      const focusedRegionId = focusedRegion.value?.id ?? null;
       for (let rowIndex = 0; rowIndex < count; rowIndex++) {
         const row = props.source.getRow(rowIndex);
         const rowKey = props.source.getRowKey?.(rowIndex) ?? row.key;
-        rowStarts.set(rowIndex, visualRows.length);
-        const rows = layoutTranscriptRow({
+        const localHoverRegionId = rowHasRegionId(row, rowKey, hoverRegionId)
+          ? hoverRegionId
+          : null;
+        const localFocusedRegionId = rowHasRegionId(row, rowKey, focusedRegionId)
+          ? focusedRegionId
+          : null;
+        const cacheKey = {
+          version: props.version,
           row,
           rowIndex,
           rowKey,
           width,
+          wrap: props.wrap,
           baseStyle,
-          hoverRegionId: hoveredRegion.value?.id ?? null,
-          focusedRegionId: focusedRegion.value?.id ?? null,
           hoverStyle: props.hoverStyle,
           focusStyle: props.focusStyle,
-          wrap: props.wrap,
-        });
+          hoverRegionId: localHoverRegionId,
+          focusedRegionId: localFocusedRegionId,
+        };
+        rowStarts.set(rowIndex, visualRows.length);
+        const cached = rowLayoutCache.get(rowIndex);
+        const rows = sameCachedLayout(cached, cacheKey)
+          ? cached!.visualRows
+          : layoutTranscriptRow({
+              row,
+              rowIndex,
+              rowKey,
+              width,
+              baseStyle,
+              hoverRegionId: localHoverRegionId,
+              focusedRegionId: localFocusedRegionId,
+              hoverStyle: props.hoverStyle,
+              focusStyle: props.focusStyle,
+              wrap: props.wrap,
+            });
+        if (rows !== cached?.visualRows)
+          rowLayoutCache.set(rowIndex, { ...cacheKey, visualRows: rows });
         for (const visualRow of rows) {
           visualRows.push(visualRow);
           regions.push(...visualRow.hitRegions);
         }
         rowEnds.set(rowIndex, visualRows.length);
+      }
+      for (const rowIndex of rowLayoutCache.keys()) {
+        if (rowIndex >= count) rowLayoutCache.delete(rowIndex);
       }
       return { visualRows, rowStarts, rowEnds, regions };
     });
@@ -154,16 +246,31 @@ export const TTranscriptView = defineComponent({
       return props.source.getRow(visualRow.rowIndex);
     }
 
+    function firstRowIndex(): number {
+      return normalizeInt(props.source.firstRowIndex?.() ?? 0);
+    }
+
     function regionEvent(region: TTranscriptHitRegion, event?: unknown): TTranscriptRegionEvent {
       return {
         region,
         row: props.source.getRow(region.rowIndex),
         rowIndex: region.rowIndex,
+        absoluteRowIndex: firstRowIndex() + region.rowIndex,
         event,
       };
     }
 
+    function isDisabledActionRegion(region: TTranscriptHitRegion): boolean {
+      return (
+        region.kind === "action" &&
+        Boolean(
+          (region.payload as { action?: { disabled?: boolean } } | undefined)?.action?.disabled,
+        )
+      );
+    }
+
     function emitRegion(region: TTranscriptHitRegion, pointerEvent?: unknown): void {
+      if (isDisabledActionRegion(region)) return;
       const event = regionEvent(region, pointerEvent);
       if (region.kind === "action") emit("actionClick", event);
       else if (region.kind === "link") emit("linkClick", event);
@@ -189,7 +296,6 @@ export const TTranscriptView = defineComponent({
       const prev = hoveredRegion.value;
       if (prev?.id === region?.id) return;
       hoveredRegion.value = region;
-      interactionVersion.value++;
       invalidateRegion(prev);
       invalidateRegion(region);
       emit("hoverRegion", region ? regionEvent(region) : null);
@@ -199,7 +305,6 @@ export const TTranscriptView = defineComponent({
       const prev = focusedRegion.value;
       if (prev?.id === region?.id) return;
       focusedRegion.value = region;
-      interactionVersion.value++;
       invalidateRegion(prev);
       invalidateRegion(region);
     }
@@ -226,6 +331,7 @@ export const TTranscriptView = defineComponent({
     function activateFocusedRegion(): boolean {
       const region = focusedRegion.value;
       if (!region) return false;
+      if (!layoutState.value.regions.some((candidate) => candidate.id === region.id)) return false;
       emitRegion(region);
       return true;
     }
@@ -359,6 +465,17 @@ export const TTranscriptView = defineComponent({
       return nodes;
     }
 
+    function getVisualRow(index: number): TTranscriptVisualRow | undefined {
+      return layoutState.value.visualRows[index];
+    }
+
+    function selectionTextForVisualRow(item: unknown): string {
+      const visualRow = item as TTranscriptVisualRow | undefined;
+      if (!visualRow) return "";
+      const row = rowForVisualRow(visualRow);
+      return visualRow.selectableText ?? plainTextForTranscriptRow(row);
+    }
+
     return () =>
       h(TVirtualRows, {
         ref: rowsRef,
@@ -368,16 +485,11 @@ export const TTranscriptView = defineComponent({
         h: props.h,
         zIndex: props.zIndex,
         itemCount: layoutState.value.visualRows.length,
-        itemVersion: props.version + interactionVersion.value,
-        getItem: (index: number) => layoutState.value.visualRows[index],
+        itemVersion: props.version,
+        getItem: getVisualRow,
         paintItem: paintVisualRow,
         renderItemNodes: renderVisualRowNodes,
-        selectionText: (item: unknown) => {
-          const visualRow = item as TTranscriptVisualRow | undefined;
-          if (!visualRow) return "";
-          const row = rowForVisualRow(visualRow);
-          return visualRow.selectableText ?? plainTextForTranscriptRow(row);
-        },
+        selectionText: selectionTextForVisualRow,
         scrollTop: currentScrollTop(),
         style: props.style,
         autoFocus: props.autoFocus,
@@ -392,6 +504,7 @@ export const TTranscriptView = defineComponent({
           const rowEvent: TTranscriptRowEvent = {
             row: rowForVisualRow(visualRow),
             rowIndex: visualRow.rowIndex,
+            absoluteRowIndex: firstRowIndex() + visualRow.rowIndex,
             event: event.event,
           };
           emit("rowClick", rowEvent);

--- a/src/vue/components/TTranscriptView.ts
+++ b/src/vue/components/TTranscriptView.ts
@@ -1,5 +1,10 @@
 import type { PropType } from "vue";
-import type { TVirtualRowsHandle, TVirtualRowsPaintContext } from "./TVirtualRows.js";
+import type {
+  TVirtualRowsHandle,
+  TVirtualRowsPaintContext,
+  TVirtualRowsRenderNodesContext,
+  TVirtualRowsSelectionSpanTextContext,
+} from "./TVirtualRows.js";
 import type { Style } from "../../core/types.js";
 import type {
   TTranscriptDataSource,
@@ -7,12 +12,17 @@ import type {
   TTranscriptRegionEvent,
   TTranscriptRow,
   TTranscriptRowEvent,
+  TTranscriptSelectionSegment,
   TTranscriptSegment,
   TTranscriptViewHandle,
   TTranscriptVisualRow,
 } from "../transcript/types.js";
 import { computed, defineComponent, getCurrentInstance, h, ref, watch } from "vue";
-import { layoutTranscriptRow } from "../transcript/layout.js";
+import {
+  layoutTranscriptRow,
+  transcriptActionRegionId,
+  transcriptLinkRegionId,
+} from "../transcript/layout.js";
 import { plainTextForTranscriptRow } from "../transcript/plain-text.js";
 import { sliceByCellsRange } from "../utils/text.js";
 import { TView } from "./TView.js";
@@ -78,12 +88,16 @@ function sourceSegmentsForRegion(row: TTranscriptRow): readonly TTranscriptSegme
 
 function rowHasRegionId(row: TTranscriptRow, rowKey: string | number, id: string | null): boolean {
   if (!id) return false;
-  if ("actions" in row && row.actions?.some((action) => action.id === id)) return true;
+  if (
+    "actions" in row &&
+    row.actions?.some((action) => transcriptActionRegionId(rowKey, action.id) === id)
+  )
+    return true;
   const segments = sourceSegmentsForRegion(row);
   for (let i = 0; i < segments.length; i++) {
     const segment = segments[i]!;
     if (segment.href == null) continue;
-    if ((segment.tokenId ?? `link:${rowKey}:${i}`) === id) return true;
+    if (transcriptLinkRegionId(rowKey, i, segment.tokenId) === id) return true;
   }
   return false;
 }
@@ -420,13 +434,13 @@ export const TTranscriptView = defineComponent({
       for (const segment of visualRow.segments) {
         const start = x;
         const end = start + segment.cells;
-        const drawStart = Math.max(0, start);
-        const drawEnd = Math.min(paintCtx.w, end);
+        const drawStart = Math.max(paintCtx.clipX, start);
+        const drawEnd = Math.min(paintCtx.clipX + paintCtx.w, end);
         if (drawEnd > drawStart) {
           paintCtx.terminal.write(
             sliceByCellsRange(segment.text, drawStart - start, drawEnd - start),
             {
-              x: paintCtx.x + drawStart,
+              x: paintCtx.x + (drawStart - paintCtx.clipX),
               y: paintCtx.y,
               style: segment.style,
             },
@@ -436,7 +450,7 @@ export const TTranscriptView = defineComponent({
       }
     }
 
-    function renderVisualRowNodes(ctx: { item: unknown; index: number; row: number }): any[] {
+    function renderVisualRowNodes(ctx: TVirtualRowsRenderNodesContext): any[] {
       const visualRow = ctx.item as TTranscriptVisualRow | undefined;
       if (!visualRow) return [];
       const nodes: any[] = [];
@@ -465,15 +479,41 @@ export const TTranscriptView = defineComponent({
       return nodes;
     }
 
+    function textForSelectionSegments(
+      segments: readonly TTranscriptSelectionSegment[],
+      x0: number,
+      x1: number,
+    ): string {
+      let text = "";
+      for (const segment of segments) {
+        const start = Math.max(x0, segment.x0);
+        const end = Math.min(x1, segment.x1);
+        if (end <= start || !segment.selectable) continue;
+        text += sliceByCellsRange(segment.text, start - segment.x0, end - segment.x0);
+      }
+      return text;
+    }
+
     function getVisualRow(index: number): TTranscriptVisualRow | undefined {
       return layoutState.value.visualRows[index];
     }
 
-    function selectionTextForVisualRow(item: unknown): string {
-      const visualRow = item as TTranscriptVisualRow | undefined;
+    function selectionTextForVisualRow(visualRow: TTranscriptVisualRow | undefined): string {
       if (!visualRow) return "";
       const row = rowForVisualRow(visualRow);
       return visualRow.selectableText ?? plainTextForTranscriptRow(row);
+    }
+
+    function selectionTextForItem(item: unknown): string {
+      return selectionTextForVisualRow(item as TTranscriptVisualRow | undefined);
+    }
+
+    function selectionTextForVisualRowSpan(ctx: TVirtualRowsSelectionSpanTextContext): string {
+      const visualRow = ctx.item as TTranscriptVisualRow | undefined;
+      if (!visualRow) return "";
+      if (visualRow.selectionSegments.length)
+        return textForSelectionSegments(visualRow.selectionSegments, ctx.x0, ctx.x1);
+      return sliceByCellsRange(selectionTextForVisualRow(visualRow), ctx.x0, ctx.x1);
     }
 
     return () =>
@@ -489,7 +529,8 @@ export const TTranscriptView = defineComponent({
         getItem: getVisualRow,
         paintItem: paintVisualRow,
         renderItemNodes: renderVisualRowNodes,
-        selectionText: selectionTextForVisualRow,
+        selectionText: selectionTextForItem,
+        selectionSpanText: selectionTextForVisualRowSpan,
         scrollTop: currentScrollTop(),
         style: props.style,
         autoFocus: props.autoFocus,

--- a/src/vue/components/TTranscriptView.ts
+++ b/src/vue/components/TTranscriptView.ts
@@ -1,0 +1,402 @@
+import type { PropType } from "vue";
+import type { TVirtualRowsHandle, TVirtualRowsPaintContext } from "./TVirtualRows.js";
+import type { Style } from "../../core/types.js";
+import type {
+  TTranscriptDataSource,
+  TTranscriptHitRegion,
+  TTranscriptRegionEvent,
+  TTranscriptRow,
+  TTranscriptRowEvent,
+  TTranscriptViewHandle,
+  TTranscriptVisualRow,
+} from "../transcript/types.js";
+import { computed, defineComponent, getCurrentInstance, h, ref, watch } from "vue";
+import { layoutTranscriptRow } from "../transcript/layout.js";
+import { plainTextForTranscriptRow } from "../transcript/plain-text.js";
+import { sliceByCellsRange } from "../utils/text.js";
+import { TView } from "./TView.js";
+import { TVirtualRows } from "./TVirtualRows.js";
+import { useTerminal } from "../composables/use-terminal.js";
+
+type RowScrollMode = "off" | "unsafe-full-row";
+
+type LayoutState = Readonly<{
+  visualRows: readonly TTranscriptVisualRow[];
+  rowStarts: ReadonlyMap<number, number>;
+  rowEnds: ReadonlyMap<number, number>;
+  regions: readonly TTranscriptHitRegion[];
+}>;
+
+const EMPTY_LAYOUT: LayoutState = Object.freeze({
+  visualRows: Object.freeze([]),
+  rowStarts: new Map(),
+  rowEnds: new Map(),
+  regions: Object.freeze([]),
+});
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function normalizeInt(value: unknown): number {
+  const n = Math.floor(Number(value));
+  return Number.isFinite(n) ? n : 0;
+}
+
+export const TTranscriptView = defineComponent({
+  name: "TTranscriptView",
+  props: {
+    x: { type: Number, required: true },
+    y: { type: Number, required: true },
+    w: { type: Number, required: true },
+    h: { type: Number, required: true },
+    zIndex: { type: Number, default: 0 },
+    source: {
+      type: Object as PropType<TTranscriptDataSource>,
+      required: true,
+    },
+    version: { type: Number, required: true },
+    scrollTop: { type: Number, default: undefined },
+    defaultScrollTop: { type: Number, default: 0 },
+    autoStickToBottom: { type: Boolean, default: false },
+    selectable: { type: Boolean, default: true },
+    wrap: { type: Boolean, default: false },
+    overscan: { type: Number, default: 0 },
+    style: { type: Object as PropType<Style>, default: undefined },
+    hoverStyle: { type: Object as PropType<Style>, default: undefined },
+    focusStyle: { type: Object as PropType<Style>, default: undefined },
+    autoFocus: { type: Boolean, default: false },
+    focusable: { type: Boolean, default: true },
+    wheelScroll: { type: Boolean, default: true },
+    rowScrollMode: {
+      type: String as PropType<RowScrollMode>,
+      default: "unsafe-full-row",
+    },
+  },
+  emits: [
+    "scroll",
+    "update:scrollTop",
+    "rowClick",
+    "actionClick",
+    "linkClick",
+    "foldToggle",
+    "toolClick",
+    "hoverRegion",
+    "selectionHover",
+    "search",
+    "searchMatch",
+  ],
+  setup(props, { emit, expose }) {
+    const { defaultStyle } = useTerminal();
+    const instance = getCurrentInstance();
+    const rowsRef = ref<TVirtualRowsHandle | null>(null);
+    const innerScrollTop = ref(normalizeInt(props.defaultScrollTop));
+    const hoveredRegion = ref<TTranscriptHitRegion | null>(null);
+    const focusedRegion = ref<TTranscriptHitRegion | null>(null);
+    const interactionVersion = ref(0);
+
+    function isScrollControlled(): boolean {
+      return Object.prototype.hasOwnProperty.call(instance?.vnode.props ?? {}, "scrollTop");
+    }
+
+    function currentScrollTop(): number {
+      return normalizeInt(isScrollControlled() ? props.scrollTop : innerScrollTop.value);
+    }
+
+    const layoutState = computed<LayoutState>(() => {
+      void props.version;
+      void interactionVersion.value;
+      const width = Math.max(1, Math.floor(props.w));
+      const count = Math.max(0, normalizeInt(props.source.rowCount()));
+      if (!count) return EMPTY_LAYOUT;
+
+      const visualRows: TTranscriptVisualRow[] = [];
+      const rowStarts = new Map<number, number>();
+      const rowEnds = new Map<number, number>();
+      const regions: TTranscriptHitRegion[] = [];
+      const baseStyle = props.style ?? defaultStyle.value;
+      for (let rowIndex = 0; rowIndex < count; rowIndex++) {
+        const row = props.source.getRow(rowIndex);
+        const rowKey = props.source.getRowKey?.(rowIndex) ?? row.key;
+        rowStarts.set(rowIndex, visualRows.length);
+        const rows = layoutTranscriptRow({
+          row,
+          rowIndex,
+          rowKey,
+          width,
+          baseStyle,
+          hoverRegionId: hoveredRegion.value?.id ?? null,
+          focusedRegionId: focusedRegion.value?.id ?? null,
+          hoverStyle: props.hoverStyle,
+          focusStyle: props.focusStyle,
+          wrap: props.wrap,
+        });
+        for (const visualRow of rows) {
+          visualRows.push(visualRow);
+          regions.push(...visualRow.hitRegions);
+        }
+        rowEnds.set(rowIndex, visualRows.length);
+      }
+      return { visualRows, rowStarts, rowEnds, regions };
+    });
+
+    const maxScrollTop = computed(() =>
+      Math.max(0, layoutState.value.visualRows.length - Math.max(0, normalizeInt(props.h))),
+    );
+
+    function setScrollTop(top: number): void {
+      const next = clamp(normalizeInt(top), 0, maxScrollTop.value);
+      if (!isScrollControlled()) innerScrollTop.value = next;
+      emit("update:scrollTop", next);
+    }
+
+    function rowForVisualRow(visualRow: TTranscriptVisualRow): TTranscriptRow {
+      return props.source.getRow(visualRow.rowIndex);
+    }
+
+    function regionEvent(region: TTranscriptHitRegion, event?: unknown): TTranscriptRegionEvent {
+      return {
+        region,
+        row: props.source.getRow(region.rowIndex),
+        rowIndex: region.rowIndex,
+        event,
+      };
+    }
+
+    function emitRegion(region: TTranscriptHitRegion, pointerEvent?: unknown): void {
+      const event = regionEvent(region, pointerEvent);
+      if (region.kind === "action") emit("actionClick", event);
+      else if (region.kind === "link") emit("linkClick", event);
+      else if (region.kind === "fold-toggle") emit("foldToggle", event);
+      else if (region.kind === "tool-call") emit("toolClick", event);
+    }
+
+    function visualIndexForRegion(region: TTranscriptHitRegion | null): number {
+      if (!region) return -1;
+      const rows = layoutState.value.visualRows;
+      for (let i = 0; i < rows.length; i++) {
+        if (rows[i]!.hitRegions.some((candidate) => candidate.id === region.id)) return i;
+      }
+      return -1;
+    }
+
+    function invalidateRegion(region: TTranscriptHitRegion | null): void {
+      const index = visualIndexForRegion(region);
+      if (index >= 0) rowsRef.value?.invalidateIndex(index);
+    }
+
+    function setHoveredRegion(region: TTranscriptHitRegion | null): void {
+      const prev = hoveredRegion.value;
+      if (prev?.id === region?.id) return;
+      hoveredRegion.value = region;
+      interactionVersion.value++;
+      invalidateRegion(prev);
+      invalidateRegion(region);
+      emit("hoverRegion", region ? regionEvent(region) : null);
+    }
+
+    function setFocusedRegion(region: TTranscriptHitRegion | null): void {
+      const prev = focusedRegion.value;
+      if (prev?.id === region?.id) return;
+      focusedRegion.value = region;
+      interactionVersion.value++;
+      invalidateRegion(prev);
+      invalidateRegion(region);
+    }
+
+    function focusRegionByOffset(offset: number): boolean {
+      const regions = layoutState.value.regions.filter((region) => region.kind !== "custom");
+      if (!regions.length) return false;
+      const current = focusedRegion.value
+        ? regions.findIndex((region) => region.id === focusedRegion.value?.id)
+        : -1;
+      const next = current < 0 ? (offset > 0 ? 0 : regions.length - 1) : current + offset;
+      setFocusedRegion(regions[(next + regions.length) % regions.length]!);
+      return true;
+    }
+
+    function focusNextRegion(): boolean {
+      return focusRegionByOffset(1);
+    }
+
+    function focusPreviousRegion(): boolean {
+      return focusRegionByOffset(-1);
+    }
+
+    function activateFocusedRegion(): boolean {
+      const region = focusedRegion.value;
+      if (!region) return false;
+      emitRegion(region);
+      return true;
+    }
+
+    function scrollToTop(): void {
+      rowsRef.value?.scrollTo(0);
+      setScrollTop(0);
+    }
+
+    function scrollToBottom(): void {
+      const top = maxScrollTop.value;
+      rowsRef.value?.scrollTo(top);
+      setScrollTop(top);
+    }
+
+    function scrollToRow(index: number, options?: { align?: "start" | "center" | "end" }): void {
+      const rowIndex = clamp(normalizeInt(index), 0, Math.max(0, props.source.rowCount() - 1));
+      const visualIndex = layoutState.value.rowStarts.get(rowIndex) ?? 0;
+      const rowEnd = layoutState.value.rowEnds.get(rowIndex) ?? visualIndex + 1;
+      const viewportRows = Math.max(1, normalizeInt(props.h));
+      const rowHeight = Math.max(1, rowEnd - visualIndex);
+      let top = visualIndex;
+      if (options?.align === "center")
+        top = visualIndex - Math.floor((viewportRows - rowHeight) / 2);
+      else if (options?.align === "end") top = rowEnd - viewportRows;
+      top = clamp(top, 0, maxScrollTop.value);
+      rowsRef.value?.scrollTo(top);
+      setScrollTop(top);
+    }
+
+    function invalidateRow(index: number): void {
+      const start = layoutState.value.rowStarts.get(index);
+      const end = layoutState.value.rowEnds.get(index);
+      if (start == null || end == null) return;
+      rowsRef.value?.invalidateRange(start, end);
+    }
+
+    function invalidateRange(start: number, end: number): void {
+      const first = clamp(normalizeInt(start), 0, props.source.rowCount());
+      const last = clamp(normalizeInt(end), first, props.source.rowCount());
+      const visualStart = layoutState.value.rowStarts.get(first);
+      const visualEnd = layoutState.value.rowEnds.get(last - 1);
+      if (visualStart == null || visualEnd == null) return;
+      rowsRef.value?.invalidateRange(visualStart, visualEnd);
+    }
+
+    expose({
+      scrollToBottom,
+      scrollToTop,
+      scrollToRow,
+      invalidateRow,
+      invalidateRange,
+      refreshViewport: () => rowsRef.value?.refreshViewport(),
+      focusNextRegion,
+      focusPreviousRegion,
+      activateFocusedRegion,
+      getHoveredRegion: () => hoveredRegion.value,
+    } satisfies TTranscriptViewHandle);
+
+    watch(
+      () => props.defaultScrollTop,
+      (top) => {
+        if (isScrollControlled()) return;
+        innerScrollTop.value = clamp(normalizeInt(top), 0, maxScrollTop.value);
+      },
+    );
+
+    watch(
+      () => layoutState.value.visualRows.length,
+      (next, prev) => {
+        if (!props.autoStickToBottom) return;
+        const viewportRows = Math.max(0, normalizeInt(props.h));
+        const previousMax = Math.max(0, prev - viewportRows);
+        if (currentScrollTop() < previousMax) return;
+        const nextTop = Math.max(0, next - viewportRows);
+        rowsRef.value?.scrollTo(nextTop);
+        setScrollTop(nextTop);
+      },
+    );
+
+    function paintVisualRow(paintCtx: TVirtualRowsPaintContext): void {
+      const visualRow = paintCtx.item as TTranscriptVisualRow | undefined;
+      if (!visualRow) return;
+
+      let x = 0;
+      for (const segment of visualRow.segments) {
+        const start = x;
+        const end = start + segment.cells;
+        const drawStart = Math.max(0, start);
+        const drawEnd = Math.min(paintCtx.w, end);
+        if (drawEnd > drawStart) {
+          paintCtx.terminal.write(
+            sliceByCellsRange(segment.text, drawStart - start, drawEnd - start),
+            {
+              x: paintCtx.x + drawStart,
+              y: paintCtx.y,
+              style: segment.style,
+            },
+          );
+        }
+        x = end;
+      }
+    }
+
+    function renderVisualRowNodes(ctx: { item: unknown; index: number; row: number }): any[] {
+      const visualRow = ctx.item as TTranscriptVisualRow | undefined;
+      if (!visualRow) return [];
+      const nodes: any[] = [];
+      for (const region of visualRow.hitRegions) {
+        nodes.push(
+          h(TView, {
+            key: `${region.id}:${ctx.index}:${region.x0}`,
+            x: region.x0,
+            y: ctx.row,
+            w: Math.max(1, region.x1 - region.x0),
+            h: 1,
+            zIndex: 2,
+            focusable: false,
+            onPointerenter: () => setHoveredRegion(region),
+            onPointermove: () => setHoveredRegion(region),
+            onPointerleave: () => {
+              if (hoveredRegion.value?.id === region.id) setHoveredRegion(null);
+            },
+            onClick: (e: any) => {
+              e.stopPropagation?.();
+              emitRegion(region, e);
+            },
+          }),
+        );
+      }
+      return nodes;
+    }
+
+    return () =>
+      h(TVirtualRows, {
+        ref: rowsRef,
+        x: props.x,
+        y: props.y,
+        w: props.w,
+        h: props.h,
+        zIndex: props.zIndex,
+        itemCount: layoutState.value.visualRows.length,
+        itemVersion: props.version + interactionVersion.value,
+        getItem: (index: number) => layoutState.value.visualRows[index],
+        paintItem: paintVisualRow,
+        renderItemNodes: renderVisualRowNodes,
+        selectionText: (item: unknown) => {
+          const visualRow = item as TTranscriptVisualRow | undefined;
+          if (!visualRow) return "";
+          const row = rowForVisualRow(visualRow);
+          return visualRow.selectableText ?? plainTextForTranscriptRow(row);
+        },
+        scrollTop: currentScrollTop(),
+        style: props.style,
+        autoFocus: props.autoFocus,
+        focusable: props.focusable,
+        selectable: props.selectable,
+        wheelScroll: props.wheelScroll,
+        rowScrollMode: props.rowScrollMode,
+        onScroll: (payload: any) => emit("scroll", payload),
+        onItemClick: (event: { item: unknown; event?: unknown }) => {
+          const visualRow = event.item as TTranscriptVisualRow | undefined;
+          if (!visualRow) return;
+          const rowEvent: TTranscriptRowEvent = {
+            row: rowForVisualRow(visualRow),
+            rowIndex: visualRow.rowIndex,
+            event: event.event,
+          };
+          emit("rowClick", rowEvent);
+        },
+        "onUpdate:scrollTop": setScrollTop,
+      });
+  },
+});

--- a/src/vue/components/TTranscriptView.ts
+++ b/src/vue/components/TTranscriptView.ts
@@ -21,7 +21,9 @@ import { computed, defineComponent, getCurrentInstance, h, ref, watch } from "vu
 import {
   layoutTranscriptRow,
   transcriptActionRegionId,
+  transcriptFoldToggleRegionId,
   transcriptLinkRegionId,
+  transcriptToolCallRegionId,
 } from "../transcript/layout.js";
 import { plainTextForTranscriptRow } from "../transcript/plain-text.js";
 import { sliceByCellsRange } from "../utils/text.js";
@@ -91,6 +93,11 @@ function rowHasRegionId(row: TTranscriptRow, rowKey: string | number, id: string
   if (
     "actions" in row &&
     row.actions?.some((action) => transcriptActionRegionId(rowKey, action.id) === id)
+  )
+    return true;
+  if (
+    row.kind === "tool-call" &&
+    (transcriptFoldToggleRegionId(rowKey) === id || transcriptToolCallRegionId(rowKey) === id)
   )
     return true;
   const segments = sourceSegmentsForRegion(row);
@@ -292,18 +299,18 @@ export const TTranscriptView = defineComponent({
       else if (region.kind === "tool-call") emit("toolClick", event);
     }
 
-    function visualIndexForRegion(region: TTranscriptHitRegion | null): number {
-      if (!region) return -1;
+    function visualIndexesForRegion(region: TTranscriptHitRegion | null): number[] {
+      if (!region) return [];
       const rows = layoutState.value.visualRows;
+      const indexes: number[] = [];
       for (let i = 0; i < rows.length; i++) {
-        if (rows[i]!.hitRegions.some((candidate) => candidate.id === region.id)) return i;
+        if (rows[i]!.hitRegions.some((candidate) => candidate.id === region.id)) indexes.push(i);
       }
-      return -1;
+      return indexes;
     }
 
     function invalidateRegion(region: TTranscriptHitRegion | null): void {
-      const index = visualIndexForRegion(region);
-      if (index >= 0) rowsRef.value?.invalidateIndex(index);
+      for (const index of visualIndexesForRegion(region)) rowsRef.value?.invalidateIndex(index);
     }
 
     function setHoveredRegion(region: TTranscriptHitRegion | null): void {
@@ -323,8 +330,24 @@ export const TTranscriptView = defineComponent({
       invalidateRegion(region);
     }
 
+    function visibleFocusableRegions(): TTranscriptHitRegion[] {
+      const rows = layoutState.value.visualRows;
+      const top = clamp(currentScrollTop(), 0, rows.length);
+      const bottom = Math.min(rows.length, top + Math.max(0, normalizeInt(props.h)));
+      const seen = new Set<string>();
+      const regions: TTranscriptHitRegion[] = [];
+      for (let i = top; i < bottom; i++) {
+        for (const region of rows[i]?.hitRegions ?? []) {
+          if (seen.has(region.id)) continue;
+          seen.add(region.id);
+          regions.push(region);
+        }
+      }
+      return regions;
+    }
+
     function focusRegionByOffset(offset: number): boolean {
-      const regions = layoutState.value.regions.filter((region) => region.kind !== "custom");
+      const regions = visibleFocusableRegions();
       if (!regions.length) return false;
       const current = focusedRegion.value
         ? regions.findIndex((region) => region.id === focusedRegion.value?.id)
@@ -345,7 +368,7 @@ export const TTranscriptView = defineComponent({
     function activateFocusedRegion(): boolean {
       const region = focusedRegion.value;
       if (!region) return false;
-      if (!layoutState.value.regions.some((candidate) => candidate.id === region.id)) return false;
+      if (!visibleFocusableRegions().some((candidate) => candidate.id === region.id)) return false;
       emitRegion(region);
       return true;
     }

--- a/src/vue/components/TVirtualRows.ts
+++ b/src/vue/components/TVirtualRows.ts
@@ -204,6 +204,7 @@ export const TVirtualRows = defineComponent({
     let dirtyRowsHint: readonly number[] | undefined;
     let renderNodeId: string | null = null;
     let pendingWheelTop: number | null = null;
+    let pendingSelectionScrollFocusRemap = false;
     let alive = true;
 
     const itemCount = computed(() => Math.max(0, normalizeInt(props.itemCount)));
@@ -268,8 +269,7 @@ export const TVirtualRows = defineComponent({
     }
 
     function setCurrentScrollTop(top: number): void {
-      if (isScrollControlled()) controlledScrollTop.value = top;
-      else innerScrollTop.value = top;
+      if (!isScrollControlled()) innerScrollTop.value = top;
     }
 
     function hasPaintableViewport(): boolean {
@@ -355,6 +355,12 @@ export const TVirtualRows = defineComponent({
       const clampedTop = clampScrollTop(nextTop);
       const delta = clampedTop - prevTop;
       if (!delta) return false;
+
+      if (isScrollControlled()) {
+        if (options?.emitUpdate !== false) emit("update:scrollTop", clampedTop);
+        if (options?.emitScroll) emitScroll(clampedTop);
+        return true;
+      }
 
       setCurrentScrollTop(clampedTop);
       if (options?.emitUpdate !== false) emit("update:scrollTop", clampedTop);
@@ -487,7 +493,10 @@ export const TVirtualRows = defineComponent({
         emitScroll: true,
         strategy: "viewport-repaint",
       });
-      if (changed) selection.refresh({ remapFocus: true });
+      if (changed) {
+        if (isScrollControlled()) pendingSelectionScrollFocusRemap = true;
+        else selection.refresh({ remapFocus: true });
+      }
       return changed;
     }
 
@@ -678,20 +687,35 @@ export const TVirtualRows = defineComponent({
       () => props.scrollTop,
       () => {
         if (!isScrollControlled()) return;
+        const desiredTop = normalizeInt(props.scrollTop);
         const nextTop = clampScrollTop(props.scrollTop);
         if (!initializedScrollTop) {
           initializedScrollTop = true;
           controlledScrollTop.value = nextTop;
           markViewportDirty();
           invalidateSelf("normal");
+          if (desiredTop !== nextTop) {
+            emit("update:scrollTop", nextTop);
+            emitScroll(nextTop);
+          }
           return;
         }
-        if (nextTop === controlledScrollTop.value) return;
+        if (nextTop === controlledScrollTop.value) {
+          if (desiredTop !== nextTop) {
+            emit("update:scrollTop", nextTop);
+            emitScroll(nextTop);
+          }
+          return;
+        }
         cancelWheelScrollFrame();
-        const changed = applyScrollTop(nextTop, { emitUpdate: false });
-        if (changed) {
-          selection.refresh();
-          invalidateSelf("high");
+        controlledScrollTop.value = nextTop;
+        markViewportDirty();
+        selection.refresh(pendingSelectionScrollFocusRemap ? { remapFocus: true } : undefined);
+        pendingSelectionScrollFocusRemap = false;
+        invalidateSelf("high");
+        if (desiredTop !== nextTop) {
+          emit("update:scrollTop", nextTop);
+          emitScroll(nextTop);
         }
       },
       { immediate: true },
@@ -713,7 +737,14 @@ export const TVirtualRows = defineComponent({
       () => {
         resetWheelScrollState(wheelState);
         const nextTop = clampScrollTop(currentScrollTop());
-        setCurrentScrollTop(nextTop);
+        if (isScrollControlled()) {
+          if (controlledScrollTop.value !== nextTop) {
+            emit("update:scrollTop", nextTop);
+            emitScroll(nextTop);
+          }
+        } else {
+          setCurrentScrollTop(nextTop);
+        }
         markViewportDirty();
         invalidateSelf("normal");
       },

--- a/src/vue/components/TVirtualRows.ts
+++ b/src/vue/components/TVirtualRows.ts
@@ -85,6 +85,9 @@ export type TVirtualRowsPaintContext = Readonly<{
   x: number;
   y: number;
   w: number;
+  clipX: number;
+  clipY: number;
+  fullW: number;
   scrollTop: number;
   style: Style;
 }>;
@@ -93,7 +96,18 @@ export type TVirtualRowsRenderNodesContext = Readonly<{
   item: unknown;
   index: number;
   row: number;
+  clipX: number;
+  clipY: number;
+  fullW: number;
   scrollTop: number;
+}>;
+
+export type TVirtualRowsSelectionSpanTextContext = Readonly<{
+  item: unknown;
+  index: number;
+  x0: number;
+  x1: number;
+  cols: number;
 }>;
 
 export type TVirtualRowsScrollMetrics = Readonly<{
@@ -141,6 +155,10 @@ export const TVirtualRows = defineComponent({
     },
     selectionText: {
       type: Function as PropType<(item: unknown, index: number) => string>,
+      default: undefined,
+    },
+    selectionSpanText: {
+      type: Function as PropType<(ctx: TVirtualRowsSelectionSpanTextContext) => string>,
       default: undefined,
     },
     scrollTop: { type: Number, default: undefined },
@@ -531,7 +549,18 @@ export const TVirtualRows = defineComponent({
       const cols = Math.max(1, Math.floor(props.w));
       return terminalSelectionRowSpans(range, cols, itemCount.value)
         .map((span) => {
-          const text = sliceByCellsRange(itemText(span.y), span.x0, span.x1);
+          const item = props.getItem(span.y);
+          const text = props.selectionSpanText
+            ? String(
+                props.selectionSpanText({
+                  item,
+                  index: span.y,
+                  x0: span.x0,
+                  x1: span.x1,
+                  cols,
+                }) ?? "",
+              )
+            : sliceByCellsRange(itemText(span.y), span.x0, span.x1);
           return span.x1 >= cols ? text.trimEnd() : text;
         })
         .join("\n");
@@ -777,6 +806,7 @@ export const TVirtualRows = defineComponent({
         props.itemVersion,
         props.getItem,
         props.paintItem,
+        props.selectionSpanText,
         props.style,
         defaultStyle.value,
       ],
@@ -784,8 +814,9 @@ export const TVirtualRows = defineComponent({
         dirtyRowsHint = undefined;
         if (!visible.value) return;
         const r = normalizedRect();
+        const full = normalizedFullRect();
         if (r.w <= 0 || r.h <= 0) return;
-        const { y: clipY } = clipOffsets();
+        const { x: clipX, y: clipY } = clipOffsets();
         const top = currentScrollTop();
         const base = props.style ?? defaultStyle.value;
         const blank = spaces(r.w);
@@ -804,6 +835,9 @@ export const TVirtualRows = defineComponent({
             x: r.x,
             y,
             w: r.w,
+            clipX,
+            clipY,
+            fullW: full.w,
             scrollTop: top,
             style: base,
           });
@@ -825,7 +859,8 @@ export const TVirtualRows = defineComponent({
       const children: VNodeChild[] = [];
       if (props.renderItemNodes && visible.value) {
         const r = normalizedRect();
-        const { y: clipY } = clipOffsets();
+        const full = normalizedFullRect();
+        const { x: clipX, y: clipY } = clipOffsets();
         const top = currentScrollTop();
         for (let y = r.y; y < r.y + r.h; y++) {
           const row = clipY + (y - r.y);
@@ -836,6 +871,9 @@ export const TVirtualRows = defineComponent({
               item: props.getItem(index),
               index,
               row,
+              clipX,
+              clipY,
+              fullW: full.w,
               scrollTop: top,
             }),
           );

--- a/src/vue/components/TVirtualRows.ts
+++ b/src/vue/components/TVirtualRows.ts
@@ -1,0 +1,816 @@
+import type { PropType, VNodeChild } from "vue";
+import type { TerminalRenderPlane } from "../../core/render-plane.js";
+import type { Style, Terminal } from "../../core/types.js";
+import type {
+  Rect,
+  TerminalKeyboardEvent,
+  TerminalPointerEvent,
+} from "../../events/manager/types.js";
+import type {
+  SelectedRowSpan,
+  SelectionTextProvider,
+  TerminalSelectionPoint,
+  TerminalSelectionRange,
+} from "../../selection/terminal-selection.js";
+import {
+  computed,
+  defineComponent,
+  getCurrentInstance,
+  h,
+  inject,
+  onBeforeUnmount,
+  provide,
+  ref,
+  shallowReactive,
+  watch,
+  watchEffect,
+} from "vue";
+import {
+  terminalSelectionRowSpans,
+  terminalSelectionVisibleRowSpans,
+} from "../../selection/terminal-selection.js";
+import { useLayout } from "../composables/use-layout.js";
+import { useRenderNode } from "../composables/use-render-node.js";
+import { useRenderStack } from "../composables/use-render-stack.js";
+import { useTerminal } from "../composables/use-terminal.js";
+import { useTerminalNode } from "../composables/use-terminal-node.js";
+import { useVisibility } from "../composables/use-visibility.js";
+import { EventZIndexContextKey, LayoutContextKey, RenderPlaneContextKey } from "../context.js";
+import { RenderStackKey } from "../render/context.js";
+import { createFrameMailbox } from "../scheduler/frame-mailbox.js";
+import { intersectRect, normalizeCellRect, translateRect } from "../utils/rect.js";
+import { sliceByCellsRange, spaces } from "../utils/text.js";
+import {
+  applyWheelScroll,
+  createWheelScrollState,
+  resetWheelScrollState,
+} from "../utils/wheel-scroll.js";
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function normalizeInt(value: unknown): number {
+  const n = Math.floor(Number(value));
+  return Number.isFinite(n) ? n : 0;
+}
+
+function getWheelScrollInput(e: { deltaY?: number; deltaMode?: number }): {
+  deltaY: number;
+  mode: "auto" | "line" | "pixel";
+} {
+  const deltaY = Number(e.deltaY ?? 0);
+  const deltaMode = typeof e.deltaMode === "number" ? e.deltaMode : undefined;
+  if (
+    Number.isInteger(deltaY) &&
+    deltaY !== 0 &&
+    Math.abs(deltaY) >= 100 &&
+    Math.abs(deltaY) % 100 === 0 &&
+    deltaMode == null
+  ) {
+    return { deltaY: deltaY / 100, mode: "line" };
+  }
+  if (deltaMode === 1) return { deltaY, mode: "line" };
+  if (deltaMode === 0) return { deltaY, mode: "pixel" };
+  return { deltaY, mode: "auto" };
+}
+
+export type TVirtualRowsRowScrollMode = "off" | "unsafe-full-row";
+
+export type TVirtualRowsPaintContext = Readonly<{
+  terminal: Terminal;
+  item: unknown;
+  index: number;
+  row: number;
+  x: number;
+  y: number;
+  w: number;
+  scrollTop: number;
+  style: Style;
+}>;
+
+export type TVirtualRowsRenderNodesContext = Readonly<{
+  item: unknown;
+  index: number;
+  row: number;
+  scrollTop: number;
+}>;
+
+export type TVirtualRowsScrollMetrics = Readonly<{
+  scrollTop: number;
+  maxScrollTop: number;
+  viewportRows: number;
+  itemCount: number;
+  atTop: boolean;
+  atBottom: boolean;
+}>;
+
+export type TVirtualRowsScrollPayload = TVirtualRowsScrollMetrics;
+
+export type TVirtualRowsHandle = Readonly<{
+  scrollTo: (top: number) => void;
+  scrollBy: (delta: number) => void;
+  invalidateIndex: (index: number) => void;
+  invalidateRange: (start: number, end: number) => void;
+  refreshViewport: () => void;
+  getScrollMetrics: () => TVirtualRowsScrollMetrics;
+}>;
+
+let virtualRowsInstanceSeq = 0;
+
+const EMPTY_RECT: Rect = Object.freeze({ x: 0, y: 0, w: 0, h: 0 });
+
+export const TVirtualRows = defineComponent({
+  name: "TVirtualRows",
+  props: {
+    x: { type: Number, required: true },
+    y: { type: Number, required: true },
+    w: { type: Number, required: true },
+    h: { type: Number, required: true },
+    zIndex: { type: Number, default: 0 },
+    itemCount: { type: Number, required: true },
+    itemVersion: { type: Number, required: true },
+    getItem: { type: Function as PropType<(index: number) => unknown>, required: true },
+    paintItem: {
+      type: Function as PropType<(ctx: TVirtualRowsPaintContext) => void>,
+      required: true,
+    },
+    renderItemNodes: {
+      type: Function as PropType<(ctx: TVirtualRowsRenderNodesContext) => VNodeChild>,
+      default: undefined,
+    },
+    selectionText: {
+      type: Function as PropType<(item: unknown, index: number) => string>,
+      default: undefined,
+    },
+    scrollTop: { type: Number, default: undefined },
+    style: { type: Object as PropType<Style>, default: undefined },
+    autoFocus: { type: Boolean, default: false },
+    focusable: { type: Boolean, default: true },
+    selectable: { type: Boolean, default: false },
+    wheelScroll: { type: Boolean, default: true },
+    rowScrollMode: {
+      type: String as PropType<TVirtualRowsRowScrollMode>,
+      default: "off",
+    },
+  },
+  emits: [
+    "update:scrollTop",
+    "scroll",
+    "clickCapture",
+    "click",
+    "contextmenuCapture",
+    "contextmenu",
+    "pointerdownCapture",
+    "pointerdown",
+    "pointermoveCapture",
+    "pointermove",
+    "pointerupCapture",
+    "pointerup",
+    "pointerleave",
+    "wheel",
+    "focus",
+    "blur",
+    "keydown",
+    "itemClick",
+  ],
+  setup(props, { emit, expose }) {
+    const { terminal, scheduler, render, rendererCapabilities, defaultStyle, events, selection } =
+      useTerminal();
+    const instance = getCurrentInstance();
+    const layout = useLayout();
+    const { visible, rootProps } = useVisibility();
+    const plane = inject(RenderPlaneContextKey, ref<TerminalRenderPlane>("default"));
+    const parentEventZ = inject(EventZIndexContextKey, computed(() => 0) as any);
+    const eventZ = computed(() => (parentEventZ.value ?? 0) + (props.zIndex ?? 0));
+    const parentStack = useRenderStack();
+    const childLayout = shallowReactive({
+      originX: 0,
+      originY: 0,
+      clipRect: null as Rect | null,
+    });
+    const childStack = computed(() => render.createStack(parentStack.value, props.zIndex));
+    provide(LayoutContextKey, childLayout);
+    provide(RenderStackKey, childStack as any);
+    provide(EventZIndexContextKey, eventZ as any);
+
+    const virtualRowsInstanceId = ++virtualRowsInstanceSeq;
+    const frameTaskId = `TVirtualRows:${virtualRowsInstanceId}`;
+    const innerScrollTop = ref(0);
+    const controlledScrollTop = ref(0);
+    const focused = ref(false);
+    const wheelState = createWheelScrollState();
+    let initializedScrollTop = false;
+    let dirtyRowsHint: readonly number[] | undefined;
+    let renderNodeId: string | null = null;
+    let pendingWheelTop: number | null = null;
+    let alive = true;
+
+    const itemCount = computed(() => Math.max(0, normalizeInt(props.itemCount)));
+
+    const fullRect = computed<Rect>(() =>
+      translateRect(
+        {
+          x: normalizeInt(props.x),
+          y: normalizeInt(props.y),
+          w: Math.max(0, normalizeInt(props.w)),
+          h: Math.max(0, normalizeInt(props.h)),
+        },
+        layout.originX,
+        layout.originY,
+      ),
+    );
+
+    const absRect = computed<Rect>(() => {
+      const translated = fullRect.value;
+      if (!layout.clipRect) return translated;
+      return intersectRect(translated, layout.clipRect) ?? EMPTY_RECT;
+    });
+
+    function normalizedRect(): Rect {
+      return normalizeCellRect(absRect.value);
+    }
+
+    function normalizedFullRect(): Rect {
+      return normalizeCellRect(fullRect.value);
+    }
+
+    function clipOffsets(): { x: number; y: number } {
+      const full = normalizedFullRect();
+      const clip = normalizedRect();
+      return {
+        x: Math.max(0, clip.x - full.x),
+        y: Math.max(0, clip.y - full.y),
+      };
+    }
+
+    function viewportHeight(): number {
+      return normalizedRect().h;
+    }
+
+    function maxScrollTop(): number {
+      const { y: clipY } = clipOffsets();
+      return Math.max(0, itemCount.value - (clipY + viewportHeight()));
+    }
+
+    function clampScrollTop(value: unknown): number {
+      return clamp(normalizeInt(value), 0, maxScrollTop());
+    }
+
+    function isScrollControlled(): boolean {
+      return Object.prototype.hasOwnProperty.call(instance?.vnode.props ?? {}, "scrollTop");
+    }
+
+    function currentScrollTop(): number {
+      return clampScrollTop(
+        isScrollControlled() ? controlledScrollTop.value : innerScrollTop.value,
+      );
+    }
+
+    function setCurrentScrollTop(top: number): void {
+      if (isScrollControlled()) controlledScrollTop.value = top;
+      else innerScrollTop.value = top;
+    }
+
+    function hasPaintableViewport(): boolean {
+      const r = normalizedRect();
+      return visible.value && r.w > 0 && r.h > 0;
+    }
+
+    function isClipped(): boolean {
+      const r = normalizedRect();
+      const full = normalizedFullRect();
+      return r.x !== full.x || r.y !== full.y || r.w !== full.w || r.h !== full.h;
+    }
+
+    function scrollMetrics(top = currentScrollTop()): TVirtualRowsScrollMetrics {
+      const maxTop = maxScrollTop();
+      return {
+        scrollTop: top,
+        maxScrollTop: maxTop,
+        viewportRows: viewportHeight(),
+        itemCount: itemCount.value,
+        atTop: top <= 0,
+        atBottom: top >= maxTop,
+      };
+    }
+
+    function emitScroll(top = currentScrollTop()): void {
+      emit("scroll", scrollMetrics(top));
+    }
+
+    function viewportRows(): number[] {
+      const r = normalizedRect();
+      const rows: number[] = [];
+      for (let y = r.y; y < r.y + r.h; y++) rows.push(y);
+      return rows;
+    }
+
+    function exposedRowsForDelta(y0: number, h: number, delta: number): number[] {
+      const rows: number[] = [];
+      if (delta > 0) {
+        for (let i = h - delta; i < h; i++) rows.push(y0 + i);
+      } else {
+        for (let i = 0; i < -delta; i++) rows.push(y0 + i);
+      }
+      return rows;
+    }
+
+    function unionDirtyRows(nextRows: readonly number[]): readonly number[] {
+      if (!dirtyRowsHint?.length) return nextRows.slice().sort((a, b) => a - b);
+      const rows = new Set(dirtyRowsHint);
+      for (const y of nextRows) rows.add(y);
+      return Array.from(rows).sort((a, b) => a - b);
+    }
+
+    function markRowsDirty(nextRows: readonly number[]): boolean {
+      if (!hasPaintableViewport()) return false;
+      dirtyRowsHint = unionDirtyRows(nextRows);
+      if (!renderNodeId) return false;
+      if (render.markDirtyRows(renderNodeId, dirtyRowsHint)) return true;
+      dirtyRowsHint = undefined;
+      return false;
+    }
+
+    function markViewportDirty(): boolean {
+      return markRowsDirty(viewportRows());
+    }
+
+    function invalidateSelf(priority: "low" | "normal" | "high" = "normal"): void {
+      scheduler.invalidate({ priority, plane: plane.value, reason: "scroll" });
+    }
+
+    function applyScrollTop(
+      nextTop: number,
+      options?: Readonly<{
+        emitScroll?: boolean;
+        emitUpdate?: boolean;
+        strategy?: "auto" | "viewport-repaint";
+      }>,
+    ): boolean {
+      const r = normalizedRect();
+      const h = r.h;
+      if (h <= 0) return false;
+      const prevTop = currentScrollTop();
+      const clampedTop = clampScrollTop(nextTop);
+      const delta = clampedTop - prevTop;
+      if (!delta) return false;
+
+      setCurrentScrollTop(clampedTop);
+      if (options?.emitUpdate !== false) emit("update:scrollTop", clampedTop);
+
+      const size = terminal.size();
+      const ownsFullRows = Math.floor(r.x) === 0 && Math.floor(r.w) >= size.cols;
+      const withinTerminalRows = r.y >= 0 && r.y + h <= size.rows;
+      const canUseScrollPlane =
+        (options?.strategy ?? "auto") === "auto" &&
+        props.rowScrollMode === "unsafe-full-row" &&
+        rendererCapabilities.value.scrollOperations &&
+        ownsFullRows &&
+        withinTerminalRows &&
+        !isClipped() &&
+        Math.abs(delta) < h &&
+        !dirtyRowsHint?.length;
+
+      if (canUseScrollPlane) {
+        render.unsafeScrollPlaneRows(plane.value, r.y, r.y + h, delta);
+        markRowsDirty(exposedRowsForDelta(r.y, h, delta));
+      } else {
+        markViewportDirty();
+      }
+
+      if (options?.emitScroll) emitScroll(clampedTop);
+      return true;
+    }
+
+    const wheelMailbox = createFrameMailbox<number>({
+      scheduler,
+      id: `${frameTaskId}:wheel`,
+      reason: "scroll",
+      priority: "high",
+      sync: true,
+      apply(nextTop, ctx) {
+        pendingWheelTop = null;
+        if (!alive || !hasPaintableViewport()) {
+          resetWheelScrollState(wheelState);
+          return;
+        }
+        const changed = applyScrollTop(nextTop, { emitScroll: true });
+        if (!changed) {
+          resetWheelScrollState(wheelState);
+          return;
+        }
+        selection.refresh();
+        ctx.invalidate({ priority: "high", plane: plane.value, reason: "scroll" });
+      },
+    });
+
+    function cancelWheelScrollFrame(): void {
+      pendingWheelTop = null;
+      wheelMailbox.cancel();
+      resetWheelScrollState(wheelState);
+    }
+
+    function requestWheelScroll(nextTop: number): boolean {
+      pendingWheelTop = nextTop;
+      try {
+        if (wheelMailbox.queue(nextTop)) return true;
+      } catch (error) {
+        pendingWheelTop = null;
+        resetWheelScrollState(wheelState);
+        throw error;
+      }
+      pendingWheelTop = null;
+      resetWheelScrollState(wheelState);
+      return false;
+    }
+
+    function scrollTo(top: number): void {
+      cancelWheelScrollFrame();
+      const changed = applyScrollTop(top, {
+        emitScroll: true,
+        strategy: "viewport-repaint",
+      });
+      if (changed) {
+        selection.refresh();
+        invalidateSelf("high");
+      }
+    }
+
+    function scrollBy(delta: number): void {
+      const n = normalizeInt(delta);
+      if (!n) return;
+      scrollTo(currentScrollTop() + n);
+    }
+
+    function refreshViewport(): void {
+      markViewportDirty();
+      invalidateSelf("normal");
+    }
+
+    function invalidateRange(start: number, end: number): void {
+      if (!hasPaintableViewport()) return;
+      const r = normalizedRect();
+      const { y: clipY } = clipOffsets();
+      const top = currentScrollTop() + clipY;
+      const lo = clamp(normalizeInt(start), 0, itemCount.value);
+      const hi = clamp(normalizeInt(end), lo, itemCount.value);
+      const rows: number[] = [];
+      for (let index = lo; index < hi; index++) {
+        const y = r.y + (index - top);
+        if (y >= r.y && y < r.y + r.h) rows.push(y);
+      }
+      if (!rows.length) return;
+      markRowsDirty(rows);
+      invalidateSelf("normal");
+    }
+
+    function invalidateIndex(index: number): void {
+      const n = normalizeInt(index);
+      invalidateRange(n, n + 1);
+    }
+
+    expose({
+      scrollTo,
+      scrollBy,
+      invalidateIndex,
+      invalidateRange,
+      refreshViewport,
+      getScrollMetrics: scrollMetrics,
+    } satisfies TVirtualRowsHandle);
+
+    function scrollSelectionBy(delta: number): boolean {
+      const n = normalizeInt(delta);
+      if (!n) return false;
+      cancelWheelScrollFrame();
+      const changed = applyScrollTop(currentScrollTop() + n, {
+        emitScroll: true,
+        strategy: "viewport-repaint",
+      });
+      if (changed) selection.refresh({ remapFocus: true });
+      return changed;
+    }
+
+    function itemText(index: number): string {
+      const item = props.getItem(index);
+      if (props.selectionText) return String(props.selectionText(item, index) ?? "");
+      return typeof item === "string" || typeof item === "number" || typeof item === "boolean"
+        ? String(item)
+        : "";
+    }
+
+    function selectionPointForCell(point: TerminalSelectionPoint): TerminalSelectionPoint | null {
+      const r = normalizedRect();
+      if (point.x < r.x || point.y < r.y || point.x >= r.x + r.w || point.y >= r.y + r.h) {
+        return null;
+      }
+      const { x: clipX, y: clipY } = clipOffsets();
+      const virtualY = currentScrollTop() + clipY + (point.y - r.y);
+      if (virtualY < 0 || virtualY >= itemCount.value) return null;
+      return {
+        x: clamp(clipX + (point.x - r.x), 0, Math.max(0, props.w - 1)),
+        y: virtualY,
+      };
+    }
+
+    function canHandleSelectionRange(range: TerminalSelectionRange): boolean {
+      if (!props.selectable) return false;
+      return Boolean(selectionPointForCell(range.anchor) && selectionPointForCell(range.focus));
+    }
+
+    function textForSelectionRange(range: TerminalSelectionRange): string {
+      const cols = Math.max(1, Math.floor(props.w));
+      return terminalSelectionRowSpans(range, cols, itemCount.value)
+        .map((span) => {
+          const text = sliceByCellsRange(itemText(span.y), span.x0, span.x1);
+          return span.x1 >= cols ? text.trimEnd() : text;
+        })
+        .join("\n");
+    }
+
+    function visibleSpansForSelectionRange(
+      providerRange: TerminalSelectionRange,
+      _screenRange: TerminalSelectionRange,
+    ): readonly SelectedRowSpan[] {
+      const r = normalizedRect();
+      const { x: clipX, y: clipY } = clipOffsets();
+      const cols = Math.max(1, Math.floor(props.w));
+      const top = currentScrollTop() + clipY;
+      const bottom = top + r.h;
+      const providerSpans = terminalSelectionVisibleRowSpans(
+        providerRange,
+        cols,
+        itemCount.value,
+        top,
+        bottom,
+      );
+      const result: SelectedRowSpan[] = [];
+      for (const span of providerSpans) {
+        const screenY = r.y + (span.y - top);
+        const screenX0 = r.x + span.x0 - clipX;
+        const screenX1 = r.x + span.x1 - clipX;
+        const x0 = Math.max(r.x, screenX0);
+        const x1 = Math.min(r.x + r.w, screenX1);
+        if (screenY >= r.y && screenY < r.y + r.h && x1 > x0) {
+          result.push({ y: screenY, x0, x1 });
+        }
+      }
+      return result;
+    }
+
+    const selectionTextProvider: SelectionTextProvider = {
+      id: `${frameTaskId}:selection-text`,
+      get rect() {
+        return normalizedRect();
+      },
+      canHandle: canHandleSelectionRange,
+      pointForCell: selectionPointForCell,
+      getText: textForSelectionRange,
+      getVisibleSpans: visibleSpansForSelectionRange,
+    };
+    const unregisterSelectionTextProvider = selection.registerTextProvider(selectionTextProvider);
+    onBeforeUnmount(unregisterSelectionTextProvider);
+
+    const eventNode = useTerminalNode(() => ({
+      rect: normalizedRect(),
+      zIndex: eventZ.value,
+      visible: visible.value,
+      focusable: props.focusable,
+      selectable: props.selectable,
+      selectionScrollBy: scrollSelectionBy,
+      handlers: {
+        clickCapture: (e: TerminalPointerEvent) => emit("clickCapture", e),
+        click: (e: TerminalPointerEvent) => {
+          emit("click", e);
+          const r = normalizedRect();
+          const { y: clipY } = clipOffsets();
+          const index = currentScrollTop() + clipY + (e.cellY - r.y);
+          if (index < 0 || index >= itemCount.value) return;
+          emit("itemClick", { index, item: props.getItem(index), row: e.cellY - r.y, event: e });
+        },
+        contextmenuCapture: (e: TerminalPointerEvent) => emit("contextmenuCapture", e),
+        contextmenu: (e: TerminalPointerEvent) => emit("contextmenu", e),
+        pointerdownCapture: (e: TerminalPointerEvent) => emit("pointerdownCapture", e),
+        pointerdown: (e: TerminalPointerEvent) => emit("pointerdown", e),
+        pointermoveCapture: (e: TerminalPointerEvent) => emit("pointermoveCapture", e),
+        pointermove: (e: TerminalPointerEvent) => emit("pointermove", e),
+        pointerupCapture: (e: TerminalPointerEvent) => emit("pointerupCapture", e),
+        pointerup: (e: TerminalPointerEvent) => emit("pointerup", e),
+        pointerleave: (e: TerminalPointerEvent) => emit("pointerleave", e),
+        wheel: (e: any) => {
+          emit("wheel", e);
+          if (!props.wheelScroll) return;
+          const { deltaY, mode } = getWheelScrollInput(e);
+          if (!deltaY) return;
+          const baseTop = pendingWheelTop ?? currentScrollTop();
+          const now =
+            typeof e.time === "number"
+              ? e.time
+              : typeof e.timeStamp === "number"
+                ? e.timeStamp
+                : Date.now();
+          const { nextTop, dir } = applyWheelScroll(
+            wheelState,
+            deltaY,
+            baseTop,
+            maxScrollTop(),
+            now,
+            mode,
+            { disableAcceleration: mode === "pixel" },
+          );
+          if (!dir || nextTop === baseTop) return;
+          if (!requestWheelScroll(nextTop)) return;
+          e.preventDefault?.();
+        },
+        focus: () => {
+          focused.value = true;
+          emit("focus");
+          invalidateSelf();
+        },
+        blur: () => {
+          focused.value = false;
+          emit("blur");
+          invalidateSelf();
+        },
+        keydown: (e: TerminalKeyboardEvent) => {
+          emit("keydown", e);
+          if (e.key === "ArrowUp") {
+            e.preventDefault();
+            scrollBy(-1);
+          } else if (e.key === "ArrowDown") {
+            e.preventDefault();
+            scrollBy(1);
+          } else if (e.key === "PageUp") {
+            e.preventDefault();
+            scrollBy(-viewportHeight());
+          } else if (e.key === "PageDown") {
+            e.preventDefault();
+            scrollBy(viewportHeight());
+          } else if (e.key === "Home") {
+            e.preventDefault();
+            scrollTo(0);
+          } else if (e.key === "End") {
+            e.preventDefault();
+            scrollTo(maxScrollTop());
+          }
+        },
+      },
+    }));
+
+    watchEffect(() => {
+      if (!props.autoFocus) return;
+      if (!visible.value) return;
+      const manager = events.value;
+      const nodeId = eventNode.id.value;
+      if (!manager || !nodeId) return;
+      if (manager.getFocused() === nodeId) return;
+      manager.focus(nodeId);
+    });
+
+    watchEffect(() => {
+      const full = normalizedFullRect();
+      childLayout.originX = full.x;
+      childLayout.originY = full.y;
+      childLayout.clipRect = normalizedRect();
+    });
+
+    watch(
+      () => props.scrollTop,
+      () => {
+        if (!isScrollControlled()) return;
+        const nextTop = clampScrollTop(props.scrollTop);
+        if (!initializedScrollTop) {
+          initializedScrollTop = true;
+          controlledScrollTop.value = nextTop;
+          markViewportDirty();
+          invalidateSelf("normal");
+          return;
+        }
+        if (nextTop === controlledScrollTop.value) return;
+        cancelWheelScrollFrame();
+        const changed = applyScrollTop(nextTop, { emitUpdate: false });
+        if (changed) {
+          selection.refresh();
+          invalidateSelf("high");
+        }
+      },
+      { immediate: true },
+    );
+
+    watch(
+      [
+        () => itemCount.value,
+        () => props.itemVersion,
+        () => fullRect.value.x,
+        () => fullRect.value.y,
+        () => fullRect.value.w,
+        () => fullRect.value.h,
+        () => absRect.value.x,
+        () => absRect.value.y,
+        () => absRect.value.w,
+        () => absRect.value.h,
+      ],
+      () => {
+        resetWheelScrollState(wheelState);
+        const nextTop = clampScrollTop(currentScrollTop());
+        setCurrentScrollTop(nextTop);
+        markViewportDirty();
+        invalidateSelf("normal");
+      },
+      { immediate: true },
+    );
+
+    watch(
+      () => visible.value,
+      (nextVisible) => {
+        if (!nextVisible) cancelWheelScrollFrame();
+      },
+    );
+
+    onBeforeUnmount(() => {
+      alive = false;
+      pendingWheelTop = null;
+      resetWheelScrollState(wheelState);
+      wheelMailbox.dispose();
+    });
+
+    const renderNode = useRenderNode(() => ({
+      zIndex: props.zIndex,
+      rect: visible.value ? normalizedRect() : EMPTY_RECT,
+      dirtyRowsHint,
+      deps: [
+        visible.value,
+        absRect.value,
+        fullRect.value,
+        itemCount.value,
+        props.itemVersion,
+        props.getItem,
+        props.paintItem,
+        props.style,
+        defaultStyle.value,
+      ],
+      paint: (dirtyRows) => {
+        dirtyRowsHint = undefined;
+        if (!visible.value) return;
+        const r = normalizedRect();
+        if (r.w <= 0 || r.h <= 0) return;
+        const { y: clipY } = clipOffsets();
+        const top = currentScrollTop();
+        const base = props.style ?? defaultStyle.value;
+        const blank = spaces(r.w);
+
+        const paintRow = (y: number): void => {
+          if (y < r.y || y >= r.y + r.h) return;
+          terminal.write(blank, { x: r.x, y, style: base });
+          const row = clipY + (y - r.y);
+          const index = top + row;
+          if (index < 0 || index >= itemCount.value) return;
+          props.paintItem({
+            terminal,
+            item: props.getItem(index),
+            index,
+            row,
+            x: r.x,
+            y,
+            w: r.w,
+            scrollTop: top,
+            style: base,
+          });
+        };
+
+        if (dirtyRows?.length) {
+          for (const y of dirtyRows) paintRow(y);
+          return;
+        }
+        for (let y = r.y; y < r.y + r.h; y++) paintRow(y);
+      },
+    }));
+
+    watchEffect(() => {
+      renderNodeId = renderNode.id.value;
+    });
+
+    return () => {
+      const children: VNodeChild[] = [];
+      if (props.renderItemNodes && visible.value) {
+        const r = normalizedRect();
+        const { y: clipY } = clipOffsets();
+        const top = currentScrollTop();
+        for (let y = r.y; y < r.y + r.h; y++) {
+          const row = clipY + (y - r.y);
+          const index = top + row;
+          if (index < 0 || index >= itemCount.value) continue;
+          children.push(
+            props.renderItemNodes({
+              item: props.getItem(index),
+              index,
+              row,
+              scrollTop: top,
+            }),
+          );
+        }
+      }
+      return h("div", rootProps, children);
+    };
+  },
+});

--- a/src/vue/transcript/hit-regions.ts
+++ b/src/vue/transcript/hit-regions.ts
@@ -1,0 +1,12 @@
+import type { TTranscriptHitRegion, TTranscriptVisualRow } from "./types.js";
+
+export function findTranscriptHitRegion(
+  visualRow: TTranscriptVisualRow | undefined,
+  x: number,
+): TTranscriptHitRegion | null {
+  if (!visualRow) return null;
+  for (const region of visualRow.hitRegions) {
+    if (x >= region.x0 && x < region.x1) return region;
+  }
+  return null;
+}

--- a/src/vue/transcript/layout.ts
+++ b/src/vue/transcript/layout.ts
@@ -8,7 +8,6 @@ import type {
 } from "./types.js";
 import type { Style } from "../../core/types.js";
 import { forEachTextCellSegment, sanitizeInlineText, textCellWidth } from "../utils/text.js";
-import { plainTextForTranscriptRow } from "./plain-text.js";
 
 export type TTranscriptRowLayoutOptions = Readonly<{
   row: TTranscriptRow;
@@ -80,6 +79,7 @@ export function layoutTranscriptRow(options: TTranscriptRowLayoutOptions): TTran
   let current = createVisualRow(0, 0);
   let x = 0;
   let absoluteCell = 0;
+  let currentSelectableText = "";
 
   function createVisualRow(partIndex: number, startCell: number) {
     return {
@@ -96,9 +96,10 @@ export function layoutTranscriptRow(options: TTranscriptRowLayoutOptions): TTran
 
   function pushCurrentIfNeeded(force = false): void {
     if (!force && !current.segments.length && !current.hitRegions.length) return;
-    current.selectableText = plainTextForTranscriptRow(options.row);
+    current.selectableText = currentSelectableText;
     visualRows.push(current);
     current = createVisualRow(visualRows.length, absoluteCell);
+    currentSelectableText = "";
     x = 0;
   }
 
@@ -133,6 +134,7 @@ export function layoutTranscriptRow(options: TTranscriptRowLayoutOptions): TTran
       });
     }
     current.text += text;
+    if (selectable !== false) currentSelectableText += text;
     x += clippedCells;
     absoluteCell += clippedCells;
     if (options.wrap !== false && x >= width) pushCurrentIfNeeded(true);
@@ -182,18 +184,20 @@ export function layoutTranscriptRow(options: TTranscriptRowLayoutOptions): TTran
     if (x > 0) appendPiece(" ", 1, options.baseStyle, false, undefined);
     const text = sanitizeInlineText(`[${action.label}]`);
     const baseStyle = mergeStyle(options.baseStyle, styleForAction(action));
-    const regionBase = {
-      id: action.id,
-      kind: "action" as const,
-      rowIndex: options.rowIndex,
-      payload: { action, row: options.row },
-      hoverStyle: action.hoverStyle ?? options.hoverStyle,
-      focusStyle: action.focusStyle ?? options.focusStyle,
-    };
+    const regionBase = action.disabled
+      ? undefined
+      : {
+          id: action.id,
+          kind: "action" as const,
+          rowIndex: options.rowIndex,
+          payload: { action, row: options.row },
+          hoverStyle: action.hoverStyle ?? options.hoverStyle,
+          focusStyle: action.focusStyle ?? options.focusStyle,
+        };
     const activeStyle =
-      action.id === options.focusedRegionId
+      regionBase && action.id === options.focusedRegionId
         ? mergeStyle(baseStyle, regionBase.focusStyle)
-        : action.id === options.hoverRegionId
+        : regionBase && action.id === options.hoverRegionId
           ? mergeStyle(baseStyle, regionBase.hoverStyle)
           : baseStyle;
     appendPiece(text, textCellWidth(text), activeStyle, false, undefined, regionBase);
@@ -204,7 +208,7 @@ export function layoutTranscriptRow(options: TTranscriptRowLayoutOptions): TTran
   if ("actions" in options.row) {
     for (const action of options.row.actions ?? []) appendAction(action);
   }
-  pushCurrentIfNeeded(true);
+  pushCurrentIfNeeded();
   return visualRows.length ? visualRows : [createVisualRow(0, 0)];
 }
 

--- a/src/vue/transcript/layout.ts
+++ b/src/vue/transcript/layout.ts
@@ -35,7 +35,7 @@ function mergeStyle(base: Style, next?: Style): Style {
 }
 
 export function transcriptActionRegionId(rowKey: string | number, actionId: string): string {
-  return `action:${rowKey}:${actionId}`;
+  return JSON.stringify(["action", rowKey, actionId]);
 }
 
 export function transcriptLinkRegionId(
@@ -43,15 +43,15 @@ export function transcriptLinkRegionId(
   sourceSegmentIndex: number,
   tokenId?: string,
 ): string {
-  return `link:${rowKey}:${tokenId ?? sourceSegmentIndex}`;
+  return JSON.stringify(["link", rowKey, tokenId ?? sourceSegmentIndex]);
 }
 
 export function transcriptFoldToggleRegionId(rowKey: string | number): string {
-  return `fold-toggle:${rowKey}`;
+  return JSON.stringify(["fold-toggle", rowKey]);
 }
 
 export function transcriptToolCallRegionId(rowKey: string | number): string {
-  return `tool-call:${rowKey}`;
+  return JSON.stringify(["tool-call", rowKey]);
 }
 
 function sameVisualSegment(

--- a/src/vue/transcript/layout.ts
+++ b/src/vue/transcript/layout.ts
@@ -2,6 +2,7 @@ import type {
   TTranscriptAction,
   TTranscriptHitRegion,
   TTranscriptRow,
+  TTranscriptSelectionSegment,
   TTranscriptSegment,
   TTranscriptVisualRow,
   TTranscriptVisualSegment,
@@ -31,6 +32,18 @@ function styleForAction(action: TTranscriptAction): Style {
 
 function mergeStyle(base: Style, next?: Style): Style {
   return next ? { ...base, ...next } : base;
+}
+
+export function transcriptActionRegionId(rowKey: string | number, actionId: string): string {
+  return `action:${rowKey}:${actionId}`;
+}
+
+export function transcriptLinkRegionId(
+  rowKey: string | number,
+  sourceSegmentIndex: number,
+  tokenId?: string,
+): string {
+  return `link:${rowKey}:${tokenId ?? sourceSegmentIndex}`;
 }
 
 function sameVisualSegment(
@@ -72,6 +85,7 @@ export function layoutTranscriptRow(options: TTranscriptRowLayoutOptions): TTran
     partIndex: number;
     startCell: number;
     segments: TTranscriptVisualSegment[];
+    selectionSegments: TTranscriptSelectionSegment[];
     hitRegions: TTranscriptHitRegion[];
     selectableText?: string;
     text: string;
@@ -88,6 +102,7 @@ export function layoutTranscriptRow(options: TTranscriptRowLayoutOptions): TTran
       partIndex,
       startCell,
       segments: [] as TTranscriptVisualSegment[],
+      selectionSegments: [] as TTranscriptSelectionSegment[],
       hitRegions: [] as TTranscriptHitRegion[],
       selectableText: undefined as string | undefined,
       text: "",
@@ -101,6 +116,19 @@ export function layoutTranscriptRow(options: TTranscriptRowLayoutOptions): TTran
     current = createVisualRow(visualRows.length, absoluteCell);
     currentSelectableText = "";
     x = 0;
+  }
+
+  function appendSelectionSegment(text: string, x0: number, x1: number, selectable: boolean): void {
+    const last = current.selectionSegments[current.selectionSegments.length - 1];
+    if (last && last.selectable === selectable && last.x1 === x0) {
+      current.selectionSegments[current.selectionSegments.length - 1] = {
+        ...last,
+        x1,
+        text: `${last.text}${text}`,
+      };
+      return;
+    }
+    current.selectionSegments.push({ x0, x1, text, selectable });
   }
 
   function appendPiece(
@@ -134,6 +162,7 @@ export function layoutTranscriptRow(options: TTranscriptRowLayoutOptions): TTran
       });
     }
     current.text += text;
+    appendSelectionSegment(text, x, x + clippedCells, selectable !== false);
     if (selectable !== false) currentSelectableText += text;
     x += clippedCells;
     absoluteCell += clippedCells;
@@ -147,10 +176,10 @@ export function layoutTranscriptRow(options: TTranscriptRowLayoutOptions): TTran
     const regionBase =
       segment.href != null
         ? {
-            id: segment.tokenId ?? `link:${options.rowKey}:${sourceSegmentIndex}`,
+            id: transcriptLinkRegionId(options.rowKey, sourceSegmentIndex, segment.tokenId),
             kind: "link" as const,
             rowIndex: options.rowIndex,
-            payload: { href: segment.href, segment, row: options.row },
+            payload: { href: segment.href, tokenId: segment.tokenId, segment, row: options.row },
             hoverStyle: options.hoverStyle,
             focusStyle: options.focusStyle,
           }
@@ -187,17 +216,17 @@ export function layoutTranscriptRow(options: TTranscriptRowLayoutOptions): TTran
     const regionBase = action.disabled
       ? undefined
       : {
-          id: action.id,
+          id: transcriptActionRegionId(options.rowKey, action.id),
           kind: "action" as const,
           rowIndex: options.rowIndex,
-          payload: { action, row: options.row },
+          payload: { actionId: action.id, action, row: options.row },
           hoverStyle: action.hoverStyle ?? options.hoverStyle,
           focusStyle: action.focusStyle ?? options.focusStyle,
         };
     const activeStyle =
-      regionBase && action.id === options.focusedRegionId
+      regionBase && regionBase.id === options.focusedRegionId
         ? mergeStyle(baseStyle, regionBase.focusStyle)
-        : regionBase && action.id === options.hoverRegionId
+        : regionBase && regionBase.id === options.hoverRegionId
           ? mergeStyle(baseStyle, regionBase.hoverStyle)
           : baseStyle;
     appendPiece(text, textCellWidth(text), activeStyle, false, undefined, regionBase);

--- a/src/vue/transcript/layout.ts
+++ b/src/vue/transcript/layout.ts
@@ -1,0 +1,221 @@
+import type {
+  TTranscriptAction,
+  TTranscriptHitRegion,
+  TTranscriptRow,
+  TTranscriptSegment,
+  TTranscriptVisualRow,
+  TTranscriptVisualSegment,
+} from "./types.js";
+import type { Style } from "../../core/types.js";
+import { forEachTextCellSegment, sanitizeInlineText, textCellWidth } from "../utils/text.js";
+import { plainTextForTranscriptRow } from "./plain-text.js";
+
+export type TTranscriptRowLayoutOptions = Readonly<{
+  row: TTranscriptRow;
+  rowIndex: number;
+  rowKey: string | number;
+  width: number;
+  baseStyle: Style;
+  hoverRegionId?: string | null;
+  focusedRegionId?: string | null;
+  hoverStyle?: Style;
+  focusStyle?: Style;
+  wrap?: boolean;
+}>;
+
+function styleForAction(action: TTranscriptAction): Style {
+  if (action.style) return action.style;
+  if (action.kind === "danger") return { fg: "redBright", bold: true };
+  if (action.kind === "primary") return { fg: "cyanBright", bold: true };
+  return { fg: "whiteBright" };
+}
+
+function mergeStyle(base: Style, next?: Style): Style {
+  return next ? { ...base, ...next } : base;
+}
+
+function sameVisualSegment(
+  segment: TTranscriptVisualSegment | undefined,
+  style: Style,
+  selectable: boolean | undefined,
+  sourceSegmentIndex: number | undefined,
+): boolean {
+  return (
+    Boolean(segment) &&
+    segment!.style === style &&
+    segment!.selectable === selectable &&
+    segment!.sourceSegmentIndex === sourceSegmentIndex
+  );
+}
+
+function rowSourceSegments(row: TTranscriptRow): readonly TTranscriptSegment[] {
+  if (row.kind === "message") return row.segments;
+  if (row.kind === "approval") {
+    const description = row.description ?? [];
+    return [{ text: row.title }, ...(description.length ? [{ text: " " }] : []), ...description];
+  }
+  if (row.kind === "tool-call") {
+    const content: TTranscriptSegment[] = [
+      { text: row.collapsed ? `▸ ${row.title}` : `▾ ${row.title}` },
+    ];
+    if (row.summary?.length) content.push({ text: " " }, ...row.summary);
+    if (!row.collapsed && row.body?.length) content.push({ text: " " }, ...row.body);
+    return content;
+  }
+  return [{ text: row.label }];
+}
+
+export function layoutTranscriptRow(options: TTranscriptRowLayoutOptions): TTranscriptVisualRow[] {
+  const width = Math.max(1, Math.floor(options.width));
+  const visualRows: Array<{
+    rowIndex: number;
+    rowKey: string | number;
+    partIndex: number;
+    startCell: number;
+    segments: TTranscriptVisualSegment[];
+    hitRegions: TTranscriptHitRegion[];
+    selectableText?: string;
+    text: string;
+  }> = [];
+  let current = createVisualRow(0, 0);
+  let x = 0;
+  let absoluteCell = 0;
+
+  function createVisualRow(partIndex: number, startCell: number) {
+    return {
+      rowIndex: options.rowIndex,
+      rowKey: options.rowKey,
+      partIndex,
+      startCell,
+      segments: [] as TTranscriptVisualSegment[],
+      hitRegions: [] as TTranscriptHitRegion[],
+      selectableText: undefined as string | undefined,
+      text: "",
+    };
+  }
+
+  function pushCurrentIfNeeded(force = false): void {
+    if (!force && !current.segments.length && !current.hitRegions.length) return;
+    current.selectableText = plainTextForTranscriptRow(options.row);
+    visualRows.push(current);
+    current = createVisualRow(visualRows.length, absoluteCell);
+    x = 0;
+  }
+
+  function appendPiece(
+    text: string,
+    cells: number,
+    style: Style,
+    selectable: boolean | undefined,
+    sourceSegmentIndex: number | undefined,
+    region?: Omit<TTranscriptHitRegion, "x0" | "x1" | "visualRow">,
+  ): void {
+    if (cells <= 0 || !text) return;
+    if (options.wrap !== false && x > 0 && x + cells > width) pushCurrentIfNeeded(true);
+    const clippedCells = cells;
+
+    const last = current.segments[current.segments.length - 1];
+    if (sameVisualSegment(last, style, selectable, sourceSegmentIndex)) {
+      current.segments[current.segments.length - 1] = {
+        ...last!,
+        text: `${last!.text}${text}`,
+        cells: last!.cells + clippedCells,
+      };
+    } else {
+      current.segments.push({ text, cells: clippedCells, style, selectable, sourceSegmentIndex });
+    }
+    if (region) {
+      current.hitRegions.push({
+        ...region,
+        visualRow: current.partIndex,
+        x0: x,
+        x1: x + clippedCells,
+      });
+    }
+    current.text += text;
+    x += clippedCells;
+    absoluteCell += clippedCells;
+    if (options.wrap !== false && x >= width) pushCurrentIfNeeded(true);
+  }
+
+  function appendTextSegment(segment: TTranscriptSegment, sourceSegmentIndex: number): void {
+    const raw = sanitizeInlineText(segment.text);
+    if (!raw) return;
+    const style = mergeStyle(options.baseStyle, segment.style);
+    const regionBase =
+      segment.href != null
+        ? {
+            id: segment.tokenId ?? `link:${options.rowKey}:${sourceSegmentIndex}`,
+            kind: "link" as const,
+            rowIndex: options.rowIndex,
+            payload: { href: segment.href, segment, row: options.row },
+            hoverStyle: options.hoverStyle,
+            focusStyle: options.focusStyle,
+          }
+        : undefined;
+    const activeStyle =
+      regionBase?.id && regionBase.id === options.focusedRegionId
+        ? mergeStyle(style, regionBase.focusStyle ?? options.focusStyle)
+        : regionBase?.id && regionBase.id === options.hoverRegionId
+          ? mergeStyle(style, regionBase.hoverStyle ?? options.hoverStyle)
+          : style;
+
+    if (options.wrap === false) {
+      const cells = textCellWidth(raw);
+      appendPiece(raw, cells, activeStyle, segment.selectable, sourceSegmentIndex, regionBase);
+      return;
+    }
+
+    forEachTextCellSegment(raw, (piece) => {
+      appendPiece(
+        piece.text,
+        piece.cells,
+        activeStyle,
+        segment.selectable,
+        sourceSegmentIndex,
+        regionBase,
+      );
+    });
+  }
+
+  function appendAction(action: TTranscriptAction): void {
+    if (x > 0) appendPiece(" ", 1, options.baseStyle, false, undefined);
+    const text = sanitizeInlineText(`[${action.label}]`);
+    const baseStyle = mergeStyle(options.baseStyle, styleForAction(action));
+    const regionBase = {
+      id: action.id,
+      kind: "action" as const,
+      rowIndex: options.rowIndex,
+      payload: { action, row: options.row },
+      hoverStyle: action.hoverStyle ?? options.hoverStyle,
+      focusStyle: action.focusStyle ?? options.focusStyle,
+    };
+    const activeStyle =
+      action.id === options.focusedRegionId
+        ? mergeStyle(baseStyle, regionBase.focusStyle)
+        : action.id === options.hoverRegionId
+          ? mergeStyle(baseStyle, regionBase.hoverStyle)
+          : baseStyle;
+    appendPiece(text, textCellWidth(text), activeStyle, false, undefined, regionBase);
+  }
+
+  const segments = rowSourceSegments(options.row);
+  for (let i = 0; i < segments.length; i++) appendTextSegment(segments[i]!, i);
+  if ("actions" in options.row) {
+    for (const action of options.row.actions ?? []) appendAction(action);
+  }
+  pushCurrentIfNeeded(true);
+  return visualRows.length ? visualRows : [createVisualRow(0, 0)];
+}
+
+export function layoutTranscriptRows(
+  rows: readonly TTranscriptRow[],
+  options: Omit<TTranscriptRowLayoutOptions, "row" | "rowIndex" | "rowKey">,
+): TTranscriptVisualRow[] {
+  const out: TTranscriptVisualRow[] = [];
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i]!;
+    out.push(...layoutTranscriptRow({ ...options, row, rowIndex: i, rowKey: row.key }));
+  }
+  return out;
+}

--- a/src/vue/transcript/layout.ts
+++ b/src/vue/transcript/layout.ts
@@ -46,6 +46,14 @@ export function transcriptLinkRegionId(
   return `link:${rowKey}:${tokenId ?? sourceSegmentIndex}`;
 }
 
+export function transcriptFoldToggleRegionId(rowKey: string | number): string {
+  return `fold-toggle:${rowKey}`;
+}
+
+export function transcriptToolCallRegionId(rowKey: string | number): string {
+  return `tool-call:${rowKey}`;
+}
+
 function sameVisualSegment(
   segment: TTranscriptVisualSegment | undefined,
   style: Style,
@@ -169,11 +177,15 @@ export function layoutTranscriptRow(options: TTranscriptRowLayoutOptions): TTran
     if (options.wrap !== false && x >= width) pushCurrentIfNeeded(true);
   }
 
-  function appendTextSegment(segment: TTranscriptSegment, sourceSegmentIndex: number): void {
+  function appendTextSegment(
+    segment: TTranscriptSegment,
+    sourceSegmentIndex: number,
+    fallbackRegion?: Omit<TTranscriptHitRegion, "x0" | "x1" | "visualRow">,
+  ): void {
     const raw = sanitizeInlineText(segment.text);
     if (!raw) return;
     const style = mergeStyle(options.baseStyle, segment.style);
-    const regionBase =
+    const linkRegion =
       segment.href != null
         ? {
             id: transcriptLinkRegionId(options.rowKey, sourceSegmentIndex, segment.tokenId),
@@ -184,6 +196,7 @@ export function layoutTranscriptRow(options: TTranscriptRowLayoutOptions): TTran
             focusStyle: options.focusStyle,
           }
         : undefined;
+    const regionBase = linkRegion ?? fallbackRegion;
     const activeStyle =
       regionBase?.id && regionBase.id === options.focusedRegionId
         ? mergeStyle(style, regionBase.focusStyle ?? options.focusStyle)
@@ -233,7 +246,29 @@ export function layoutTranscriptRow(options: TTranscriptRowLayoutOptions): TTran
   }
 
   const segments = rowSourceSegments(options.row);
-  for (let i = 0; i < segments.length; i++) appendTextSegment(segments[i]!, i);
+  if (options.row.kind === "tool-call") {
+    const foldRegion = {
+      id: transcriptFoldToggleRegionId(options.rowKey),
+      kind: "fold-toggle" as const,
+      rowIndex: options.rowIndex,
+      payload: { row: options.row, rowKey: options.rowKey, collapsed: options.row.collapsed },
+      hoverStyle: options.hoverStyle,
+      focusStyle: options.focusStyle,
+    };
+    const toolRegion = {
+      id: transcriptToolCallRegionId(options.rowKey),
+      kind: "tool-call" as const,
+      rowIndex: options.rowIndex,
+      payload: { row: options.row, rowKey: options.rowKey },
+      hoverStyle: options.hoverStyle,
+      focusStyle: options.focusStyle,
+    };
+    for (let i = 0; i < segments.length; i++) {
+      appendTextSegment(segments[i]!, i, i === 0 ? foldRegion : toolRegion);
+    }
+  } else {
+    for (let i = 0; i < segments.length; i++) appendTextSegment(segments[i]!, i);
+  }
   if ("actions" in options.row) {
     for (const action of options.row.actions ?? []) appendAction(action);
   }

--- a/src/vue/transcript/plain-text.ts
+++ b/src/vue/transcript/plain-text.ts
@@ -1,0 +1,14 @@
+import type { TTranscriptRow } from "./types.js";
+
+export function plainTextForTranscriptRow(row: TTranscriptRow): string {
+  if (row.selectableText != null) return row.selectableText;
+  if (row.kind === "message") return row.segments.map((segment) => segment.text).join("");
+  if (row.kind === "action") return row.label;
+  if (row.kind === "approval") {
+    const description = row.description?.map((segment) => segment.text).join("") ?? "";
+    return description ? `${row.title}\n${description}` : row.title;
+  }
+  const summary = row.summary?.map((segment) => segment.text).join("") ?? "";
+  const body = row.collapsed ? "" : (row.body?.map((segment) => segment.text).join("") ?? "");
+  return [row.title, summary, body].filter(Boolean).join("\n");
+}

--- a/src/vue/transcript/types.ts
+++ b/src/vue/transcript/types.ts
@@ -74,6 +74,13 @@ export type TTranscriptVisualSegment = Readonly<{
   sourceSegmentIndex?: number;
 }>;
 
+export type TTranscriptSelectionSegment = Readonly<{
+  x0: number;
+  x1: number;
+  text: string;
+  selectable: boolean;
+}>;
+
 export type TTranscriptHitRegion = Readonly<{
   id: string;
   kind: "link" | "action" | "fold-toggle" | "tool-call" | "custom";
@@ -92,6 +99,7 @@ export type TTranscriptVisualRow = Readonly<{
   partIndex: number;
   startCell: number;
   segments: readonly TTranscriptVisualSegment[];
+  selectionSegments: readonly TTranscriptSelectionSegment[];
   hitRegions: readonly TTranscriptHitRegion[];
   selectableText?: string;
   text: string;

--- a/src/vue/transcript/types.ts
+++ b/src/vue/transcript/types.ts
@@ -83,7 +83,7 @@ export type TTranscriptSelectionSegment = Readonly<{
 
 export type TTranscriptHitRegion = Readonly<{
   id: string;
-  kind: "link" | "action" | "fold-toggle" | "tool-call" | "custom";
+  kind: "link" | "action" | "fold-toggle" | "tool-call";
   rowIndex: number;
   visualRow: number;
   x0: number;

--- a/src/vue/transcript/types.ts
+++ b/src/vue/transcript/types.ts
@@ -1,0 +1,124 @@
+import type { Style } from "../../core/types.js";
+
+export type TTranscriptSegment = Readonly<{
+  text: string;
+  style?: Style;
+  href?: string;
+  selectable?: boolean;
+  tokenId?: string;
+  meta?: unknown;
+}>;
+
+export type TTranscriptAction = Readonly<{
+  id: string;
+  label: string;
+  disabled?: boolean;
+  kind?: "primary" | "secondary" | "danger";
+  style?: Style;
+  hoverStyle?: Style;
+  focusStyle?: Style;
+  payload?: unknown;
+}>;
+
+export type TTranscriptRow =
+  | {
+      kind: "message";
+      key: string | number;
+      role?: "user" | "assistant" | "system" | "tool";
+      segments: readonly TTranscriptSegment[];
+      selectableText?: string;
+      actions?: readonly TTranscriptAction[];
+      meta?: unknown;
+    }
+  | {
+      kind: "action";
+      key: string | number;
+      label: string;
+      actions: readonly TTranscriptAction[];
+      selectableText?: string;
+      meta?: unknown;
+    }
+  | {
+      kind: "tool-call";
+      key: string | number;
+      title: string;
+      collapsed: boolean;
+      summary?: readonly TTranscriptSegment[];
+      body?: readonly TTranscriptSegment[];
+      actions?: readonly TTranscriptAction[];
+      selectableText?: string;
+      meta?: unknown;
+    }
+  | {
+      kind: "approval";
+      key: string | number;
+      title: string;
+      description?: readonly TTranscriptSegment[];
+      actions: readonly TTranscriptAction[];
+      selectableText?: string;
+      meta?: unknown;
+    };
+
+export type TTranscriptDataSource = Readonly<{
+  rowCount(): number;
+  getRow(index: number): TTranscriptRow;
+  getRowKey?: (index: number) => string | number;
+  firstRowIndex?: () => number;
+}>;
+
+export type TTranscriptVisualSegment = Readonly<{
+  text: string;
+  cells: number;
+  style: Style;
+  selectable?: boolean;
+  sourceSegmentIndex?: number;
+}>;
+
+export type TTranscriptHitRegion = Readonly<{
+  id: string;
+  kind: "link" | "action" | "fold-toggle" | "tool-call" | "custom";
+  rowIndex: number;
+  visualRow: number;
+  x0: number;
+  x1: number;
+  payload?: unknown;
+  hoverStyle?: Style;
+  focusStyle?: Style;
+}>;
+
+export type TTranscriptVisualRow = Readonly<{
+  rowIndex: number;
+  rowKey: string | number;
+  partIndex: number;
+  startCell: number;
+  segments: readonly TTranscriptVisualSegment[];
+  hitRegions: readonly TTranscriptHitRegion[];
+  selectableText?: string;
+  text: string;
+}>;
+
+export type TTranscriptRegionEvent = Readonly<{
+  region: TTranscriptHitRegion;
+  row: TTranscriptRow;
+  rowIndex: number;
+  event?: unknown;
+}>;
+
+export type TTranscriptRowEvent = Readonly<{
+  row: TTranscriptRow;
+  rowIndex: number;
+  event?: unknown;
+}>;
+
+export type TTranscriptViewHandle = Readonly<{
+  scrollToBottom(): void;
+  scrollToTop(): void;
+  scrollToRow(index: number, options?: { align?: "start" | "center" | "end" }): void;
+  invalidateRow(index: number): void;
+  invalidateRange(start: number, end: number): void;
+  refreshViewport(): void;
+  focusNextRegion(): boolean;
+  focusPreviousRegion(): boolean;
+  activateFocusedRegion(): boolean;
+  getHoveredRegion(): TTranscriptHitRegion | null;
+}>;

--- a/src/vue/transcript/types.ts
+++ b/src/vue/transcript/types.ts
@@ -101,12 +101,14 @@ export type TTranscriptRegionEvent = Readonly<{
   region: TTranscriptHitRegion;
   row: TTranscriptRow;
   rowIndex: number;
+  absoluteRowIndex: number;
   event?: unknown;
 }>;
 
 export type TTranscriptRowEvent = Readonly<{
   row: TTranscriptRow;
   rowIndex: number;
+  absoluteRowIndex: number;
   event?: unknown;
 }>;
 

--- a/test/api-surface.test.ts
+++ b/test/api-surface.test.ts
@@ -132,6 +132,7 @@ describe("public API surface", () => {
         "TLogView",
         "TLogVirtualLinksPanel",
         "TLogVirtualSearchResults",
+        "TTranscriptView",
         "TVirtualList",
         "captureTLogViewSessionState",
         "createAppendOnlyLogStore",

--- a/test/transcript-layout.test.ts
+++ b/test/transcript-layout.test.ts
@@ -21,6 +21,23 @@ describe("transcript row layout", () => {
     expect(rows[0]?.segments[0]?.cells).toBe(3);
   });
 
+  it("keeps selectable text scoped to each wrapped visual row", () => {
+    const rows = layoutTranscriptRow({
+      row: {
+        kind: "message",
+        key: "msg",
+        segments: [{ text: "abcdef" }],
+      },
+      rowIndex: 0,
+      rowKey: "msg",
+      width: 3,
+      baseStyle: {},
+      wrap: true,
+    });
+
+    expect(rows.map((row) => row.selectableText)).toEqual(["abc", "def"]);
+  });
+
   it("lays out action hit regions without adding actions to copy text", () => {
     const row = {
       kind: "approval" as const,
@@ -45,6 +62,26 @@ describe("transcript row layout", () => {
       rowIndex: 2,
     });
     expect(plainTextForTranscriptRow(row)).toBe("Allow command?\npnpm test");
+  });
+
+  it("does not create hit regions for disabled actions", () => {
+    const row = {
+      kind: "approval" as const,
+      key: "approval",
+      title: "Allow command?",
+      actions: [{ id: "approve", label: "Approve", disabled: true }],
+    };
+    const rows = layoutTranscriptRow({
+      row,
+      rowIndex: 0,
+      rowKey: row.key,
+      width: 80,
+      baseStyle: {},
+      wrap: false,
+    });
+
+    expect(rows[0]?.text).toContain("[Approve]");
+    expect(rows[0]?.hitRegions).toEqual([]);
   });
 
   it("omits collapsed tool-call body from plain text", () => {

--- a/test/transcript-layout.test.ts
+++ b/test/transcript-layout.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { layoutTranscriptRow } from "../src/vue/transcript/layout.js";
+import {
+  layoutTranscriptRow,
+  transcriptActionRegionId,
+  transcriptFoldToggleRegionId,
+  transcriptToolCallRegionId,
+} from "../src/vue/transcript/layout.js";
 import { plainTextForTranscriptRow } from "../src/vue/transcript/plain-text.js";
 import { sliceByCellsRange } from "../src/vue/utils/text.js";
 
@@ -58,7 +63,7 @@ describe("transcript row layout", () => {
 
     expect(rows).toHaveLength(1);
     expect(rows[0]?.hitRegions[0]).toMatchObject({
-      id: "action:approval:approve",
+      id: transcriptActionRegionId("approval", "approve"),
       kind: "action",
       rowIndex: 2,
       payload: { actionId: "approve" },
@@ -104,8 +109,8 @@ describe("transcript row layout", () => {
       wrap: false,
     });
 
-    expect(first[0]?.hitRegions[0]?.id).toBe("action:first:approve");
-    expect(second[0]?.hitRegions[0]?.id).toBe("action:second:approve");
+    expect(first[0]?.hitRegions[0]?.id).toBe(transcriptActionRegionId("first", "approve"));
+    expect(second[0]?.hitRegions[0]?.id).toBe(transcriptActionRegionId("second", "approve"));
   });
 
   it("keeps selection segments aligned across non-selectable cells", () => {
@@ -174,12 +179,12 @@ describe("transcript row layout", () => {
     expect(rows[0]?.hitRegions.map((region) => region.kind)).toContain("tool-call");
     expect(rows[0]?.hitRegions.some((region) => region.kind === "action")).toBe(false);
     expect(rows[0]?.hitRegions.find((region) => region.kind === "fold-toggle")).toMatchObject({
-      id: "fold-toggle:tool",
+      id: transcriptFoldToggleRegionId("tool"),
       rowIndex: 1,
       payload: { collapsed: false },
     });
     expect(rows[0]?.hitRegions.find((region) => region.kind === "tool-call")).toMatchObject({
-      id: "tool-call:tool",
+      id: transcriptToolCallRegionId("tool"),
       rowIndex: 1,
     });
   });

--- a/test/transcript-layout.test.ts
+++ b/test/transcript-layout.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { layoutTranscriptRow } from "../src/vue/transcript/layout.js";
+import { plainTextForTranscriptRow } from "../src/vue/transcript/plain-text.js";
+
+describe("transcript row layout", () => {
+  it("wraps rich text by terminal cells", () => {
+    const rows = layoutTranscriptRow({
+      row: {
+        kind: "message",
+        key: "msg",
+        segments: [{ text: "a中b", style: { fg: "cyan" } }],
+      },
+      rowIndex: 0,
+      rowKey: "msg",
+      width: 3,
+      baseStyle: {},
+      wrap: true,
+    });
+
+    expect(rows.map((row) => row.text)).toEqual(["a中", "b"]);
+    expect(rows[0]?.segments[0]?.cells).toBe(3);
+  });
+
+  it("lays out action hit regions without adding actions to copy text", () => {
+    const row = {
+      kind: "approval" as const,
+      key: "approval",
+      title: "Allow command?",
+      description: [{ text: "pnpm test" }],
+      actions: [{ id: "approve", label: "Approve", kind: "primary" as const }],
+    };
+    const rows = layoutTranscriptRow({
+      row,
+      rowIndex: 2,
+      rowKey: row.key,
+      width: 80,
+      baseStyle: {},
+      wrap: false,
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.hitRegions[0]).toMatchObject({
+      id: "approve",
+      kind: "action",
+      rowIndex: 2,
+    });
+    expect(plainTextForTranscriptRow(row)).toBe("Allow command?\npnpm test");
+  });
+
+  it("omits collapsed tool-call body from plain text", () => {
+    const row = {
+      kind: "tool-call" as const,
+      key: "tool",
+      title: "read_file",
+      collapsed: true,
+      summary: [{ text: "src/index.ts" }],
+      body: [{ text: "hidden body" }],
+    };
+
+    expect(plainTextForTranscriptRow(row)).toBe("read_file\nsrc/index.ts");
+  });
+});

--- a/test/transcript-layout.test.ts
+++ b/test/transcript-layout.test.ts
@@ -151,6 +151,39 @@ describe("transcript row layout", () => {
     expect(rows[0]?.hitRegions).toEqual([]);
   });
 
+  it("creates fold and tool-call hit regions for tool-call rows", () => {
+    const row = {
+      kind: "tool-call" as const,
+      key: "tool",
+      title: "read_file",
+      collapsed: false,
+      summary: [{ text: "src/index.ts" }],
+      body: [{ text: "contents" }],
+      actions: [{ id: "retry", label: "Retry", disabled: true }],
+    };
+    const rows = layoutTranscriptRow({
+      row,
+      rowIndex: 1,
+      rowKey: row.key,
+      width: 80,
+      baseStyle: {},
+      wrap: false,
+    });
+
+    expect(rows[0]?.hitRegions.map((region) => region.kind)).toContain("fold-toggle");
+    expect(rows[0]?.hitRegions.map((region) => region.kind)).toContain("tool-call");
+    expect(rows[0]?.hitRegions.some((region) => region.kind === "action")).toBe(false);
+    expect(rows[0]?.hitRegions.find((region) => region.kind === "fold-toggle")).toMatchObject({
+      id: "fold-toggle:tool",
+      rowIndex: 1,
+      payload: { collapsed: false },
+    });
+    expect(rows[0]?.hitRegions.find((region) => region.kind === "tool-call")).toMatchObject({
+      id: "tool-call:tool",
+      rowIndex: 1,
+    });
+  });
+
   it("omits collapsed tool-call body from plain text", () => {
     const row = {
       kind: "tool-call" as const,

--- a/test/transcript-layout.test.ts
+++ b/test/transcript-layout.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { layoutTranscriptRow } from "../src/vue/transcript/layout.js";
 import { plainTextForTranscriptRow } from "../src/vue/transcript/plain-text.js";
+import { sliceByCellsRange } from "../src/vue/utils/text.js";
 
 describe("transcript row layout", () => {
   it("wraps rich text by terminal cells", () => {
@@ -57,11 +58,77 @@ describe("transcript row layout", () => {
 
     expect(rows).toHaveLength(1);
     expect(rows[0]?.hitRegions[0]).toMatchObject({
-      id: "approve",
+      id: "action:approval:approve",
       kind: "action",
       rowIndex: 2,
+      payload: { actionId: "approve" },
     });
+    const region = rows[0]!.hitRegions[0]!;
+    expect(
+      sliceByCellsRange(
+        rows[0]!.selectionSegments.map((segment) => segment.text).join(""),
+        region.x0,
+        region.x1,
+      ),
+    ).toBe("[Approve]");
+    expect(
+      rows[0]!.selectionSegments.find(
+        (segment) => segment.x0 <= region.x0 && segment.x1 >= region.x1,
+      ),
+    ).toMatchObject({ selectable: false });
     expect(plainTextForTranscriptRow(row)).toBe("Allow command?\npnpm test");
+  });
+
+  it("scopes repeated action ids by row key", () => {
+    const makeRow = (key: string) => ({
+      kind: "approval" as const,
+      key,
+      title: "Allow?",
+      actions: [{ id: "approve", label: "Approve", kind: "primary" as const }],
+    });
+
+    const first = layoutTranscriptRow({
+      row: makeRow("first"),
+      rowIndex: 0,
+      rowKey: "first",
+      width: 80,
+      baseStyle: {},
+      wrap: false,
+    });
+    const second = layoutTranscriptRow({
+      row: makeRow("second"),
+      rowIndex: 1,
+      rowKey: "second",
+      width: 80,
+      baseStyle: {},
+      wrap: false,
+    });
+
+    expect(first[0]?.hitRegions[0]?.id).toBe("action:first:approve");
+    expect(second[0]?.hitRegions[0]?.id).toBe("action:second:approve");
+  });
+
+  it("keeps selection segments aligned across non-selectable cells", () => {
+    const rows = layoutTranscriptRow({
+      row: {
+        kind: "message",
+        key: "msg",
+        segments: [{ text: "AA" }, { text: "XX", selectable: false }, { text: "BB" }],
+      },
+      rowIndex: 0,
+      rowKey: "msg",
+      width: 80,
+      baseStyle: {},
+      wrap: false,
+    });
+
+    expect(rows[0]?.text).toBe("AAXXBB");
+    expect(rows[0]?.selectableText).toBe("AABB");
+    expect(rows[0]?.selectionSegments).toEqual([
+      { x0: 0, x1: 2, text: "AA", selectable: true },
+      { x0: 2, x1: 4, text: "XX", selectable: false },
+      { x0: 4, x1: 6, text: "BB", selectable: true },
+    ]);
   });
 
   it("does not create hit regions for disabled actions", () => {

--- a/test/transcript-view.test.ts
+++ b/test/transcript-view.test.ts
@@ -34,6 +34,14 @@ function rowText(
     .trimEnd();
 }
 
+function cellStyle(
+  mounted: { terminal: { getRow: (y: number) => readonly { style: Record<string, unknown> }[] } },
+  x: number,
+  y: number,
+): Record<string, unknown> {
+  return mounted.terminal.getRow(y)[x]?.style ?? {};
+}
+
 function installNavigatorClipboard(writes: string[]): () => void {
   const previous = (navigator as any).clipboard;
   Object.defineProperty(navigator, "clipboard", {
@@ -266,6 +274,205 @@ describe("TTranscriptView", () => {
       expect(actionX).toBeGreaterThanOrEqual(0);
 
       app.events.dispatch({ type: "click", cellX: actionX, cellY: 0, time: 1_000 } as any);
+      expect(viewRef.value?.focusNextRegion()).toBe(false);
+      expect(viewRef.value?.activateFocusedRegion()).toBe(false);
+      expect(actionClick).not.toHaveBeenCalled();
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("emits foldToggle from collapsed and expanded tool-call header clicks", async () => {
+    const foldToggle = vi.fn();
+    const rows: TTranscriptRow[] = [
+      {
+        kind: "tool-call",
+        key: "collapsed",
+        title: "read_file",
+        collapsed: true,
+        summary: [{ text: "src/index.ts" }],
+      },
+      {
+        kind: "tool-call",
+        key: "expanded",
+        title: "run_tests",
+        collapsed: false,
+        body: [{ text: "passed" }],
+      },
+    ];
+    const App = defineComponent({
+      name: "TranscriptToolFoldApp",
+      setup() {
+        return () =>
+          h(TTranscriptView, {
+            x: 0,
+            y: 0,
+            w: 32,
+            h: 2,
+            source: createSource(rows),
+            version: 1,
+            onFoldToggle: foldToggle,
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 32, rows: 4, component: App });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "click", cellX: 0, cellY: 0, time: 1_000 } as any);
+      app.events.dispatch({ type: "click", cellX: 0, cellY: 1, time: 1_001 } as any);
+
+      expect(foldToggle).toHaveBeenCalledTimes(2);
+      expect(foldToggle.mock.calls.map(([event]) => event.row.key)).toEqual([
+        "collapsed",
+        "expanded",
+      ]);
+      expect(foldToggle.mock.calls.map(([event]) => event.region.kind)).toEqual([
+        "fold-toggle",
+        "fold-toggle",
+      ]);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("emits toolClick from tool-call body regions", async () => {
+    const toolClick = vi.fn();
+    const row: TTranscriptRow = {
+      kind: "tool-call",
+      key: "tool",
+      title: "run_tests",
+      collapsed: false,
+      body: [{ text: "passed" }],
+    };
+    const App = defineComponent({
+      name: "TranscriptToolClickApp",
+      setup() {
+        return () =>
+          h(TTranscriptView, {
+            x: 0,
+            y: 0,
+            w: 32,
+            h: 1,
+            source: createSource([row]),
+            version: 1,
+            onToolClick: toolClick,
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 32, rows: 3, component: App });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      const bodyX = rowText(app, 0).indexOf("passed");
+      expect(bodyX).toBeGreaterThanOrEqual(0);
+      app.events.dispatch({ type: "click", cellX: bodyX, cellY: 0, time: 1_000 } as any);
+
+      expect(toolClick).toHaveBeenCalledTimes(1);
+      expect(toolClick.mock.calls[0]?.[0].region.kind).toBe("tool-call");
+      expect(toolClick.mock.calls[0]?.[0].row).toBe(row);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("repaints every wrapped visual row for hovered and focused links", async () => {
+    const viewRef = ref<TTranscriptViewHandle | null>(null);
+    const row: TTranscriptRow = {
+      kind: "message",
+      key: "msg",
+      segments: [{ text: "abcdef", href: "https://example.com" }],
+    };
+    const App = defineComponent({
+      name: "TranscriptWrappedLinkRepaintApp",
+      setup() {
+        return () =>
+          h(TTranscriptView, {
+            ref: viewRef,
+            x: 0,
+            y: 0,
+            w: 3,
+            h: 2,
+            source: createSource([row]),
+            version: 1,
+            wrap: true,
+            hoverStyle: { inverse: true },
+            focusStyle: { underline: true },
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 3, rows: 3, component: App });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      expect(rowText(app, 0)).toBe("abc");
+      expect(rowText(app, 1)).toBe("def");
+
+      app.events.dispatch({ type: "pointermove", cellX: 0, cellY: 0, time: 1_000 } as any);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(cellStyle(app, 0, 0)).toMatchObject({ inverse: true });
+      expect(cellStyle(app, 0, 1)).toMatchObject({ inverse: true });
+
+      expect(viewRef.value?.focusNextRegion()).toBe(true);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(cellStyle(app, 0, 0)).toMatchObject({ underline: true });
+      expect(cellStyle(app, 0, 1)).toMatchObject({ underline: true });
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("does not focus or activate offscreen regions by keyboard navigation", async () => {
+    const actionClick = vi.fn();
+    const viewRef = ref<TTranscriptViewHandle | null>(null);
+    const rows: TTranscriptRow[] = [
+      {
+        kind: "message",
+        key: "visible",
+        segments: [{ text: "visible" }],
+      },
+      {
+        kind: "approval",
+        key: "offscreen",
+        title: "Allow?",
+        actions: [{ id: "approve", label: "Approve" }],
+      },
+    ];
+    const App = defineComponent({
+      name: "TranscriptVisibleFocusApp",
+      setup() {
+        return () =>
+          h(TTranscriptView, {
+            ref: viewRef,
+            x: 0,
+            y: 0,
+            w: 24,
+            h: 1,
+            source: createSource(rows),
+            version: 1,
+            onActionClick: actionClick,
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 24, rows: 3, component: App });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
       expect(viewRef.value?.focusNextRegion()).toBe(false);
       expect(viewRef.value?.activateFocusedRegion()).toBe(false);
       expect(actionClick).not.toHaveBeenCalled();

--- a/test/transcript-view.test.ts
+++ b/test/transcript-view.test.ts
@@ -6,6 +6,7 @@ import {
   type TTranscriptRow,
   type TTranscriptViewHandle,
 } from "../src/experimental.js";
+import { transcriptActionRegionId, transcriptLinkRegionId } from "../src/vue/transcript/layout.js";
 import {
   defineComponent,
   h,
@@ -123,6 +124,12 @@ async function copyTranscriptSelection(
 }
 
 describe("TTranscriptView", () => {
+  it("generates unambiguous hit region ids for structured keys", () => {
+    expect(transcriptActionRegionId("a:b", "c")).not.toBe(transcriptActionRegionId("a", "b:c"));
+    expect(transcriptLinkRegionId("a:b", 0, "c")).not.toBe(transcriptLinkRegionId("a", 0, "b:c"));
+    expect(transcriptLinkRegionId("a:0", 1)).not.toBe(transcriptLinkRegionId("a", 0, "0:1"));
+  });
+
   it("copies wrapped visual rows without repeating the full message", async () => {
     const rows: TTranscriptRow[] = [
       {
@@ -282,6 +289,107 @@ describe("TTranscriptView", () => {
     }
   });
 
+  it("handles visible regions with Tab, Enter, and Escape when enabled", async () => {
+    const actionClick = vi.fn();
+    const rows: TTranscriptRow[] = [
+      {
+        kind: "approval",
+        key: "approval",
+        title: "Allow?",
+        actions: [
+          { id: "first", label: "First" },
+          { id: "second", label: "Second" },
+        ],
+      },
+    ];
+    const App = defineComponent({
+      name: "TranscriptKeyboardRegionsApp",
+      setup() {
+        return () =>
+          h(TTranscriptView, {
+            x: 0,
+            y: 0,
+            w: 32,
+            h: 1,
+            source: createSource(rows),
+            version: 1,
+            autoFocus: true,
+            onActionClick: actionClick,
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 32, rows: 3, component: App });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "keydown", key: "Tab", code: "Tab", time: 1_000 } as any);
+      app.events.dispatch({ type: "keydown", key: "Enter", code: "Enter", time: 1_001 } as any);
+      app.events.dispatch({
+        type: "keydown",
+        key: "Tab",
+        code: "Tab",
+        shiftKey: true,
+        time: 1_002,
+      } as any);
+      app.events.dispatch({ type: "keydown", key: "Enter", code: "Enter", time: 1_003 } as any);
+      app.events.dispatch({ type: "keydown", key: "Escape", code: "Escape", time: 1_004 } as any);
+      app.events.dispatch({ type: "keydown", key: "Enter", code: "Enter", time: 1_005 } as any);
+
+      expect(actionClick.mock.calls.map(([event]) => event.region.payload.actionId)).toEqual([
+        "first",
+        "second",
+      ]);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("does not intercept region keyboard handling when keyboardRegions is disabled", async () => {
+    const actionClick = vi.fn();
+    const rows: TTranscriptRow[] = [
+      {
+        kind: "approval",
+        key: "approval",
+        title: "Allow?",
+        actions: [{ id: "approve", label: "Approve" }],
+      },
+    ];
+    const App = defineComponent({
+      name: "TranscriptKeyboardRegionsDisabledApp",
+      setup() {
+        return () =>
+          h(TTranscriptView, {
+            x: 0,
+            y: 0,
+            w: 32,
+            h: 1,
+            source: createSource(rows),
+            version: 1,
+            autoFocus: true,
+            keyboardRegions: false,
+            onActionClick: actionClick,
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 32, rows: 3, component: App });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      app.events.dispatch({ type: "keydown", key: "Tab", code: "Tab", time: 1_000 } as any);
+      app.events.dispatch({ type: "keydown", key: "Enter", code: "Enter", time: 1_001 } as any);
+
+      expect(actionClick).not.toHaveBeenCalled();
+    } finally {
+      app.dispose();
+    }
+  });
+
   it("emits foldToggle from collapsed and expanded tool-call header clicks", async () => {
     const foldToggle = vi.fn();
     const rows: TTranscriptRow[] = [
@@ -434,6 +542,108 @@ describe("TTranscriptView", () => {
     }
   });
 
+  it("clears hovered regions when they leave the visible viewport", async () => {
+    const hoverRegion = vi.fn();
+    const viewRef = ref<TTranscriptViewHandle | null>(null);
+    const rows: TTranscriptRow[] = [
+      {
+        kind: "approval",
+        key: "approval",
+        title: "Allow?",
+        actions: [{ id: "approve", label: "Approve" }],
+      },
+      {
+        kind: "message",
+        key: "next",
+        segments: [{ text: "next" }],
+      },
+    ];
+    const App = defineComponent({
+      name: "TranscriptHoverReconcileApp",
+      setup() {
+        return () =>
+          h(TTranscriptView, {
+            ref: viewRef,
+            x: 0,
+            y: 0,
+            w: 32,
+            h: 1,
+            source: createSource(rows),
+            version: 1,
+            onHoverRegion: hoverRegion,
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 32, rows: 3, component: App });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      const actionX = rowText(app, 0).indexOf("[Approve]");
+      expect(actionX).toBeGreaterThanOrEqual(0);
+      app.events.dispatch({ type: "pointermove", cellX: actionX, cellY: 0, time: 1_000 } as any);
+      await nextTick();
+      expect(viewRef.value?.getHoveredRegion()?.id).toBe(
+        transcriptActionRegionId("approval", "approve"),
+      );
+
+      viewRef.value?.scrollToRow(1);
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(viewRef.value?.getHoveredRegion()).toBeNull();
+      expect(hoverRegion.mock.calls.at(-1)?.[0]).toBeNull();
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("warns in debug perf mode when transcript rows flatten past the prototype bound", async () => {
+    const previousDebugPerf = (globalThis as any).__VT_DEBUG_PERF__;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    (globalThis as any).__VT_DEBUG_PERF__ = true;
+    const rows = Array.from(
+      { length: 5001 },
+      (_, index): TTranscriptRow => ({
+        kind: "message",
+        key: index,
+        segments: [{ text: `row-${index}` }],
+      }),
+    );
+    const App = defineComponent({
+      name: "TranscriptLargeFlattenWarningApp",
+      setup() {
+        return () =>
+          h(TTranscriptView, {
+            x: 0,
+            y: 0,
+            w: 16,
+            h: 1,
+            source: createSource(rows),
+            version: 1,
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 16, rows: 2, component: App });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(warn).toHaveBeenCalledWith(
+        "[vue-tui] TTranscriptView flattens all transcript rows; use TLogView or windowed source for large retained output.",
+      );
+    } finally {
+      app.dispose();
+      warn.mockRestore();
+      if (previousDebugPerf === undefined) delete (globalThis as any).__VT_DEBUG_PERF__;
+      else (globalThis as any).__VT_DEBUG_PERF__ = previousDebugPerf;
+    }
+  });
+
   it("does not focus or activate offscreen regions by keyboard navigation", async () => {
     const actionClick = vi.fn();
     const viewRef = ref<TTranscriptViewHandle | null>(null);
@@ -530,9 +740,9 @@ describe("TTranscriptView", () => {
 
       expect(actionClick.mock.calls.map(([event]) => event.rowIndex)).toEqual([0, 1, 0]);
       expect(actionClick.mock.calls.map(([event]) => event.region.id)).toEqual([
-        "action:first:approve",
-        "action:second:approve",
-        "action:first:approve",
+        transcriptActionRegionId("first", "approve"),
+        transcriptActionRegionId("second", "approve"),
+        transcriptActionRegionId("first", "approve"),
       ]);
       expect(actionClick.mock.calls[0]?.[0].region.payload).toMatchObject({ actionId: "approve" });
     } finally {

--- a/test/transcript-view.test.ts
+++ b/test/transcript-view.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTerminalApp } from "../src/cli.js";
+import {
+  TTranscriptView,
+  type TTranscriptDataSource,
+  type TTranscriptRow,
+  type TTranscriptViewHandle,
+} from "../src/experimental.js";
+import { defineComponent, h, mountTerminal, nextTick, ref } from "./ui-regressions-support.js";
+import { installManualRaf } from "./helpers/manual-raf.js";
+
+function createSource(rows: readonly TTranscriptRow[]): TTranscriptDataSource {
+  return {
+    rowCount: () => rows.length,
+    getRow: (index) => rows[index]!,
+  };
+}
+
+function rowText(
+  mounted: { terminal: { getRow: (y: number) => readonly { ch: string }[] } },
+  y: number,
+): string {
+  return mounted.terminal
+    .getRow(y)
+    .map((cell) => cell.ch)
+    .join("")
+    .trimEnd();
+}
+
+function installNavigatorClipboard(writes: string[]): () => void {
+  const previous = (navigator as any).clipboard;
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: {
+      readText: vi.fn(async () => writes[writes.length - 1] ?? ""),
+      writeText: vi.fn(async (text: string) => {
+        writes.push(text);
+      }),
+    },
+  });
+  return () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: previous,
+    });
+  };
+}
+
+async function settleClipboard(): Promise<void> {
+  await nextTick();
+  await Promise.resolve();
+}
+
+async function copyWrappedSelection(
+  start: { x: number; y: number },
+  end: { x: number; y: number },
+): Promise<string> {
+  const writes: string[] = [];
+  const restore = installNavigatorClipboard(writes);
+  const mounted = await mountTerminal(
+    () =>
+      h(TTranscriptView, {
+        x: 0,
+        y: 0,
+        w: 3,
+        h: 2,
+        source: createSource([
+          {
+            kind: "message",
+            key: "msg",
+            segments: [{ text: "abcdef" }],
+          },
+        ]),
+        version: 1,
+        wrap: true,
+        selectable: true,
+      }),
+    3,
+    2,
+    { selection: true },
+  );
+
+  try {
+    const container = mounted.container()!;
+    container.dispatchEvent(
+      new MouseEvent("mousedown", { clientX: start.x, clientY: start.y, bubbles: true }),
+    );
+    container.dispatchEvent(
+      new MouseEvent("mousemove", { clientX: end.x, clientY: end.y, bubbles: true }),
+    );
+    container.dispatchEvent(
+      new MouseEvent("mouseup", { clientX: end.x, clientY: end.y, bubbles: true }),
+    );
+    await settleClipboard();
+    return writes[0] ?? "";
+  } finally {
+    mounted.unmount();
+    restore();
+  }
+}
+
+describe("TTranscriptView", () => {
+  it("copies wrapped visual rows without repeating the full message", async () => {
+    await expect(copyWrappedSelection({ x: 0, y: 0 }, { x: 2, y: 0 })).resolves.toBe("abc");
+    await expect(copyWrappedSelection({ x: 0, y: 1 }, { x: 2, y: 1 })).resolves.toBe("def");
+    await expect(copyWrappedSelection({ x: 0, y: 0 }, { x: 2, y: 1 })).resolves.toBe("abc\ndef");
+  });
+
+  it("waits for parent-controlled scrollTop before repainting", async () => {
+    const raf = installManualRaf();
+    const updates: number[] = [];
+    const scrolls: number[] = [];
+    const rows = Array.from(
+      { length: 20 },
+      (_, index): TTranscriptRow => ({
+        kind: "message",
+        key: index,
+        segments: [{ text: `row-${index}` }],
+      }),
+    );
+    const App = defineComponent({
+      name: "TranscriptControlledScrollApp",
+      setup() {
+        return () =>
+          h(TTranscriptView, {
+            x: 0,
+            y: 0,
+            w: 10,
+            h: 2,
+            source: createSource(rows),
+            version: 1,
+            scrollTop: 0,
+            autoFocus: true,
+            onScroll: (payload: { scrollTop: number }) => {
+              scrolls.push(payload.scrollTop);
+            },
+            "onUpdate:scrollTop": (value: number) => {
+              updates.push(value);
+            },
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 10, rows: 4, component: App });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      expect(rowText(app, 0)).toBe("row-0");
+
+      app.events.dispatch({ type: "wheel", cellX: 0, cellY: 0, deltaY: 100, time: 1_000 });
+      expect(raf.pending()).toBe(1);
+      raf.runNext();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(updates).toEqual([1]);
+      expect(scrolls).toEqual([1]);
+      expect(rowText(app, 0)).toBe("row-0");
+    } finally {
+      app.dispose();
+      raf.restore();
+    }
+  });
+
+  it("does not focus or click disabled actions", async () => {
+    const actionClick = vi.fn();
+    const viewRef = ref<TTranscriptViewHandle | null>(null);
+    const row: TTranscriptRow = {
+      kind: "approval",
+      key: "approval",
+      title: "Allow?",
+      actions: [{ id: "approve", label: "Approve", disabled: true }],
+    };
+    const App = defineComponent({
+      name: "TranscriptDisabledActionApp",
+      setup() {
+        return () =>
+          h(TTranscriptView, {
+            ref: viewRef,
+            x: 0,
+            y: 0,
+            w: 24,
+            h: 2,
+            source: createSource([row]),
+            version: 1,
+            onActionClick: actionClick,
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 24, rows: 4, component: App });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      const firstRow = rowText(app, 0);
+      const actionX = firstRow.indexOf("[Approve]");
+      expect(actionX).toBeGreaterThanOrEqual(0);
+
+      app.events.dispatch({ type: "click", cellX: actionX, cellY: 0, time: 1_000 } as any);
+      expect(viewRef.value?.focusNextRegion()).toBe(false);
+      expect(viewRef.value?.activateFocusedRegion()).toBe(false);
+      expect(actionClick).not.toHaveBeenCalled();
+    } finally {
+      app.dispose();
+    }
+  });
+});

--- a/test/transcript-view.test.ts
+++ b/test/transcript-view.test.ts
@@ -6,7 +6,14 @@ import {
   type TTranscriptRow,
   type TTranscriptViewHandle,
 } from "../src/experimental.js";
-import { defineComponent, h, mountTerminal, nextTick, ref } from "./ui-regressions-support.js";
+import {
+  defineComponent,
+  h,
+  mountTerminal,
+  nextTick,
+  ref,
+  TView,
+} from "./ui-regressions-support.js";
 import { installManualRaf } from "./helpers/manual-raf.js";
 
 function createSource(rows: readonly TTranscriptRow[]): TTranscriptDataSource {
@@ -51,9 +58,15 @@ async function settleClipboard(): Promise<void> {
   await Promise.resolve();
 }
 
-async function copyWrappedSelection(
-  start: { x: number; y: number },
-  end: { x: number; y: number },
+async function copyTranscriptSelection(
+  options: Readonly<{
+    rows: readonly TTranscriptRow[];
+    w: number;
+    h: number;
+    wrap?: boolean;
+    start: { x: number; y: number };
+    end: { x: number; y: number };
+  }>,
 ): Promise<string> {
   const writes: string[] = [];
   const restore = installNavigatorClipboard(writes);
@@ -62,34 +75,36 @@ async function copyWrappedSelection(
       h(TTranscriptView, {
         x: 0,
         y: 0,
-        w: 3,
-        h: 2,
-        source: createSource([
-          {
-            kind: "message",
-            key: "msg",
-            segments: [{ text: "abcdef" }],
-          },
-        ]),
+        w: options.w,
+        h: options.h,
+        source: createSource(options.rows),
         version: 1,
-        wrap: true,
+        wrap: options.wrap,
         selectable: true,
       }),
-    3,
-    2,
+    options.w,
+    options.h,
     { selection: true },
   );
 
   try {
     const container = mounted.container()!;
     container.dispatchEvent(
-      new MouseEvent("mousedown", { clientX: start.x, clientY: start.y, bubbles: true }),
+      new MouseEvent("mousedown", {
+        clientX: options.start.x,
+        clientY: options.start.y,
+        bubbles: true,
+      }),
     );
     container.dispatchEvent(
-      new MouseEvent("mousemove", { clientX: end.x, clientY: end.y, bubbles: true }),
+      new MouseEvent("mousemove", {
+        clientX: options.end.x,
+        clientY: options.end.y,
+        bubbles: true,
+      }),
     );
     container.dispatchEvent(
-      new MouseEvent("mouseup", { clientX: end.x, clientY: end.y, bubbles: true }),
+      new MouseEvent("mouseup", { clientX: options.end.x, clientY: options.end.y, bubbles: true }),
     );
     await settleClipboard();
     return writes[0] ?? "";
@@ -101,9 +116,61 @@ async function copyWrappedSelection(
 
 describe("TTranscriptView", () => {
   it("copies wrapped visual rows without repeating the full message", async () => {
-    await expect(copyWrappedSelection({ x: 0, y: 0 }, { x: 2, y: 0 })).resolves.toBe("abc");
-    await expect(copyWrappedSelection({ x: 0, y: 1 }, { x: 2, y: 1 })).resolves.toBe("def");
-    await expect(copyWrappedSelection({ x: 0, y: 0 }, { x: 2, y: 1 })).resolves.toBe("abc\ndef");
+    const rows: TTranscriptRow[] = [
+      {
+        kind: "message",
+        key: "msg",
+        segments: [{ text: "abcdef" }],
+      },
+    ];
+    await expect(
+      copyTranscriptSelection({
+        rows,
+        w: 3,
+        h: 2,
+        wrap: true,
+        start: { x: 0, y: 0 },
+        end: { x: 2, y: 0 },
+      }),
+    ).resolves.toBe("abc");
+    await expect(
+      copyTranscriptSelection({
+        rows,
+        w: 3,
+        h: 2,
+        wrap: true,
+        start: { x: 0, y: 1 },
+        end: { x: 2, y: 1 },
+      }),
+    ).resolves.toBe("def");
+    await expect(
+      copyTranscriptSelection({
+        rows,
+        w: 3,
+        h: 2,
+        wrap: true,
+        start: { x: 0, y: 0 },
+        end: { x: 2, y: 1 },
+      }),
+    ).resolves.toBe("abc\ndef");
+  });
+
+  it("copies selectable text after non-selectable cells without coordinate drift", async () => {
+    await expect(
+      copyTranscriptSelection({
+        rows: [
+          {
+            kind: "message",
+            key: "msg",
+            segments: [{ text: "AA" }, { text: "XX", selectable: false }, { text: "BB" }],
+          },
+        ],
+        w: 6,
+        h: 1,
+        start: { x: 4, y: 0 },
+        end: { x: 5, y: 0 },
+      }),
+    ).resolves.toBe("BB");
   });
 
   it("waits for parent-controlled scrollTop before repainting", async () => {
@@ -202,6 +269,101 @@ describe("TTranscriptView", () => {
       expect(viewRef.value?.focusNextRegion()).toBe(false);
       expect(viewRef.value?.activateFocusedRegion()).toBe(false);
       expect(actionClick).not.toHaveBeenCalled();
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("focuses repeated action ids by row-scoped region id", async () => {
+    const actionClick = vi.fn();
+    const viewRef = ref<TTranscriptViewHandle | null>(null);
+    const rows: TTranscriptRow[] = [
+      {
+        kind: "approval",
+        key: "first",
+        title: "Allow first?",
+        actions: [{ id: "approve", label: "Approve" }],
+      },
+      {
+        kind: "approval",
+        key: "second",
+        title: "Allow second?",
+        actions: [{ id: "approve", label: "Approve" }],
+      },
+    ];
+    const App = defineComponent({
+      name: "TranscriptRepeatedActionIdsApp",
+      setup() {
+        return () =>
+          h(TTranscriptView, {
+            ref: viewRef,
+            x: 0,
+            y: 0,
+            w: 32,
+            h: 2,
+            source: createSource(rows),
+            version: 1,
+            onActionClick: actionClick,
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 32, rows: 4, component: App });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(viewRef.value?.focusNextRegion()).toBe(true);
+      expect(viewRef.value?.activateFocusedRegion()).toBe(true);
+      expect(viewRef.value?.focusNextRegion()).toBe(true);
+      expect(viewRef.value?.activateFocusedRegion()).toBe(true);
+      expect(viewRef.value?.focusNextRegion()).toBe(true);
+      expect(viewRef.value?.activateFocusedRegion()).toBe(true);
+
+      expect(actionClick.mock.calls.map(([event]) => event.rowIndex)).toEqual([0, 1, 0]);
+      expect(actionClick.mock.calls.map(([event]) => event.region.id)).toEqual([
+        "action:first:approve",
+        "action:second:approve",
+        "action:first:approve",
+      ]);
+      expect(actionClick.mock.calls[0]?.[0].region.payload).toMatchObject({ actionId: "approve" });
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("paints horizontally clipped transcript rows from the clipped cell offset", async () => {
+    const App = defineComponent({
+      name: "TranscriptHorizontalClipApp",
+      setup() {
+        return () =>
+          h(TView, { x: 0, y: 0, w: 4, h: 1 }, () =>
+            h(TTranscriptView, {
+              x: -3,
+              y: 0,
+              w: 10,
+              h: 1,
+              source: createSource([
+                {
+                  kind: "message",
+                  key: "msg",
+                  segments: [{ text: "ABCDEFGH" }],
+                },
+              ]),
+              version: 1,
+            }),
+          );
+      },
+    });
+    const app = createTerminalApp({ cols: 8, rows: 2, component: App });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(rowText(app, 0)).toBe("DEFG");
     } finally {
       app.dispose();
     }


### PR DESCRIPTION
## Summary
- add experimental `TTranscriptView` for rich transcript rows, hit regions, hover/focus state, controlled scrolling, and action/link events
- add internal `TVirtualRows` viewport that handles dirty-row repaint, selection provider plumbing, and unsafe full-row scroll support
- add transcript row layout/plain-text helpers and layout tests

## Validation
- `pnpm exec oxfmt --check src/vue/components/TVirtualRows.ts src/vue/components/TTranscriptView.ts src/vue/transcript/types.ts src/vue/transcript/layout.ts src/vue/transcript/plain-text.ts src/vue/transcript/hit-regions.ts src/experimental.ts test/transcript-layout.test.ts`
- `pnpm exec oxlint src/vue/components/TVirtualRows.ts src/vue/components/TTranscriptView.ts src/vue/transcript/types.ts src/vue/transcript/layout.ts src/vue/transcript/plain-text.ts src/vue/transcript/hit-regions.ts src/experimental.ts test/transcript-layout.test.ts`
- `pnpm exec tsc -p tsconfig.json --noEmit --pretty false`
- `pnpm exec vitest run test/transcript-layout.test.ts`
- `pnpm run build:raw`
- `VUE_TUI_REQUIRE_DIST_EXPORTS=1 pnpm exec vitest run test/package-exports.test.ts`