### PR TITLE
Stabilize advanced panel and overlay edge cases

### DIFF
--- a/src/vue/components/TCommandPalette.ts
+++ b/src/vue/components/TCommandPalette.ts
@@ -410,8 +410,13 @@ export const TCommandPalette = defineComponent({
     watch(
       () => [props.modelValue, props.initialQuery] as const,
       ([open, initial]) => {
-        if (open && props.query == null) innerQuery.value = initial;
-        if (!open && props.resetQueryOnClose && query.value !== "") setQuery("");
+        if (open) {
+          suppressNextDialogClose = false;
+          if (props.query == null) innerQuery.value = initial;
+          return;
+        }
+
+        if (props.resetQueryOnClose && query.value !== "") setQuery("");
       },
       { immediate: true },
     );

--- a/src/vue/components/TPanels.ts
+++ b/src/vue/components/TPanels.ts
@@ -1,6 +1,6 @@
 import type { PropType } from "vue";
 import type { Style } from "../../core/types.js";
-import { computed, defineComponent, h } from "vue";
+import { computed, defineComponent, h, ref } from "vue";
 import { useTerminal } from "../composables/use-terminal.js";
 import { textCellWidth } from "../utils/text.js";
 import { fitCellText, mergeStyle } from "./simple-utils.js";
@@ -10,6 +10,12 @@ import { TView } from "./TView.js";
 function normalizeCellCount(value: number): number {
   const n = Math.floor(Number(value));
   return Number.isFinite(n) ? Math.max(0, n) : 0;
+}
+
+function normalizePaneSize(value: unknown, fallback = 0): number {
+  const n = Math.floor(Number(value));
+  if (Number.isFinite(n)) return Math.max(0, n);
+  return normalizeCellCount(fallback);
 }
 
 export type TTabsItem = Readonly<{
@@ -71,6 +77,7 @@ export const TTabs = defineComponent({
   },
   setup(props, { emit }) {
     const { defaultStyle } = useTerminal();
+    const focusedKey = ref<string | null>(null);
     const baseStyle = computed(() => mergeStyle(defaultStyle.value, props.style));
 
     function activate(item: TTabsItem): void {
@@ -80,24 +87,36 @@ export const TTabs = defineComponent({
       emit("change", item);
     }
 
-    function activateIndex(index: number): void {
+    function enabledTabIndexByKey(key: string | null | undefined): number {
+      if (!key) return -1;
+      return props.items.findIndex((item) => item.key === key && !item.disabled);
+    }
+
+    function activateIndex(
+      index: number,
+      opts: Readonly<{ trackFocus?: boolean }> = {},
+    ): void {
       const item = props.items[index];
       if (!item) return;
+      if (opts.trackFocus && !item.disabled) focusedKey.value = item.key;
       activate(item);
     }
 
     function navigationBaseIndex(fallbackIndex: number): number {
-      const activeIndex = props.items.findIndex(
-        (item) => item.key === props.activeKey && !item.disabled,
-      );
+      const activeIndex = enabledTabIndexByKey(props.activeKey);
       return activeIndex >= 0 ? activeIndex : fallbackIndex;
+    }
+
+    function activationBaseIndex(fallbackIndex: number): number {
+      const focusedIndex = enabledTabIndexByKey(focusedKey.value);
+      return focusedIndex >= 0 ? focusedIndex : fallbackIndex;
     }
 
     function onTabKeydown(event: any, index: number): void {
       const key = event?.key;
       if (key === "Enter" || key === " ") {
         event.preventDefault?.();
-        activateIndex(index);
+        activateIndex(activationBaseIndex(index));
         return;
       }
 
@@ -114,7 +133,7 @@ export const TTabs = defineComponent({
                 : null;
       if (next == null) return;
       event.preventDefault?.();
-      activateIndex(next);
+      activateIndex(next, { trackFocus: true });
     }
 
     return () => {
@@ -156,7 +175,13 @@ export const TTabs = defineComponent({
             w: itemWidth,
             h: 1,
             focusable: !item.disabled,
-            onClick: () => activate(item),
+            onClick: () => {
+              if (!item.disabled) focusedKey.value = item.key;
+              activate(item);
+            },
+            onFocus: () => {
+              if (!item.disabled) focusedKey.value = item.key;
+            },
             onKeydown: (event: any) => onTabKeydown(event, index),
           }),
         );
@@ -182,7 +207,7 @@ function resolvePaneSizes(
   const count = sizes.length;
   if (count === 0) return [];
   if (available <= 0) return sizes.map(() => 0);
-  const mins = sizes.map((_, index) => Math.max(0, Math.floor(minSizes[index] ?? 1)));
+  const mins = sizes.map((_, index) => normalizePaneSize(minSizes[index], 1));
   const minTotal = mins.reduce((sum, min) => sum + min, 0);
 
   if (minTotal >= available) {
@@ -201,7 +226,9 @@ function resolvePaneSizes(
     return out;
   }
 
-  const out = sizes.map((size, index) => Math.max(mins[index]!, Math.floor(size)));
+  const out = sizes.map((size, index) =>
+    Math.max(mins[index]!, normalizePaneSize(size, mins[index]!)),
+  );
   const used = out.reduce((sum, size) => sum + size, 0);
 
   if (used > available) {
@@ -281,8 +308,8 @@ export const TSplitPane = defineComponent({
       if (index < 0 || index >= next.length - 1) return;
       const left0 = next[index]!;
       const right0 = next[index + 1]!;
-      const leftMin = Math.max(0, Math.floor(props.minSizes[index] ?? 1));
-      const rightMin = Math.max(0, Math.floor(props.minSizes[index + 1] ?? 1));
+      const leftMin = normalizePaneSize(props.minSizes[index], 1);
+      const rightMin = normalizePaneSize(props.minSizes[index + 1], 1);
       const applied = Math.max(leftMin - left0, Math.min(right0 - rightMin, delta));
       next[index] = left0 + applied;
       next[index + 1] = right0 - applied;

--- a/src/vue/components/TPanels.ts
+++ b/src/vue/components/TPanels.ts
@@ -92,10 +92,7 @@ export const TTabs = defineComponent({
       return props.items.findIndex((item) => item.key === key && !item.disabled);
     }
 
-    function activateIndex(
-      index: number,
-      opts: Readonly<{ trackFocus?: boolean }> = {},
-    ): void {
+    function activateIndex(index: number, opts: Readonly<{ trackFocus?: boolean }> = {}): void {
       const item = props.items[index];
       if (!item) return;
       if (opts.trackFocus && !item.disabled) focusedKey.value = item.key;

--- a/src/vue/overlay.ts
+++ b/src/vue/overlay.ts
@@ -30,17 +30,34 @@ function clamp(n: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, n));
 }
 
+function cellCount(value: unknown): number {
+  const n = Math.floor(Number(value));
+  return Number.isFinite(n) ? Math.max(0, n) : 0;
+}
+
+function cellOffset(value: unknown): number {
+  const n = Math.floor(Number(value));
+  return Number.isFinite(n) ? n : 0;
+}
+
 export function resolveOverlayPlacement(opts: TOverlayPlacementOptions): { x: number; y: number } {
-  const cols = Math.max(0, Math.floor(opts.viewport.w));
-  const rows = Math.max(0, Math.floor(opts.viewport.h));
-  const w = Math.max(0, Math.floor(opts.size.w));
-  const h = Math.max(0, Math.floor(opts.size.h));
+  const cols = cellCount(opts.viewport.w);
+  const rows = cellCount(opts.viewport.h);
+  const w = cellCount(opts.size.w);
+  const h = cellCount(opts.size.h);
   const placement = opts.placement ?? "center";
-  const dx = Math.floor(opts.offsetX ?? 0);
-  const dy = Math.floor(opts.offsetY ?? 0);
+  const dx = cellOffset(opts.offsetX ?? 0);
+  const dy = cellOffset(opts.offsetY ?? 0);
   const maxX = Math.max(0, cols - w);
   const maxY = Math.max(0, rows - h);
-  const anchor = opts.anchor;
+  const anchor = opts.anchor
+    ? {
+        x: cellOffset(opts.anchor.x),
+        y: cellOffset(opts.anchor.y),
+        w: cellCount(opts.anchor.w),
+        h: cellCount(opts.anchor.h),
+      }
+    : null;
 
   let x = Math.floor((cols - w) / 2);
   let y = Math.floor((rows - h) / 2);

--- a/test/p1-p2-components.test.ts
+++ b/test/p1-p2-components.test.ts
@@ -1908,6 +1908,87 @@ describe("P1/P2 public components", () => {
     }
   });
 
+  it("keeps TTabs Enter and Space aligned with arrow-navigation active tab", async () => {
+    const activeKey = ref("one");
+    const changes: string[] = [];
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TTabs, {
+          x: 0,
+          y: 0,
+          w: 32,
+          items: [
+            { key: "one", label: "One" },
+            { key: "two", label: "Two" },
+            { key: "three", label: "Three" },
+          ],
+          activeKey: activeKey.value,
+          "onUpdate:activeKey": (key: string) => {
+            activeKey.value = key;
+          },
+          onChange: (item: { key: string }) => {
+            changes.push(item.key);
+          },
+        }),
+      40,
+      4,
+    );
+
+    try {
+      await nextTick();
+      mounted.scheduler()?.flushNow();
+
+      const firstTab = mounted
+        .events()!
+        .debugNodes()
+        .find((node) => node.visible && node.focusable && node.rect.x === 0 && node.rect.y === 0);
+
+      expect(firstTab).toBeTruthy();
+      mounted.events()!.focus(firstTab!.id);
+
+      mounted.container()!.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "ArrowRight",
+          code: "ArrowRight",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+
+      await nextTick();
+
+      mounted.container()!.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "ArrowRight",
+          code: "ArrowRight",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+
+      await nextTick();
+
+      expect(activeKey.value).toBe("three");
+
+      mounted.container()!.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: " ",
+          code: "Space",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+
+      await nextTick();
+
+      expect(activeKey.value).toBe("three");
+      expect(changes).toEqual(["two", "three"]);
+    } finally {
+      mounted.unmount();
+    }
+  });
+
   it("uses cell widths for wide feedback labels and tab hit areas", async () => {
     const mounted = await mountTerminal(
       () => [
@@ -2928,6 +3009,48 @@ describe("P1/P2 public components", () => {
     }
   });
 
+  it("normalizes non-finite TSplitPane sizes", async () => {
+    let resolvedPanes: readonly { x: number; y: number; w: number; h: number }[] = [];
+
+    const mounted = await mountTerminal(
+      () =>
+        h(
+          TSplitPane as any,
+          {
+            x: 0,
+            y: 0,
+            w: 8,
+            h: 3,
+            sizes: [Number.NaN as any, 2],
+            minSizes: [1, 1],
+          },
+          {
+            default: ({
+              panes,
+            }: {
+              panes: readonly { x: number; y: number; w: number; h: number }[];
+            }) => {
+              resolvedPanes = panes;
+              return [];
+            },
+          },
+        ),
+      12,
+      5,
+    );
+
+    try {
+      await nextTick();
+
+      expect(resolvedPanes).toEqual([
+        { x: 0, y: 0, w: 1, h: 3 },
+        { x: 2, y: 0, w: 6, h: 3 },
+      ]);
+    } finally {
+      mounted.unmount();
+    }
+  });
+
   it("resizes split panes from minimal controlled sizes with keyboard input", async () => {
     const sizes = ref([1, 1]);
     const updates: number[][] = [];
@@ -3199,6 +3322,26 @@ describe("P1/P2 public components", () => {
         placement: "top-left",
       }),
     ).toEqual({ x: 20, y: 1 });
+  });
+
+  it("normalizes non-finite overlay placement inputs", () => {
+    expect(
+      resolveOverlayPlacement({
+        viewport: { w: Number.NaN as any, h: 5 },
+        size: { w: 2, h: Number.NaN as any },
+        offsetX: Number.NaN,
+        offsetY: Number.NaN,
+      }),
+    ).toEqual({ x: 0, y: 2 });
+
+    expect(
+      resolveOverlayPlacement({
+        viewport: { w: 10, h: 10 },
+        size: { w: 2, h: 2 },
+        placement: "bottom-right",
+        anchor: { x: Number.NaN, y: 1, w: Number.NaN, h: 1 } as any,
+      }),
+    ).toEqual({ x: 0, y: 2 });
   });
 
   it("keeps autocomplete suggestions open when closeOnSelect is false", async () => {
@@ -5185,6 +5328,74 @@ describe("P1/P2 public components", () => {
       expect(onClose).toHaveBeenCalledTimes(1);
 
       allowClose = true;
+      const dialogNode = mounted
+        .events()!
+        .debugNodes()
+        .find((node) => node.focusable && node.rect.w === 32 && node.rect.h === 10);
+
+      expect(dialogNode).toBeTruthy();
+      mounted.events()!.focus(dialogNode!.id);
+
+      mounted.container()!.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Escape",
+          code: "Escape",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      await nextTick();
+
+      expect(open.value).toBe(false);
+      expect(onClose).toHaveBeenCalledTimes(2);
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("clears command palette close suppression when reopened after accepted close", async () => {
+    const open = ref(true);
+    const onClose = vi.fn();
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TCommandPalette, {
+          modelValue: open.value,
+          "onUpdate:modelValue": (next: boolean) => {
+            open.value = next;
+          },
+          items: [{ label: "Open file" }],
+          closeOnSelect: true,
+          w: 32,
+          h: 10,
+          onClose,
+        }),
+      80,
+      24,
+    );
+
+    try {
+      await nextTick();
+      mounted.scheduler()?.flushNow();
+
+      mounted.container()!.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Enter",
+          code: "Enter",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      await nextTick();
+      mounted.scheduler()?.flushNow();
+
+      expect(open.value).toBe(false);
+      expect(onClose).toHaveBeenCalledTimes(1);
+
+      open.value = true;
+      await nextTick();
+      mounted.scheduler()?.flushNow();
+
       const dialogNode = mounted
         .events()!
         .debugNodes()


### PR DESCRIPTION
## Summary
- keep TTabs Enter/Space activation aligned with arrow-navigation state
- normalize non-finite overlay placement and split pane size inputs
- clear TCommandPalette close suppression when reopened after accepted close

## Verification
- pnpm exec vitest run test/p1-p2-components.test.ts
- pnpm run typecheck
- pnpm run docs:gen
- pnpm run docs:build
- pnpm run build:checked