### PR TITLE
Normalize picker numeric edge cases

### DIFF
--- a/src/vue/components/TCommandPalette.ts
+++ b/src/vue/components/TCommandPalette.ts
@@ -98,6 +98,22 @@ type TCommandPaletteVisualSegment = Readonly<{
 
 const DEFAULT_MATCH_STYLE: Style = { bold: true, dim: false, underline: true };
 
+function normalizeInteger(value: unknown, fallback = 0): number {
+  const n = Math.floor(Number(value));
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function normalizeNonNegativeInteger(value: unknown, fallback = 0): number {
+  return Math.max(0, normalizeInteger(value, fallback));
+}
+
+function normalizeVisibleLimit(value: unknown): number {
+  if (value == null) return Number.POSITIVE_INFINITY;
+  const n = Math.floor(Number(value));
+  if (!Number.isFinite(n)) return Number.POSITIVE_INFINITY;
+  return Math.max(1, n);
+}
+
 function isCommandPaletteRowSelectable(item: TCommandPaletteItem | undefined): boolean {
   return Boolean(item && item.kind !== "separator" && item.kind !== "group" && !item.disabled);
 }
@@ -360,18 +376,16 @@ export const TCommandPalette = defineComponent({
     }
 
     function listHeight(): number {
-      const dialogH = Math.max(8, Math.floor(props.h));
+      const dialogH = Math.max(8, normalizeInteger(props.h, 18));
       const innerH = Math.max(1, dialogH - 4);
-      const maxVisible =
-        props.maxVisibleItems == null
-          ? Number.POSITIVE_INFINITY
-          : Math.max(1, props.maxVisibleItems);
+      const maxVisible = normalizeVisibleLimit(props.maxVisibleItems);
       return Math.max(1, Math.min(innerH - 3, maxVisible));
     }
 
     function normalizedIndex(index: number): number {
       const len = filteredEntries.value.length;
-      return len > 0 ? ((index % len) + len) % len : 0;
+      const value = normalizeInteger(index, 0);
+      return len > 0 ? ((value % len) + len) % len : 0;
     }
 
     function enabledIndexFrom(index: number, direction: 1 | -1): number {
@@ -532,7 +546,8 @@ export const TCommandPalette = defineComponent({
           providerLoading.value = false;
           return;
         }
-        if (q.trim().length < Math.max(0, props.minQueryLength)) {
+        const minQueryLength = normalizeNonNegativeInteger(props.minQueryLength, 0);
+        if (q.trim().length < minQueryLength) {
           providerItems.value = [];
           providerLoading.value = false;
           return;
@@ -566,7 +581,7 @@ export const TCommandPalette = defineComponent({
             });
         };
 
-        const delay = Math.max(0, Math.floor(props.debounce));
+        const delay = normalizeNonNegativeInteger(props.debounce, 0);
         if (delay > 0) providerTimer = setTimeout(run, delay);
         else run();
       },
@@ -580,8 +595,8 @@ export const TCommandPalette = defineComponent({
 
     return () => {
       if (!props.modelValue) return null;
-      const dialogW = Math.max(30, Math.floor(props.w));
-      const dialogH = Math.max(8, Math.floor(props.h));
+      const dialogW = Math.max(30, normalizeInteger(props.w, 72));
+      const dialogH = Math.max(8, normalizeInteger(props.h, 18));
       const innerW = Math.max(1, dialogW - 4);
       const innerH = Math.max(1, dialogH - 4);
       const listY = 2;

--- a/src/vue/components/TSelect.ts
+++ b/src/vue/components/TSelect.ts
@@ -25,8 +25,27 @@ import { DialogContextKey, EventZIndexContextKey } from "../context.js";
 import { intersectRect, translateRect } from "../utils/rect.js";
 import { sanitizeInlineText, sliceByCells, spaces, textCellWidth } from "../utils/text.js";
 
+function normalizeInteger(value: unknown, fallback = 0): number {
+  const n = Math.floor(Number(value));
+  return Number.isFinite(n) ? n : fallback;
+}
+
 function clamp(n: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, n));
+  const lo = normalizeInteger(min, 0);
+  const hi = Math.max(lo, normalizeInteger(max, lo));
+  const value = normalizeInteger(n, lo);
+  return Math.max(lo, Math.min(hi, value));
+}
+
+function normalizeVisibleLimit(value: unknown): number {
+  if (value == null) return Number.POSITIVE_INFINITY;
+  const n = Math.floor(Number(value));
+  if (!Number.isFinite(n)) return Number.POSITIVE_INFINITY;
+  return Math.max(1, n);
+}
+
+function normalizeModelIndex(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? Math.trunc(value) : -1;
 }
 
 type TextHighlightRange = Readonly<{ start: number; end: number }>;
@@ -320,10 +339,7 @@ export const TSelect = defineComponent({
     function visibleRowCount(r: Rect): number {
       return Math.max(
         0,
-        Math.min(
-          Math.floor(r.h),
-          props.maxVisible == null ? Number.POSITIVE_INFINITY : Math.max(1, props.maxVisible),
-        ),
+        Math.min(normalizeInteger(r.h, 0), normalizeVisibleLimit(props.maxVisible)),
       );
     }
 
@@ -376,7 +392,7 @@ export const TSelect = defineComponent({
     }
 
     function modelIndex(value: unknown): number {
-      if (props.valueMode === "index") return typeof value === "number" ? value : -1;
+      if (props.valueMode === "index") return normalizeModelIndex(value);
       return options.value.findIndex((opt, optIndex) =>
         valuesEqual(getOptionValue(opt, optIndex), value),
       );

--- a/src/vue/components/TSelect.ts
+++ b/src/vue/components/TSelect.ts
@@ -30,6 +30,10 @@ function normalizeInteger(value: unknown, fallback = 0): number {
   return Number.isFinite(n) ? n : fallback;
 }
 
+function normalizeNonNegativeInteger(value: unknown, fallback = 0): number {
+  return Math.max(0, normalizeInteger(value, fallback));
+}
+
 function clamp(n: number, min: number, max: number): number {
   const lo = normalizeInteger(min, 0);
   const hi = Math.max(lo, normalizeInteger(max, lo));
@@ -1049,7 +1053,7 @@ export const TSelect = defineComponent({
               if (!controller.signal.aborted) providerLoading.value = false;
             });
         };
-        const delay = Math.max(0, Math.floor(props.debounce));
+        const delay = normalizeNonNegativeInteger(props.debounce, 0);
         if (delay > 0) providerTimer = setTimeout(run, delay);
         else run();
       },

--- a/test/p1-p2-components.test.ts
+++ b/test/p1-p2-components.test.ts
@@ -325,6 +325,54 @@ describe("P1/P2 public components", () => {
     }
   });
 
+  it("drops non-finite TSelect index model values instead of spreading NaN into selection", async () => {
+    const onConfirm = vi.fn();
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TSelect, {
+          x: 0,
+          y: 0,
+          w: 12,
+          h: 2,
+          multiple: true,
+          multipleEmit: "index",
+          modelValue: [Number.NaN],
+          options: ["Alpha", "Beta"],
+          onConfirm,
+        }),
+      20,
+      5,
+    );
+
+    try {
+      await nextTick();
+      mounted.scheduler()?.flushNow();
+
+      const selectNode = mounted
+        .events()!
+        .debugNodes()
+        .find((node) => node.visible && node.focusable && node.rect.x === 0 && node.rect.y === 0);
+
+      expect(selectNode).toBeTruthy();
+      mounted.events()!.focus(selectNode!.id);
+
+      mounted.container()!.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Enter",
+          code: "Enter",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+
+      await nextTick();
+      expect(onConfirm).toHaveBeenCalledWith([]);
+    } finally {
+      mounted.unmount();
+    }
+  });
+
   it("matches NaN TSelect option values when valueMode is value", async () => {
     const selected = ref<unknown>(Number.NaN);
 
@@ -479,6 +527,35 @@ describe("P1/P2 public components", () => {
       expect(mounted.terminal.snapshot().lines[0]).toContain("Alpha");
       expect(mounted.terminal.snapshot().lines[1].trim()).toBe("");
       expect(mounted.terminal.snapshot().lines[2].trim()).toBe("");
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("normalizes non-finite TSelect active and viewport numeric props", async () => {
+    const mounted = await mountTerminal(
+      () =>
+        h(TSelect, {
+          x: 0,
+          y: 0,
+          w: 12,
+          h: 2,
+          activeIndex: Number.NaN,
+          maxVisible: Number.NaN,
+          options: ["Alpha", "Beta"],
+        }),
+      20,
+      5,
+    );
+
+    try {
+      await nextTick();
+      mounted.scheduler()?.flushNow();
+
+      const lines = mounted.terminal.snapshot().lines;
+      expect(lines[0]).toContain("Alpha");
+      expect(lines[1]).toContain("Beta");
+      expect(mounted.terminal.getCell(0, 0).style.inverse).toBe(true);
     } finally {
       mounted.unmount();
     }
@@ -5045,6 +5122,54 @@ describe("P1/P2 public components", () => {
           index: 0,
           sourceIndex: 2,
           source: "keyboard",
+        }),
+      );
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("normalizes non-finite TCommandPalette numeric props before rendering and selecting", async () => {
+    const onSelect = vi.fn();
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TCommandPalette, {
+          modelValue: true,
+          items: [{ label: "Open file" }],
+          selectedIndex: Number.NaN,
+          maxVisibleItems: Number.NaN,
+          minQueryLength: Number.NaN,
+          debounce: Number.NaN,
+          w: Number.NaN,
+          h: Number.NaN,
+          onSelect,
+        }),
+      80,
+      24,
+    );
+
+    try {
+      await nextTick();
+      mounted.scheduler()?.flushNow();
+
+      expect(mounted.terminal.snapshot().lines.join("\n")).toContain("Open file");
+
+      mounted.container()!.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Enter",
+          code: "Enter",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+
+      await nextTick();
+      expect(onSelect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          item: { label: "Open file" },
+          index: 0,
+          sourceIndex: 0,
         }),
       );
     } finally {

--- a/test/p1-p2-components.test.ts
+++ b/test/p1-p2-components.test.ts
@@ -561,6 +561,36 @@ describe("P1/P2 public components", () => {
     }
   });
 
+  it("normalizes non-finite TSelect async debounce", async () => {
+    const provider = vi.fn<
+      (query: string, ctx: { signal: AbortSignal }) => Promise<readonly string[]>
+    >(async () => ["Alpha"]);
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TSelect, {
+          x: 0,
+          y: 0,
+          w: 12,
+          h: 2,
+          debounce: Number.POSITIVE_INFINITY,
+          optionProvider: provider,
+        }),
+      20,
+      5,
+    );
+
+    try {
+      await nextTick();
+
+      expect(provider).toHaveBeenCalledTimes(1);
+      const [, ctx] = provider.mock.calls[0]!;
+      expect(ctx.signal).toBeInstanceOf(AbortSignal);
+    } finally {
+      mounted.unmount();
+    }
+  });
+
   it("renders table, data table, and tree primitives", async () => {
     const rows = [
       { id: "2", name: "build", status: "fail" },


### PR DESCRIPTION
## Summary
- Normalize non-finite numeric props in TSelect active/index/maxVisible paths.
- Normalize TCommandPalette maxVisibleItems, selectedIndex, minQueryLength, debounce, w, and h paths.
- Add P1/P2 regression coverage for picker numeric edge cases.

## Validation
- pnpm exec vitest run test/p1-p2-components.test.ts
- pnpm run typecheck
- pnpm run format:check
- pnpm run docs:gen
- pnpm run docs:build
- pnpm run build:checked
