### PR TITLE
perf: optimize shared render paths

### DIFF
--- a/src/vue/components/TCommandPalette.ts
+++ b/src/vue/components/TCommandPalette.ts
@@ -109,6 +109,12 @@ type TCommandPaletteVisualSegment = Readonly<{
   style: Style | undefined;
 }>;
 
+type TCommandPaletteFilteredEntry = Readonly<{
+  item: TCommandPaletteItem;
+  sourceIndex: number;
+  match: TCommandPaletteMatcherResult;
+}>;
+
 const DEFAULT_MATCH_STYLE: Style = { bold: true, dim: false, underline: true };
 
 function normalizeInteger(value: unknown, fallback = 0): number {
@@ -131,25 +137,47 @@ function isCommandPaletteRowSelectable(item: TCommandPaletteItem | undefined): b
   return Boolean(item && item.kind !== "separator" && item.kind !== "group" && !item.disabled);
 }
 
-function substringMatcher(
-  item: TCommandPaletteItem,
+function defaultSubstringEntries(
+  sourceItems: readonly TCommandPaletteItem[],
   query: string,
-): TCommandPaletteMatcherResult | null {
-  const q = query.trim().toLowerCase();
-  if (!q) return { score: 0 };
-  const labelRanges = computeCommandPaletteMatchRanges(item.label, q);
-  const detailRanges = item.detail ? computeCommandPaletteMatchRanges(item.detail, q) : [];
-  const keywordMatch = (item.keywords ?? []).some((keyword) =>
-    String(keyword ?? "")
-      .toLowerCase()
-      .includes(q),
-  );
-  if (!labelRanges.length && !detailRanges.length && !keywordMatch) return null;
-  return {
-    score: labelRanges.length ? 100 : detailRanges.length ? 50 : 10,
-    labelRanges,
-    detailRanges,
-  };
+): TCommandPaletteFilteredEntry[] {
+  const q = query.trim();
+  if (!q) {
+    return sourceItems.map((item, sourceIndex) => ({
+      item,
+      sourceIndex,
+      match: { score: 0 },
+    }));
+  }
+
+  const needle = q.toLowerCase();
+  const labelMatches: TCommandPaletteFilteredEntry[] = [];
+  const detailMatches: TCommandPaletteFilteredEntry[] = [];
+  const keywordMatches: TCommandPaletteFilteredEntry[] = [];
+  for (let sourceIndex = 0; sourceIndex < sourceItems.length; sourceIndex++) {
+    const item = sourceItems[sourceIndex]!;
+    if (item.kind === "separator" || item.kind === "group") continue;
+    const label = String(item.label ?? "");
+    const detail = item.detail == null ? "" : String(item.detail);
+    if (label.toLowerCase().includes(needle)) {
+      labelMatches.push({ item, sourceIndex, match: { score: 100 } });
+      continue;
+    }
+    if (detail.toLowerCase().includes(needle)) {
+      detailMatches.push({ item, sourceIndex, match: { score: 50 } });
+      continue;
+    }
+    if (
+      (item.keywords ?? []).some((keyword) =>
+        String(keyword ?? "")
+          .toLowerCase()
+          .includes(needle),
+      )
+    ) {
+      keywordMatches.push({ item, sourceIndex, match: { score: 10 } });
+    }
+  }
+  return labelMatches.concat(detailMatches, keywordMatches);
 }
 
 function fuzzyMatcher(
@@ -373,17 +401,21 @@ export const TCommandPalette = defineComponent({
     const filteredEntries = computed(() => {
       const q = query.value.trim();
       const sourceItems = props.itemsProvider ? (providerItems.value ?? []) : props.items;
-      const matcher =
-        props.matcher ?? (props.filterStrategy === "fuzzy" ? fuzzyMatcher : substringMatcher);
-      const entries = sourceItems.flatMap((item, sourceIndex) => {
+      if (!props.matcher && props.filterStrategy === "substring") {
+        return defaultSubstringEntries(sourceItems, q);
+      }
+
+      const matcher = props.matcher ?? fuzzyMatcher;
+      const entries: TCommandPaletteFilteredEntry[] = [];
+      for (let sourceIndex = 0; sourceIndex < sourceItems.length; sourceIndex++) {
+        const item = sourceItems[sourceIndex]!;
         if (item.kind === "separator" || item.kind === "group") {
-          return q
-            ? []
-            : [{ item, sourceIndex, match: { score: 0 } as TCommandPaletteMatcherResult }];
+          if (!q) entries.push({ item, sourceIndex, match: { score: 0 } });
+          continue;
         }
         const match = matcher(item, q);
-        return match ? [{ item, sourceIndex, match }] : [];
-      });
+        if (match) entries.push({ item, sourceIndex, match });
+      }
       entries.sort((a, b) => b.match.score - a.match.score || a.sourceIndex - b.sourceIndex);
       return entries;
     });

--- a/src/vue/components/TDataTable.ts
+++ b/src/vue/components/TDataTable.ts
@@ -143,37 +143,47 @@ export const TDataTable = defineComponent({
   setup(props, { emit }) {
     const innerScrollTop = ref(0);
 
-    const indexedRows = computed<readonly DataRow[]>(() =>
-      props.rows.map((row, originalIndex) => ({ row, originalIndex })),
+    const hasLocalFilter = computed(
+      () => !props.manualFilter && props.filterable && Boolean(props.filter.trim()),
     );
-    const filteredRows = computed(() => {
-      if (props.manualFilter) return indexedRows.value;
-      if (!props.filterable || !props.filter.trim()) return indexedRows.value;
+    const hasLocalSort = computed(
+      () => !props.manualSort && props.sortable && Boolean(props.sortBy),
+    );
+    const indexedRows = computed<readonly DataRow[] | null>(() => {
+      if (!hasLocalFilter.value && !hasLocalSort.value) return null;
+      return props.rows.map((row, originalIndex) => ({ row, originalIndex }));
+    });
+    const filteredRows = computed<readonly DataRow[] | null>(() => {
+      const rows = indexedRows.value;
+      if (!rows) return null;
+      if (!hasLocalFilter.value) return rows;
       const query = props.filter.trim().toLowerCase();
       if (props.filterPredicate) {
-        return indexedRows.value.filter(({ row, originalIndex }) =>
+        return rows.filter(({ row, originalIndex }) =>
           props.filterPredicate!(row, query, props.columns, originalIndex),
         );
       }
-      return indexedRows.value.filter(({ row, originalIndex }) =>
+      return rows.filter(({ row, originalIndex }) =>
         props.columns.some((column) =>
           displayValue(column, row, originalIndex).toLowerCase().includes(query),
         ),
       );
     });
 
-    const sortedRows = computed(() => {
-      const rows = [...filteredRows.value];
-      if (props.manualSort || !props.sortable || !props.sortBy) return rows;
+    const sortedRows = computed<readonly DataRow[] | null>(() => {
+      const rows = filteredRows.value;
+      if (!rows) return null;
+      if (!hasLocalSort.value) return rows;
+      const sorted = [...rows];
       const column = props.columns.find((candidate) => candidate.key === props.sortBy);
-      rows.sort((a, b) => {
+      sorted.sort((a, b) => {
         const result =
           props.sorter && column
             ? props.sorter(a.row, b.row, column)
             : compareValues(a.row[props.sortBy], b.row[props.sortBy]);
         return props.sortDirection === "desc" ? -result : result;
       });
-      return rows;
+      return sorted;
     });
     function nonNegativeInteger(value: unknown): number {
       const n = Math.floor(Number(value));
@@ -182,8 +192,12 @@ export const TDataTable = defineComponent({
 
     const visibleRowCapacity = computed(() => Math.max(0, nonNegativeInteger(props.h) - 2));
 
+    function processedRowCount(): number {
+      return sortedRows.value?.length ?? props.rows.length;
+    }
+
     function maxScrollTop(): number {
-      return Math.max(0, sortedRows.value.length - visibleRowCapacity.value);
+      return Math.max(0, processedRowCount() - visibleRowCapacity.value);
     }
 
     function clampScrollTop(value: unknown): number {
@@ -209,12 +223,27 @@ export const TDataTable = defineComponent({
       },
       { immediate: true },
     );
-    const visibleRows = computed(() =>
-      sortedRows.value.slice(
-        normalizedScrollTop.value,
-        normalizedScrollTop.value + visibleRowCapacity.value,
-      ),
-    );
+    function dataEntryAt(absoluteIndex: number): DataRow | undefined {
+      const rows = sortedRows.value;
+      if (rows) return rows[absoluteIndex];
+      const row = props.rows[absoluteIndex];
+      return row ? { row, originalIndex: absoluteIndex } : undefined;
+    }
+
+    function originalIndexForAbsoluteIndex(absoluteIndex: number): number {
+      return dataEntryAt(absoluteIndex)?.originalIndex ?? absoluteIndex;
+    }
+
+    const visibleRows = computed<readonly DataRow[]>(() => {
+      const top = normalizedScrollTop.value;
+      const bottom = top + visibleRowCapacity.value;
+      const rows = sortedRows.value;
+      if (rows) return rows.slice(top, bottom);
+      return props.rows.slice(top, bottom).map((row, index) => ({
+        row,
+        originalIndex: top + index,
+      }));
+    });
     const tableRows = computed(() => visibleRows.value.map(({ row }) => row));
     const activeAbsoluteIndex = ref<number | null>(null);
     const activeRowIdentity = ref<unknown>(NO_ACTIVE_ROW);
@@ -225,7 +254,7 @@ export const TDataTable = defineComponent({
         const format = column.format
           ? (value: unknown, row: TTableRow, visibleIndex: number) => {
               const absoluteIndex = normalizedScrollTop.value + visibleIndex;
-              const originalIndex = sortedRows.value[absoluteIndex]?.originalIndex ?? absoluteIndex;
+              const originalIndex = originalIndexForAbsoluteIndex(absoluteIndex);
               return column.format!(value, row, originalIndex);
             }
           : undefined;
@@ -239,7 +268,7 @@ export const TDataTable = defineComponent({
 
     function originalIndexAt(index: number): number {
       const absoluteIndex = normalizedScrollTop.value + index;
-      return sortedRows.value[absoluteIndex]?.originalIndex ?? absoluteIndex;
+      return originalIndexForAbsoluteIndex(absoluteIndex);
     }
 
     function dataTableRowKey(row: TTableRow, index: number): unknown {
@@ -264,15 +293,29 @@ export const TDataTable = defineComponent({
     const activeRowKey = computed(() =>
       activeRowIdentity.value === NO_ACTIVE_ROW ? undefined : activeRowIdentity.value,
     );
+    const activeRawRowKey = computed(() => {
+      if (activeAbsoluteIndex.value == null || sortedRows.value) return NO_ACTIVE_ROW;
+      const index = activeAbsoluteIndex.value;
+      const row = props.rows[index];
+      return row ? rowKey(row, index, props.rowKey as any) : NO_ACTIVE_ROW;
+    });
+
+    function findDataIndexByKey(key: unknown): number {
+      const rows = sortedRows.value;
+      if (rows) {
+        return rows.findIndex((entry) => Object.is(dataRowKey(entry), key));
+      }
+      return props.rows.findIndex((row, index) =>
+        Object.is(rowKey(row, index, props.rowKey as any), key),
+      );
+    }
 
     watch(
-      () => [props.rowKey, ...sortedRows.value.map((entry) => dataRowKey(entry))] as const,
+      () => [props.rowKey, props.rows, sortedRows.value, activeRowIdentity.value] as const,
       () => {
         if (activeRowIdentity.value === NO_ACTIVE_ROW) return;
 
-        const nextIndex = sortedRows.value.findIndex((entry) =>
-          Object.is(dataRowKey(entry), activeRowIdentity.value),
-        );
+        const nextIndex = findDataIndexByKey(activeRowIdentity.value);
 
         if (nextIndex < 0) {
           clearActiveRow();
@@ -282,12 +325,23 @@ export const TDataTable = defineComponent({
         activeAbsoluteIndex.value = nextIndex;
       },
     );
+    watch(
+      () => [props.rowKey, activeRawRowKey.value] as const,
+      ([, key]) => {
+        if (activeRowIdentity.value === NO_ACTIVE_ROW) return;
+        if (key === NO_ACTIVE_ROW) {
+          clearActiveRow();
+          return;
+        }
+        if (!Object.is(activeRowIdentity.value, key)) activeRowIdentity.value = key;
+      },
+    );
 
     function setActiveAbsoluteIndex(
       absoluteIndex: number,
     ): { dataIndex: number; scrollTop: number } | null {
-      const clamped = Math.max(0, Math.min(sortedRows.value.length - 1, absoluteIndex));
-      const entry = sortedRows.value[clamped];
+      const clamped = Math.max(0, Math.min(processedRowCount() - 1, absoluteIndex));
+      const entry = dataEntryAt(clamped);
       if (!entry) {
         clearActiveRow();
         return null;
@@ -364,7 +418,7 @@ export const TDataTable = defineComponent({
       if (event.key === "Enter" || event.key === " ") {
         const active = setActiveAbsoluteIndex(current);
         if (!active) return;
-        const entry = sortedRows.value[active.dataIndex];
+        const entry = dataEntryAt(active.dataIndex);
         if (!entry) return;
         const visibleIndex = active.dataIndex - active.scrollTop;
         commitSelection(

--- a/src/vue/components/TLogView.ts
+++ b/src/vue/components/TLogView.ts
@@ -709,6 +709,19 @@ function wrapStyledSegmentsByCells(
   };
 
   for (const seg of segments) {
+    const cells = textCellWidth(seg.text);
+    if (cells === seg.text.length) {
+      for (let i = 0; i < seg.text.length; ) {
+        if (rowCells >= width) openRow();
+        const take = Math.min(width - rowCells, seg.text.length - i);
+        if (take <= 0) break;
+        row.push({ text: seg.text.slice(i, i + take), cells: take, style: seg.style });
+        rowCells += take;
+        i += take;
+      }
+      continue;
+    }
+
     forEachTextCellSegment(seg.text, (piece) => {
       if (!piece.text || piece.cells <= 0) return;
       pushWrappedPiece(piece.text, piece.cells, seg.style);
@@ -716,6 +729,123 @@ function wrapStyledSegmentsByCells(
   }
 
   return rows;
+}
+
+function countWrappedTextRows(text: string, width: number): number {
+  width = Math.max(1, Math.floor(width));
+  if (!text) return 1;
+
+  const cells = textCellWidth(text);
+  if (cells <= 0) return 1;
+  if (cells === text.length) return Math.max(1, Math.ceil(cells / width));
+
+  let rows = 1;
+  let rowCells = 0;
+
+  forEachTextCellSegment(text, (piece) => {
+    if (!piece.text || piece.cells <= 0) return;
+    const pieceCells = piece.cells;
+    if (rowCells > 0 && rowCells + pieceCells > width) {
+      rows++;
+      rowCells = 0;
+    }
+    if (pieceCells > width) {
+      let remaining = pieceCells;
+      while (remaining > 0) {
+        if (rowCells >= width) {
+          rows++;
+          rowCells = 0;
+        }
+        const take = Math.min(width - rowCells, remaining);
+        rowCells += take;
+        remaining -= take;
+      }
+      return;
+    }
+
+    if (rowCells >= width) {
+      rows++;
+      rowCells = 0;
+    }
+    rowCells += pieceCells;
+  });
+
+  return rows;
+}
+
+function countWrappedPlainTextRows(text: string, width: number): number {
+  width = Math.max(1, Math.floor(width));
+  if (!text) return 1;
+
+  let rows = 0;
+  let rowCells = 0;
+  let sawText = false;
+
+  forEachTextCellSegment(text, (piece) => {
+    if (!piece.text || piece.cells <= 0) return;
+    sawText = true;
+
+    const cells = piece.cells;
+    if (rowCells > 0 && rowCells + cells > width) {
+      rows++;
+      rowCells = 0;
+    }
+
+    rowCells += cells;
+    if (rowCells >= width) {
+      rows++;
+      rowCells = 0;
+    }
+  });
+
+  return Math.max(1, rows + (rowCells > 0 || !sawText ? 1 : 0));
+}
+
+function countAsciiAnsiTextCells(text: string): number | null {
+  let cells = 0;
+
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    if (code > 0x7f) return null;
+
+    if (code === 0x1b) {
+      const next = text[i + 1];
+      if (next === "[") {
+        let j = i + 2;
+        while (j < text.length) {
+          const c = text.charCodeAt(j);
+          if (c >= 0x40 && c <= 0x7e) break;
+          j++;
+        }
+        if (j >= text.length) return null;
+        i = j;
+        continue;
+      }
+
+      if (next === "]") {
+        let j = i + 2;
+        while (j < text.length) {
+          const c = text.charCodeAt(j);
+          if (c === 0x07) break;
+          if (c === 0x1b && text[j + 1] === "\\") {
+            j++;
+            break;
+          }
+          j++;
+        }
+        if (j >= text.length) return null;
+        i = j;
+        continue;
+      }
+
+      return null;
+    }
+
+    if (code <= 0x1f || code === 0x7f) return null;
+    cells++;
+  }
+
+  return cells;
 }
 
 export const TLogView = defineComponent({
@@ -866,6 +996,7 @@ export const TLogView = defineComponent({
     const renderLineCache = new Map<TLogRenderCacheKey, TLogRenderCacheEntry>();
     const wrapLineCache = new Map<TLogRenderCacheKey, TLogWrapCacheEntry>();
     const ansiLineCache = new Map<TLogRenderCacheKey, TLogAnsiLineCacheEntry>();
+    const ansiTextCache = new Map<TLogRenderCacheKey, TLogRenderCacheEntry>();
     const ansiWrapCache = new Map<TLogRenderCacheKey, TLogAnsiWrapCacheEntry>();
     const ansiRowCache = new Map<TLogRenderCacheKey, TLogAnsiRowCacheEntry>();
     const linkifyLineCache = new Map<TLogRenderCacheKey, TLogAnsiLineCacheEntry>();
@@ -1020,6 +1151,10 @@ export const TLogView = defineComponent({
       return JSON.stringify(["ansi-line", key, baseStyleKey, linksEnabled() ? 1 : 0, linkKey]);
     }
 
+    function ansiTextCacheKey(key: TLogLineKey): TLogRenderCacheKey {
+      return JSON.stringify(["ansi-text", key]);
+    }
+
     function linkifyLineCacheKey(
       key: TLogLineKey,
       baseStyleKey: string,
@@ -1115,6 +1250,16 @@ export const TLogView = defineComponent({
       }
     }
 
+    function trimAnsiTextCache(): void {
+      const max = DEFAULT_LOG_RENDER_CACHE_SIZE;
+      if (ansiTextCache.size <= max) return;
+
+      const entries = Array.from(ansiTextCache.values()).sort((a, b) => a.touchedAt - b.touchedAt);
+      for (const entry of entries.slice(0, ansiTextCache.size - max)) {
+        ansiTextCache.delete(entry.key);
+      }
+    }
+
     function trimAnsiWrapCache(): void {
       const max = DEFAULT_LOG_WRAP_CACHE_SIZE;
       if (ansiWrapCache.size <= max) return;
@@ -1175,6 +1320,7 @@ export const TLogView = defineComponent({
       renderLineCache.clear();
       wrapLineCache.clear();
       ansiLineCache.clear();
+      ansiTextCache.clear();
       ansiWrapCache.clear();
       ansiRowCache.clear();
       linkifyLineCache.clear();
@@ -1285,6 +1431,26 @@ export const TLogView = defineComponent({
         touchedAt: ++cacheClock,
       });
       return segments;
+    }
+
+    function ansiPlainTextForLine(index: number, count: number): string {
+      if (index < 0 || index >= count) return "";
+
+      const rawKey = lineKey(index);
+      const key = ansiTextCacheKey(rawKey);
+      const cached = ansiTextCache.get(key);
+      if (cached) {
+        cached.touchedAt = ++cacheClock;
+        return cached.value;
+      }
+
+      const text = sanitizeAnsiInlineText(props.source.getLine(index));
+      ansiTextCache.set(key, {
+        key,
+        value: text,
+        touchedAt: ++cacheClock,
+      });
+      return text;
     }
 
     function ansiWrappedRowsForLine(
@@ -1766,17 +1932,8 @@ export const TLogView = defineComponent({
       invalidateSearchMarkers();
     }
 
-    function searchableTextForLine(
-      index: number,
-      count: number,
-      baseStyle: Style,
-      baseStyleKey: string,
-    ): string {
-      if (props.ansi) {
-        return ansiSegmentsForLine(index, count, baseStyle, baseStyleKey)
-          .map((seg) => seg.text)
-          .join("");
-      }
+    function searchableTextForLine(index: number, count: number): string {
+      if (props.ansi) return ansiPlainTextForLine(index, count);
       return sanitizeInlineText(props.source.getLine(index));
     }
 
@@ -1795,14 +1952,12 @@ export const TLogView = defineComponent({
     function previewForMatch(
       match: TLogViewSearchMatch,
       count: number,
-      baseStyle: Style,
-      baseStyleKey: string,
       options: Readonly<{
         previewWidth: number;
         contextCells: number;
       }>,
     ): TLogViewSearchResultPreview {
-      const text = searchableTextForLine(match.index, count, baseStyle, baseStyleKey);
+      const text = searchableTextForLine(match.index, count);
       const totalCells = textCellWidth(text);
       const matchCells = Math.max(1, match.endCell - match.startCell);
       const previewWidth = Math.max(options.previewWidth, matchCells);
@@ -1846,8 +2001,6 @@ export const TLogView = defineComponent({
       index: number,
       count: number,
       search: CompiledSearch,
-      baseStyle: Style,
-      baseStyleKey: string,
     ): readonly TLogSearchLineMatch[] {
       const rawKey = lineKey(index);
       const key = searchLineCacheKey(rawKey, search.key);
@@ -1857,9 +2010,7 @@ export const TLogView = defineComponent({
         return cached.matches;
       }
 
-      const matches = search.findLineMatches(
-        searchableTextForLine(index, count, baseStyle, baseStyleKey),
-      );
+      const matches = search.findLineMatches(searchableTextForLine(index, count));
       searchLineCache.set(key, {
         key,
         matches,
@@ -1872,13 +2023,11 @@ export const TLogView = defineComponent({
       index: number,
       count: number,
       search: CompiledSearch,
-      baseStyle: Style,
-      baseStyleKey: string,
       maxMatches: number,
       absoluteBase: number,
     ): void {
       if (searchMatches.length >= maxMatches) return;
-      const lineMatches = cachedLineSearchMatches(index, count, search, baseStyle, baseStyleKey);
+      const lineMatches = cachedLineSearchMatches(index, count, search);
       for (const match of lineMatches) {
         if (searchMatches.length >= maxMatches) return;
         addSearchMatch({
@@ -1909,8 +2058,6 @@ export const TLogView = defineComponent({
       const count = lineCount();
       const maxMatches = maxSearchMatches();
       const absoluteBase = firstLineIndex();
-      const base = props.style ?? defaultStyle.value;
-      const baseStyleKey = styleCacheKey(base);
       let scanned = 0;
 
       while (
@@ -1918,15 +2065,7 @@ export const TLogView = defineComponent({
         searchMatches.length < maxMatches &&
         (scanned === 0 || ctx.now() - started < budget)
       ) {
-        scanSearchLine(
-          searchCursor,
-          count,
-          compiledSearch,
-          base,
-          baseStyleKey,
-          maxMatches,
-          absoluteBase,
-        );
+        scanSearchLine(searchCursor, count, compiledSearch, maxMatches, absoluteBase);
         searchCursor++;
         scanned++;
       }
@@ -1949,6 +2088,7 @@ export const TLogView = defineComponent({
       emitSearchMarkers(true);
       markViewportDirty();
       ctx.invalidate({ priority: "low", plane: plane.value, reason: "data" });
+      trimAnsiTextCache();
       trimSearchLineCache();
     }
 
@@ -2244,24 +2384,49 @@ export const TLogView = defineComponent({
       if (count > visualIndexLineCount) appendEstimatedVisualLines(visualIndexLineCount, count);
     }
 
-    function measureVisualLine(index: number): number {
+    function measureVisualLine(
+      index: number,
+      options?: Readonly<{
+        countOnly?: boolean;
+      }>,
+    ): number {
       ensureVisualIndex();
       if (index < 0 || index >= visualIndexLineCount) return 0;
 
       const key = lineKey(index);
       if (visualKeys[index] === key) return 0;
 
-      const base = props.style ?? defaultStyle.value;
-      const rows = props.ansi
-        ? ansiWrappedRowsForLine(
-            index,
-            visualIndexLineCount,
+      let nextCount: number;
+      if (options?.countOnly === true) {
+        if (props.ansi) {
+          const raw = props.source.getLine(index);
+          const asciiCells = countAsciiAnsiTextCells(raw);
+          nextCount =
+            asciiCells == null
+              ? countWrappedTextRows(
+                  ansiPlainTextForLine(index, visualIndexLineCount),
+                  visualIndexWidth,
+                )
+              : Math.max(1, Math.ceil(asciiCells / visualIndexWidth));
+        } else {
+          nextCount = countWrappedPlainTextRows(
+            sanitizeInlineText(props.source.getLine(index)),
             visualIndexWidth,
-            base,
-            styleCacheKey(base),
-          )
-        : wrappedRowsForLine(index, visualIndexLineCount, visualIndexWidth);
-      const nextCount = Math.max(1, rows.length);
+          );
+        }
+      } else {
+        const base = props.style ?? defaultStyle.value;
+        const rows = props.ansi
+          ? ansiWrappedRowsForLine(
+              index,
+              visualIndexLineCount,
+              visualIndexWidth,
+              base,
+              styleCacheKey(base),
+            )
+          : wrappedRowsForLine(index, visualIndexLineCount, visualIndexWidth);
+        nextCount = Math.max(1, rows.length);
+      }
       const prevCount = visualCounts[index] ?? 1;
       if (nextCount !== prevCount) {
         visualCounts[index] = nextCount;
@@ -2310,6 +2475,7 @@ export const TLogView = defineComponent({
       if (visualMeasureCursor >= target) {
         syncVisualIndexStatus();
         emitVisualIndex();
+        trimAnsiTextCache();
         return;
       }
 
@@ -2323,7 +2489,7 @@ export const TLogView = defineComponent({
         const effectiveTop = currentScrollTop() + topAdjustment;
         const start = visualStartForLine(index);
         const prevCount = visualCounts[index] ?? 1;
-        const delta = measureVisualLine(index);
+        const delta = measureVisualLine(index, { countOnly: true });
         if (delta !== 0 && effectiveTop >= start + prevCount) topAdjustment += delta;
         visualMeasureCursor++;
         measuredLineCount = visualMeasureCursor;
@@ -2361,6 +2527,7 @@ export const TLogView = defineComponent({
 
       syncVisualIndexStatus();
       emitVisualIndex();
+      trimAnsiTextCache();
     }
 
     function requestVisualIndexMeasurement(restartFrom = measuredLineCount): void {
@@ -2376,6 +2543,7 @@ export const TLogView = defineComponent({
       if (measuredLineCount >= target) {
         syncVisualIndexStatus();
         emitVisualIndex();
+        trimAnsiTextCache();
         return;
       }
 
@@ -3058,20 +3226,18 @@ export const TLogView = defineComponent({
         return true;
       }
 
-      const scrollPlan = !props.wrap
-        ? prepareUnsafeFullRowScroll({
-            render,
-            plane: plane.value,
-            rect: r,
-            terminalSize: terminal.size(),
-            delta,
-            rowScrollMode: props.rowScrollMode,
-            rendererCapabilities: rendererCapabilities.value,
-            isClipped: isClipped(),
-            hasPendingDirtyRows: Boolean(dirtyRowsHint?.length),
-            strategy,
-          })
-        : null;
+      const scrollPlan = prepareUnsafeFullRowScroll({
+        render,
+        plane: plane.value,
+        rect: r,
+        terminalSize: terminal.size(),
+        delta,
+        rowScrollMode: props.rowScrollMode,
+        rendererCapabilities: rendererCapabilities.value,
+        isClipped: isClipped(),
+        hasPendingDirtyRows: Boolean(dirtyRowsHint?.length),
+        strategy,
+      });
 
       if (scrollPlan) {
         const rows = options?.extraDirtyRows?.length
@@ -3696,15 +3862,13 @@ export const TLogView = defineComponent({
       }
 
       const count = lineCount();
-      const base = props.style ?? defaultStyle.value;
-      const baseStyleKey = styleCacheKey(base);
       const previewWidth = normalizeSearchResultPreviewWidth(options?.previewWidth);
       const contextCells = normalizeSearchResultContextCells(options?.contextCells);
 
       return searchMatches.slice(offset, offset + limit).map((match, index) => ({
         matchIndex: offset + index,
         match: copySearchMatch(match),
-        preview: previewForMatch(match, count, base, baseStyleKey, {
+        preview: previewForMatch(match, count, {
           previewWidth,
           contextCells,
         }),

--- a/src/vue/components/TSelect.ts
+++ b/src/vue/components/TSelect.ts
@@ -314,6 +314,49 @@ export const TSelect = defineComponent({
     const typeaheadQuery = ref("");
     const query = computed(() => props.query ?? innerQuery.value);
     const options = computed(() => providerOptions.value ?? props.options);
+
+    function getOptionLabel(opt: SelectOption): string {
+      return isOptionObject(opt) ? opt.label : opt;
+    }
+
+    function getOptionKind(opt: SelectOption): SelectOptionWithStyle["kind"] | undefined {
+      return isOptionObject(opt) ? opt.kind : undefined;
+    }
+
+    function getOptionValue(opt: SelectOption, index: number): unknown {
+      if (props.valueMode === "index") return index;
+      if (props.valueMode === "option") return opt;
+      return isOptionObject(opt) && "value" in opt ? opt.value : getOptionLabel(opt);
+    }
+
+    const optionValueIndex = computed(() => {
+      if (props.valueMode === "index") return null;
+      const indexed = new Map<unknown, number>();
+      const opts = options.value;
+      for (let index = 0; index < opts.length; index++) {
+        const value = getOptionValue(opts[index]!, index);
+        if (typeof value === "number" && value === 0) continue;
+        if (!indexed.has(value)) indexed.set(value, index);
+      }
+      return indexed;
+    });
+
+    function valuesEqual(a: unknown, b: unknown): boolean {
+      return Object.is(a, b);
+    }
+
+    function modelIndex(value: unknown, useValueIndex = props.multiple): number {
+      if (props.valueMode === "index") return normalizeModelIndex(value);
+      if (useValueIndex) {
+        const indexed = optionValueIndex.value;
+        const cached = indexed?.get(value);
+        if (cached != null) return cached;
+      }
+      return options.value.findIndex((opt, optIndex) =>
+        valuesEqual(getOptionValue(opt, optIndex), value),
+      );
+    }
+
     const initialActive = (() => {
       const max = Math.max(0, options.value.length - 1);
       if (!props.multiple) {
@@ -376,31 +419,6 @@ export const TSelect = defineComponent({
       }
       innerActive.value = clamp(active.value, 0, max);
     });
-
-    function getOptionLabel(opt: SelectOption): string {
-      return isOptionObject(opt) ? opt.label : opt;
-    }
-
-    function getOptionKind(opt: SelectOption): SelectOptionWithStyle["kind"] | undefined {
-      return isOptionObject(opt) ? opt.kind : undefined;
-    }
-
-    function getOptionValue(opt: SelectOption, index: number): unknown {
-      if (props.valueMode === "index") return index;
-      if (props.valueMode === "option") return opt;
-      return isOptionObject(opt) && "value" in opt ? opt.value : getOptionLabel(opt);
-    }
-
-    function valuesEqual(a: unknown, b: unknown): boolean {
-      return Object.is(a, b);
-    }
-
-    function modelIndex(value: unknown): number {
-      if (props.valueMode === "index") return normalizeModelIndex(value);
-      return options.value.findIndex((opt, optIndex) =>
-        valuesEqual(getOptionValue(opt, optIndex), value),
-      );
-    }
 
     function isOptionInteractive(opt: SelectOption | undefined): opt is SelectOption {
       if (!opt) return false;

--- a/src/vue/components/TTable.ts
+++ b/src/vue/components/TTable.ts
@@ -199,6 +199,18 @@ function sameRowKey(a: unknown, b: unknown): boolean {
   return Object.is(a, b);
 }
 
+function selectedRowKeyIndex(keys: readonly unknown[] | undefined): Set<unknown> | null {
+  if (!keys?.length) return null;
+  const indexed = new Set<unknown>();
+  for (let index = 0; index < keys.length; index++) {
+    if (!(index in keys)) continue;
+    const key = keys[index];
+    if (typeof key === "number" && key === 0) return null;
+    indexed.add(key);
+  }
+  return indexed;
+}
+
 export const TTable = defineComponent({
   name: "TTable",
   props: {
@@ -270,10 +282,20 @@ export const TTable = defineComponent({
     const activeRowStyle = computed(() =>
       mergeStyle(theme.value.components.TTable?.activeStyle, props.activeStyle),
     );
+    const selectedRowKeysIndex = computed(() => selectedRowKeyIndex(props.selectedRowKeys));
     const bodyRows = computed(() => {
       const top = props.header ? 2 : 0;
       return props.rows.slice(0, Math.max(0, props.h - top));
     });
+
+    function isRowSelected(key: unknown): boolean {
+      if (props.selectedRowKey !== undefined && sameRowKey(key, props.selectedRowKey)) return true;
+      const selectedKeys = props.selectedRowKeys;
+      if (!selectedKeys?.length) return false;
+      const indexed = selectedRowKeysIndex.value;
+      if (indexed) return indexed.has(key);
+      return selectedKeys.some((candidate) => sameRowKey(candidate, key));
+    }
 
     return () => {
       const children: any[] = [];
@@ -353,9 +375,7 @@ export const TTable = defineComponent({
         const row = bodyRows.value[index]!;
         const y = (props.header ? 2 : 0) + index;
         const key = rowKey(row, index, props.rowKey as any);
-        const selected =
-          (props.selectedRowKey !== undefined && sameRowKey(key, props.selectedRowKey)) ||
-          Boolean(props.selectedRowKeys?.some((candidate) => sameRowKey(candidate, key)));
+        const selected = isRowSelected(key);
         const active = props.activeRowKey !== undefined && sameRowKey(key, props.activeRowKey);
         children.push(
           h(

--- a/src/vue/components/TTranscriptView.ts
+++ b/src/vue/components/TTranscriptView.ts
@@ -40,6 +40,17 @@ type LayoutState = Readonly<{
   rowStarts: ReadonlyMap<number, number>;
   rowEnds: ReadonlyMap<number, number>;
   regions: readonly TTranscriptHitRegion[];
+  fixedRows: boolean;
+  rowCount: number;
+}>;
+
+type WrappedLayoutDeps = Readonly<{
+  width: number;
+  baseStyle: Style;
+  hoverStyle?: Style;
+  focusStyle?: Style;
+  hoverRegionId: string | null;
+  focusedRegionId: string | null;
 }>;
 
 type RowLayoutCacheEntry = Readonly<{
@@ -64,7 +75,10 @@ const EMPTY_LAYOUT: LayoutState = Object.freeze({
   rowStarts: new Map(),
   rowEnds: new Map(),
   regions: Object.freeze([]),
+  fixedRows: false,
+  rowCount: 0,
 });
+const MAX_KEYED_ROW_LAYOUT_CACHE_ENTRIES = 2048;
 
 function clamp(n: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, n));
@@ -73,6 +87,16 @@ function clamp(n: number, min: number, max: number): number {
 function normalizeInt(value: unknown): number {
   const n = Math.floor(Number(value));
   return Number.isFinite(n) ? n : 0;
+}
+
+function normalizedChangedRange(
+  range: { start: number; end: number } | null | undefined,
+  count: number,
+): { start: number; end: number } | null {
+  if (!range) return null;
+  const start = clamp(normalizeInt(range.start), 0, count);
+  const end = clamp(normalizeInt(range.end), start, count);
+  return { start, end };
 }
 
 function sourceSegmentsForRegion(row: TTranscriptRow): readonly TTranscriptSegment[] {
@@ -113,9 +137,36 @@ function rowHasRegionId(row: TTranscriptRow, rowKey: string | number, id: string
   return false;
 }
 
+function cachedLayoutHasRegionId(
+  entry: RowLayoutCacheEntry | undefined,
+  id: string | null,
+): boolean {
+  if (!entry || !id) return false;
+  for (const visualRow of entry.visualRows) {
+    if (visualRow.hitRegions.some((region) => region.id === id)) return true;
+  }
+  return false;
+}
+
+function rowLayoutIdentityKey(rowKey: string | number, rowVersion: string | number): string {
+  return JSON.stringify([rowKey, rowVersion]);
+}
+
+function reindexVisualRows(
+  rows: readonly TTranscriptVisualRow[],
+  rowIndex: number,
+): readonly TTranscriptVisualRow[] {
+  return rows.map((visualRow) => ({
+    ...visualRow,
+    rowIndex,
+    hitRegions: visualRow.hitRegions.map((region) => ({ ...region, rowIndex })),
+  }));
+}
+
 function sameCachedLayout(
   entry: RowLayoutCacheEntry | undefined,
   next: Omit<RowLayoutCacheEntry, "visualRows">,
+  matchRowIndex = true,
 ): boolean {
   return (
     Boolean(entry) &&
@@ -123,7 +174,7 @@ function sameCachedLayout(
     entry!.rowVersion === next.rowVersion &&
     entry!.usesSourceRowVersion === next.usesSourceRowVersion &&
     (next.usesSourceRowVersion || entry!.row === next.row) &&
-    entry!.rowIndex === next.rowIndex &&
+    (!matchRowIndex || entry!.rowIndex === next.rowIndex) &&
     entry!.rowKey === next.rowKey &&
     entry!.width === next.width &&
     entry!.wrap === next.wrap &&
@@ -183,6 +234,10 @@ export const TTranscriptView = defineComponent({
     const hoveredRegion = ref<TTranscriptHitRegion | null>(null);
     const focusedRegion = ref<TTranscriptHitRegion | null>(null);
     const rowLayoutCache = new Map<number, RowLayoutCacheEntry>();
+    const keyedRowLayoutCache = new Map<string, RowLayoutCacheEntry>();
+    let previousWrappedLayout: LayoutState | null = null;
+    let previousWrappedDeps: WrappedLayoutDeps | null = null;
+    let canUseWrappedChangedRangeRepaint = false;
     let warnedLargeFlattenedRows = false;
 
     function isScrollControlled(): boolean {
@@ -193,14 +248,237 @@ export const TTranscriptView = defineComponent({
       return normalizeInt(isScrollControlled() ? props.scrollTop : innerScrollTop.value);
     }
 
+    function currentScrollTopForRowCount(count: number): number {
+      const viewportRows = Math.max(0, normalizeInt(props.h));
+      const maxTop = Math.max(0, count - viewportRows);
+      return clamp(currentScrollTop(), 0, maxTop);
+    }
+
+    function rememberKeyedRowLayout(entry: RowLayoutCacheEntry): void {
+      if (!entry.usesSourceRowVersion) return;
+      keyedRowLayoutCache.set(rowLayoutIdentityKey(entry.rowKey, entry.rowVersion), entry);
+      if (keyedRowLayoutCache.size <= MAX_KEYED_ROW_LAYOUT_CACHE_ENTRIES) return;
+      const first = keyedRowLayoutCache.keys().next().value;
+      if (first != null) keyedRowLayoutCache.delete(first);
+    }
+
+    function layoutSourceRow(
+      rowIndex: number,
+      options: Readonly<{
+        width: number;
+        baseStyle: Style;
+        hoverRegionId: string | null;
+        focusedRegionId: string | null;
+      }>,
+    ): { rows: readonly TTranscriptVisualRow[]; cacheHit: boolean } {
+      const sourceRowVersion = props.source.getRowVersion?.(rowIndex);
+      let cached = rowLayoutCache.get(rowIndex);
+      const usesSourceRowVersion = sourceRowVersion != null;
+      let row = cached?.row;
+      let rowKey = cached?.rowKey;
+      let canUseCachedRow = false;
+
+      if (
+        usesSourceRowVersion &&
+        cached?.usesSourceRowVersion &&
+        cached.rowVersion === sourceRowVersion
+      ) {
+        if (props.source.getRowKey) {
+          rowKey = props.source.getRowKey(rowIndex);
+          canUseCachedRow = rowKey === cached.rowKey;
+        } else {
+          rowKey = cached.rowKey;
+          canUseCachedRow = true;
+        }
+      }
+
+      if (!canUseCachedRow && usesSourceRowVersion && props.source.getRowKey) {
+        rowKey = props.source.getRowKey(rowIndex);
+        cached = keyedRowLayoutCache.get(rowLayoutIdentityKey(rowKey, sourceRowVersion));
+        if (cached) {
+          row = cached.row;
+          canUseCachedRow = true;
+        }
+      }
+
+      if (!canUseCachedRow || row == null || rowKey == null) {
+        row = props.source.getRow(rowIndex);
+        rowKey = props.source.getRowKey?.(rowIndex) ?? row.key;
+        canUseCachedRow = false;
+      }
+
+      const nextHoverRegionId = canUseCachedRow
+        ? cachedLayoutHasRegionId(cached, options.hoverRegionId)
+          ? options.hoverRegionId
+          : null
+        : rowHasRegionId(row, rowKey, options.hoverRegionId)
+          ? options.hoverRegionId
+          : null;
+      const nextFocusedRegionId = canUseCachedRow
+        ? cachedLayoutHasRegionId(cached, options.focusedRegionId)
+          ? options.focusedRegionId
+          : null
+        : rowHasRegionId(row, rowKey, options.focusedRegionId)
+          ? options.focusedRegionId
+          : null;
+      const cacheKey = {
+        version: props.version,
+        rowVersion: sourceRowVersion ?? props.version,
+        usesSourceRowVersion,
+        row,
+        rowIndex,
+        rowKey,
+        width: options.width,
+        wrap: props.wrap,
+        baseStyle: options.baseStyle,
+        hoverStyle: props.hoverStyle,
+        focusStyle: props.focusStyle,
+        hoverRegionId: nextHoverRegionId,
+        focusedRegionId: nextFocusedRegionId,
+      };
+      const cacheMatches = sameCachedLayout(cached, cacheKey);
+      const reindexableCacheMatches =
+        !cacheMatches && canUseCachedRow && sameCachedLayout(cached, cacheKey, false);
+      const rows = cacheMatches
+        ? cached!.visualRows
+        : reindexableCacheMatches
+          ? reindexVisualRows(cached!.visualRows, rowIndex)
+          : layoutTranscriptRow({
+              row,
+              rowIndex,
+              rowKey,
+              width: options.width,
+              baseStyle: options.baseStyle,
+              hoverRegionId: nextHoverRegionId,
+              focusedRegionId: nextFocusedRegionId,
+              hoverStyle: props.hoverStyle,
+              focusStyle: props.focusStyle,
+              wrap: props.wrap,
+            });
+      if (rows !== cached?.visualRows) {
+        const entry = { ...cacheKey, visualRows: rows };
+        rowLayoutCache.set(rowIndex, entry);
+        rememberKeyedRowLayout(entry);
+      }
+      return { rows, cacheHit: cacheMatches || reindexableCacheMatches };
+    }
+
+    function pruneRowLayoutCache(count: number): void {
+      for (const rowIndex of rowLayoutCache.keys()) {
+        if (rowIndex >= count) rowLayoutCache.delete(rowIndex);
+      }
+    }
+
+    function sameWrappedDeps(a: WrappedLayoutDeps | null, b: WrappedLayoutDeps): boolean {
+      return (
+        Boolean(a) &&
+        a!.width === b.width &&
+        a!.baseStyle === b.baseStyle &&
+        a!.hoverStyle === b.hoverStyle &&
+        a!.focusStyle === b.focusStyle &&
+        a!.hoverRegionId === b.hoverRegionId &&
+        a!.focusedRegionId === b.focusedRegionId
+      );
+    }
+
+    function visibleRegionsForVisualRows(
+      visualRows: readonly TTranscriptVisualRow[],
+    ): readonly TTranscriptHitRegion[] {
+      const top = clamp(currentScrollTop(), 0, visualRows.length);
+      const bottom = Math.min(visualRows.length, top + Math.max(0, normalizeInt(props.h)));
+      const regions: TTranscriptHitRegion[] = [];
+      for (let index = top; index < bottom; index++) {
+        regions.push(...(visualRows[index]?.hitRegions ?? []));
+      }
+      return regions;
+    }
+
+    function tryUpdateWrappedLayoutFromChangedRange(
+      count: number,
+      changedRange: { start: number; end: number } | null,
+      deps: WrappedLayoutDeps,
+    ): { state: LayoutState; cacheHit: number; cacheMiss: number } | null {
+      const previous = previousWrappedLayout;
+      if (!previous || previous.fixedRows || previous.rowCount !== count) return null;
+      if (!changedRange || !sameWrappedDeps(previousWrappedDeps, deps)) return null;
+
+      const changedCount = changedRange.end - changedRange.start;
+      if (changedCount <= 0) {
+        canUseWrappedChangedRangeRepaint = true;
+        return {
+          state: { ...previous, regions: visibleRegionsForVisualRows(previous.visualRows) },
+          cacheHit: count,
+          cacheMiss: 0,
+        };
+      }
+
+      const oldVisualStart = previous.rowStarts.get(changedRange.start);
+      const oldVisualEnd = previous.rowEnds.get(changedRange.end - 1);
+      if (oldVisualStart == null || oldVisualEnd == null) return null;
+
+      const nextRows: TTranscriptVisualRow[] = [];
+      const changedRowHeights: number[] = [];
+      let cacheHit = count - changedCount;
+      let cacheMiss = 0;
+      for (let rowIndex = changedRange.start; rowIndex < changedRange.end; rowIndex++) {
+        const result = layoutSourceRow(rowIndex, {
+          width: deps.width,
+          baseStyle: deps.baseStyle,
+          hoverRegionId: deps.hoverRegionId,
+          focusedRegionId: deps.focusedRegionId,
+        });
+        if (result.cacheHit) cacheHit++;
+        else cacheMiss++;
+        changedRowHeights.push(result.rows.length);
+        nextRows.push(...result.rows);
+      }
+
+      if (nextRows.length !== oldVisualEnd - oldVisualStart) return null;
+      canUseWrappedChangedRangeRepaint = true;
+
+      // Patch the previous wrapped layout in place; cloning the full layout would undo this path's cost saving.
+      const visualRows = previous.visualRows as TTranscriptVisualRow[];
+      for (let index = 0; index < nextRows.length; index++) {
+        visualRows[oldVisualStart + index] = nextRows[index]!;
+      }
+
+      const rowStarts = previous.rowStarts as Map<number, number>;
+      const rowEnds = previous.rowEnds as Map<number, number>;
+      let visualCursor = oldVisualStart;
+      for (
+        let rowIndex = changedRange.start, offset = 0;
+        rowIndex < changedRange.end;
+        rowIndex++, offset++
+      ) {
+        rowStarts.set(rowIndex, visualCursor);
+        visualCursor += changedRowHeights[offset] ?? 0;
+        rowEnds.set(rowIndex, visualCursor);
+      }
+
+      const state = {
+        visualRows,
+        rowStarts,
+        rowEnds,
+        regions: visibleRegionsForVisualRows(visualRows),
+        fixedRows: false,
+        rowCount: count,
+      };
+      previousWrappedLayout = state;
+      return { state, cacheHit, cacheMiss };
+    }
+
     const layoutState = computed<LayoutState>(() => {
       void props.version;
+      canUseWrappedChangedRangeRepaint = false;
       const perfEnabled = observability.framePerf.enabled.value;
       const perfStartedAt = perfEnabled ? framePerfNow() : 0;
       const width = Math.max(1, Math.floor(props.w));
       const count = Math.max(0, normalizeInt(props.source.rowCount()));
       if (!count) {
         rowLayoutCache.clear();
+        keyedRowLayoutCache.clear();
+        previousWrappedLayout = null;
+        previousWrappedDeps = null;
         if (perfEnabled) {
           observability.framePerf.recordComponent({
             name: "TTranscriptView",
@@ -218,7 +496,9 @@ export const TTranscriptView = defineComponent({
         return EMPTY_LAYOUT;
       }
 
+      const fixedRows = props.wrap === false;
       const visualRows: TTranscriptVisualRow[] = [];
+      if (fixedRows) visualRows.length = count;
       const rowStarts = new Map<number, number>();
       const rowEnds = new Map<number, number>();
       const regions: TTranscriptHitRegion[] = [];
@@ -227,63 +507,81 @@ export const TTranscriptView = defineComponent({
       const focusedRegionId = focusedRegion.value?.id ?? null;
       let cacheHit = 0;
       let cacheMiss = 0;
-      for (let rowIndex = 0; rowIndex < count; rowIndex++) {
-        const row = props.source.getRow(rowIndex);
-        const rowKey = props.source.getRowKey?.(rowIndex) ?? row.key;
-        const sourceRowVersion = props.source.getRowVersion?.(rowIndex);
-        const localHoverRegionId = rowHasRegionId(row, rowKey, hoverRegionId)
-          ? hoverRegionId
-          : null;
-        const localFocusedRegionId = rowHasRegionId(row, rowKey, focusedRegionId)
-          ? focusedRegionId
-          : null;
-        const cacheKey = {
-          version: props.version,
-          rowVersion: sourceRowVersion ?? props.version,
-          usesSourceRowVersion: sourceRowVersion != null,
-          row,
-          rowIndex,
-          rowKey,
-          width,
-          wrap: props.wrap,
-          baseStyle,
-          hoverStyle: props.hoverStyle,
-          focusStyle: props.focusStyle,
-          hoverRegionId: localHoverRegionId,
-          focusedRegionId: localFocusedRegionId,
-        };
-        rowStarts.set(rowIndex, visualRows.length);
-        const cached = rowLayoutCache.get(rowIndex);
-        const cacheMatches = sameCachedLayout(cached, cacheKey);
-        if (cacheMatches) cacheHit++;
-        else cacheMiss++;
-        const rows = cacheMatches
-          ? cached!.visualRows
-          : layoutTranscriptRow({
-              row,
-              rowIndex,
-              rowKey,
-              width,
-              baseStyle,
-              hoverRegionId: localHoverRegionId,
-              focusedRegionId: localFocusedRegionId,
-              hoverStyle: props.hoverStyle,
-              focusStyle: props.focusStyle,
-              wrap: props.wrap,
-            });
-        if (rows !== cached?.visualRows)
-          rowLayoutCache.set(rowIndex, { ...cacheKey, visualRows: rows });
-        for (const visualRow of rows) {
-          visualRows.push(visualRow);
-          regions.push(...visualRow.hitRegions);
+      const sourceChangedRange = normalizedChangedRange(props.source.getChangedRange?.(), count);
+      const wrappedDeps = {
+        width,
+        baseStyle,
+        hoverStyle: props.hoverStyle,
+        focusStyle: props.focusStyle,
+        hoverRegionId,
+        focusedRegionId,
+      };
+
+      if (fixedRows) {
+        previousWrappedLayout = null;
+        previousWrappedDeps = null;
+        const top = currentScrollTopForRowCount(count);
+        const bottom = Math.min(count, top + Math.max(0, normalizeInt(props.h)));
+        for (let rowIndex = top; rowIndex < bottom; rowIndex++) {
+          rowStarts.set(rowIndex, rowIndex);
+          rowEnds.set(rowIndex, rowIndex + 1);
+          const result = layoutSourceRow(rowIndex, {
+            width,
+            baseStyle,
+            hoverRegionId,
+            focusedRegionId,
+          });
+          if (result.cacheHit) cacheHit++;
+          else cacheMiss++;
+          const row = result.rows[0]!;
+          visualRows[rowIndex] = row;
+          regions.push(...row.hitRegions);
         }
-        rowEnds.set(rowIndex, visualRows.length);
+      } else {
+        const incremental = tryUpdateWrappedLayoutFromChangedRange(
+          count,
+          sourceChangedRange,
+          wrappedDeps,
+        );
+        if (incremental) {
+          if (perfEnabled) {
+            observability.framePerf.recordComponent({
+              name: "TTranscriptView",
+              id: instance?.uid == null ? undefined : String(instance.uid),
+              phase: "layout",
+              durationMs: framePerfNow() - perfStartedAt,
+              itemCount: count,
+              renderedCount: incremental.state.visualRows.length,
+              cacheHit: incremental.cacheHit,
+              cacheMiss: incremental.cacheMiss,
+              width,
+              version: props.version,
+            });
+          }
+          return incremental.state;
+        }
+
+        for (let rowIndex = 0; rowIndex < count; rowIndex++) {
+          rowStarts.set(rowIndex, visualRows.length);
+          const result = layoutSourceRow(rowIndex, {
+            width,
+            baseStyle,
+            hoverRegionId,
+            focusedRegionId,
+          });
+          if (result.cacheHit) cacheHit++;
+          else cacheMiss++;
+          for (const visualRow of result.rows) {
+            visualRows.push(visualRow);
+            regions.push(...visualRow.hitRegions);
+          }
+          rowEnds.set(rowIndex, visualRows.length);
+        }
       }
-      for (const rowIndex of rowLayoutCache.keys()) {
-        if (rowIndex >= count) rowLayoutCache.delete(rowIndex);
-      }
+      pruneRowLayoutCache(count);
       if (
         !warnedLargeFlattenedRows &&
+        !fixedRows &&
         (globalThis as any).__VT_DEBUG_PERF__ &&
         visualRows.length > 5000
       ) {
@@ -299,14 +597,22 @@ export const TTranscriptView = defineComponent({
           phase: "layout",
           durationMs: framePerfNow() - perfStartedAt,
           itemCount: count,
-          renderedCount: visualRows.length,
+          renderedCount: fixedRows ? cacheHit + cacheMiss : visualRows.length,
           cacheHit,
           cacheMiss,
           width,
           version: props.version,
         });
       }
-      return { visualRows, rowStarts, rowEnds, regions };
+      const state = { visualRows, rowStarts, rowEnds, regions, fixedRows, rowCount: count };
+      if (fixedRows) {
+        previousWrappedLayout = null;
+        previousWrappedDeps = null;
+      } else {
+        previousWrappedLayout = state;
+        previousWrappedDeps = wrappedDeps;
+      }
+      return state;
     });
 
     const maxScrollTop = computed(() =>
@@ -359,8 +665,13 @@ export const TTranscriptView = defineComponent({
       if (!region) return [];
       const rows = layoutState.value.visualRows;
       const indexes: number[] = [];
-      for (let i = 0; i < rows.length; i++) {
-        if (rows[i]!.hitRegions.some((candidate) => candidate.id === region.id)) indexes.push(i);
+      const top = layoutState.value.fixedRows ? clamp(currentScrollTop(), 0, rows.length) : 0;
+      const bottom = layoutState.value.fixedRows
+        ? Math.min(rows.length, top + Math.max(0, normalizeInt(props.h)))
+        : rows.length;
+      for (let i = top; i < bottom; i++) {
+        const row = getVisualRow(i);
+        if (row?.hitRegions.some((candidate) => candidate.id === region.id)) indexes.push(i);
       }
       return indexes;
     }
@@ -393,7 +704,7 @@ export const TTranscriptView = defineComponent({
       const seen = new Set<string>();
       const regions: TTranscriptHitRegion[] = [];
       for (let i = top; i < bottom; i++) {
-        for (const region of rows[i]?.hitRegions ?? []) {
+        for (const region of getVisualRow(i)?.hitRegions ?? []) {
           if (seen.has(region.id)) continue;
           seen.add(region.id);
           regions.push(region);
@@ -407,7 +718,7 @@ export const TTranscriptView = defineComponent({
       const top = clamp(currentScrollTop(), 0, rows.length);
       const bottom = Math.min(rows.length, top + Math.max(0, normalizeInt(props.h)));
       for (let i = top; i < bottom; i++) {
-        if (rows[i]?.hitRegions.some((region) => region.id === id)) return true;
+        if (getVisualRow(i)?.hitRegions.some((region) => region.id === id)) return true;
       }
       return false;
     }
@@ -476,8 +787,12 @@ export const TTranscriptView = defineComponent({
 
     function scrollToRow(index: number, options?: { align?: "start" | "center" | "end" }): void {
       const rowIndex = clamp(normalizeInt(index), 0, Math.max(0, props.source.rowCount() - 1));
-      const visualIndex = layoutState.value.rowStarts.get(rowIndex) ?? 0;
-      const rowEnd = layoutState.value.rowEnds.get(rowIndex) ?? visualIndex + 1;
+      const visualIndex = layoutState.value.fixedRows
+        ? rowIndex
+        : (layoutState.value.rowStarts.get(rowIndex) ?? 0);
+      const rowEnd = layoutState.value.fixedRows
+        ? rowIndex + 1
+        : (layoutState.value.rowEnds.get(rowIndex) ?? visualIndex + 1);
       const viewportRows = Math.max(1, normalizeInt(props.h));
       const rowHeight = Math.max(1, rowEnd - visualIndex);
       let top = visualIndex;
@@ -490,8 +805,8 @@ export const TTranscriptView = defineComponent({
     }
 
     function invalidateRow(index: number): void {
-      const start = layoutState.value.rowStarts.get(index);
-      const end = layoutState.value.rowEnds.get(index);
+      const start = layoutState.value.fixedRows ? index : layoutState.value.rowStarts.get(index);
+      const end = layoutState.value.fixedRows ? index + 1 : layoutState.value.rowEnds.get(index);
       if (start == null || end == null) return;
       rowsRef.value?.invalidateRange(start, end);
     }
@@ -499,10 +814,27 @@ export const TTranscriptView = defineComponent({
     function invalidateRange(start: number, end: number): void {
       const first = clamp(normalizeInt(start), 0, props.source.rowCount());
       const last = clamp(normalizeInt(end), first, props.source.rowCount());
-      const visualStart = layoutState.value.rowStarts.get(first);
-      const visualEnd = layoutState.value.rowEnds.get(last - 1);
+      const visualStart = layoutState.value.fixedRows
+        ? first
+        : layoutState.value.rowStarts.get(first);
+      const visualEnd = layoutState.value.fixedRows
+        ? last
+        : layoutState.value.rowEnds.get(last - 1);
       if (visualStart == null || visualEnd == null) return;
       rowsRef.value?.invalidateRange(visualStart, visualEnd);
+    }
+
+    function virtualRowsChangedRange(): { start: number; end: number } | null {
+      const state = layoutState.value;
+      const changedRange = normalizedChangedRange(props.source.getChangedRange?.(), state.rowCount);
+      if (!changedRange) return null;
+      if (state.fixedRows || changedRange.end <= changedRange.start) return changedRange;
+      if (!canUseWrappedChangedRangeRepaint) return null;
+
+      const visualStart = state.rowStarts.get(changedRange.start);
+      const visualEnd = state.rowEnds.get(changedRange.end - 1);
+      if (visualStart == null || visualEnd == null) return null;
+      return { start: visualStart, end: visualEnd };
     }
 
     expose({
@@ -613,7 +945,19 @@ export const TTranscriptView = defineComponent({
     }
 
     function getVisualRow(index: number): TTranscriptVisualRow | undefined {
-      return layoutState.value.visualRows[index];
+      const state = layoutState.value;
+      const cached = state.visualRows[index];
+      if (cached || !state.fixedRows) return cached;
+      if (index < 0 || index >= state.visualRows.length) return undefined;
+      const result = layoutSourceRow(index, {
+        width: Math.max(1, Math.floor(props.w)),
+        baseStyle: props.style ?? defaultStyle.value,
+        hoverRegionId: hoveredRegion.value?.id ?? null,
+        focusedRegionId: focusedRegion.value?.id ?? null,
+      });
+      const row = result.rows[0];
+      if (row) (state.visualRows as TTranscriptVisualRow[])[index] = row;
+      return row;
     }
 
     function selectionTextForVisualRow(visualRow: TTranscriptVisualRow | undefined): string {
@@ -644,6 +988,7 @@ export const TTranscriptView = defineComponent({
         zIndex: props.zIndex,
         itemCount: layoutState.value.visualRows.length,
         itemVersion: props.version,
+        itemChangedRange: virtualRowsChangedRange,
         getItem: getVisualRow,
         paintItem: paintVisualRow,
         renderItemNodes: renderVisualRowNodes,

--- a/src/vue/components/TTree.ts
+++ b/src/vue/components/TTree.ts
@@ -36,16 +36,24 @@ type FlatTreeNode = Readonly<{
 function flattenTree(
   nodes: readonly TTreeNode[],
   expanded: Set<string>,
+  limit: number,
   depth = 0,
   out: FlatTreeNode[] = [],
 ): FlatTreeNode[] {
+  if (out.length >= limit) return out;
   for (const node of nodes) {
+    if (out.length >= limit) break;
     const expandable = Boolean(node.children?.length);
     const isExpanded = expanded.has(node.id);
     out.push({ node, depth, expandable, expanded: isExpanded });
-    if (expandable && isExpanded) flattenTree(node.children!, expanded, depth + 1, out);
+    if (expandable && isExpanded) flattenTree(node.children!, expanded, limit, depth + 1, out);
   }
   return out;
+}
+
+function visibleRowLimit(height: number): number {
+  const limit = Math.floor(height);
+  return Number.isFinite(limit) ? Math.max(0, limit) : 0;
 }
 
 export const TTree = defineComponent({
@@ -81,7 +89,9 @@ export const TTree = defineComponent({
     const { defaultStyle } = useTerminal();
     const baseStyle = computed(() => mergeStyle(defaultStyle.value, props.style));
     const expandedSet = computed(() => new Set(props.expandedIds));
-    const rows = computed(() => flattenTree(props.nodes, expandedSet.value).slice(0, props.h));
+    const rows = computed(() =>
+      flattenTree(props.nodes, expandedSet.value, visibleRowLimit(props.h)),
+    );
 
     function toggle(item: FlatTreeNode): void {
       if (item.node.disabled || !item.expandable) return;

--- a/src/vue/components/TVirtualRows.ts
+++ b/src/vue/components/TVirtualRows.ts
@@ -55,6 +55,16 @@ function normalizeInt(value: unknown): number {
   return Number.isFinite(n) ? n : 0;
 }
 
+function normalizeChangedRange(
+  range: { start: number; end: number } | null | undefined,
+  count: number,
+): { start: number; end: number } | null {
+  if (!range) return null;
+  const start = clamp(normalizeInt(range.start), 0, count);
+  const end = clamp(normalizeInt(range.end), start, count);
+  return { start, end };
+}
+
 function getWheelScrollInput(e: { deltaY?: number; deltaMode?: number }): {
   deltaY: number;
   mode: "auto" | "line" | "pixel";
@@ -144,6 +154,10 @@ export const TVirtualRows = defineComponent({
     zIndex: { type: Number, default: 0 },
     itemCount: { type: Number, required: true },
     itemVersion: { type: Number, required: true },
+    itemChangedRange: {
+      type: Function as PropType<() => { start: number; end: number } | null | undefined>,
+      default: undefined,
+    },
     getItem: { type: Function as PropType<(index: number) => unknown>, required: true },
     paintItem: {
       type: Function as PropType<(ctx: TVirtualRowsPaintContext) => void>,
@@ -358,6 +372,37 @@ export const TVirtualRows = defineComponent({
       scheduler.invalidate({ priority, plane: plane.value, reason: "scroll" });
     }
 
+    function markScrollDamage(
+      prevTop: number,
+      nextTop: number,
+      strategy: "auto" | "viewport-repaint" = "auto",
+    ): void {
+      const r = normalizedRect();
+      const h = r.h;
+      const delta = nextTop - prevTop;
+      if (h <= 0 || !delta) return;
+
+      const size = terminal.size();
+      const ownsFullRows = Math.floor(r.x) === 0 && Math.floor(r.w) >= size.cols;
+      const withinTerminalRows = r.y >= 0 && r.y + h <= size.rows;
+      const canUseScrollPlane =
+        strategy === "auto" &&
+        props.rowScrollMode === "unsafe-full-row" &&
+        rendererCapabilities.value.scrollOperations &&
+        ownsFullRows &&
+        withinTerminalRows &&
+        !isClipped() &&
+        Math.abs(delta) < h &&
+        !dirtyRowsHint?.length;
+
+      if (canUseScrollPlane) {
+        render.unsafeScrollPlaneRows(plane.value, r.y, r.y + h, delta);
+        markRowsDirty(exposedRowsForDelta(r.y, h, delta));
+      } else {
+        markViewportDirty();
+      }
+    }
+
     function applyScrollTop(
       nextTop: number,
       options?: Readonly<{
@@ -383,25 +428,7 @@ export const TVirtualRows = defineComponent({
       setCurrentScrollTop(clampedTop);
       if (options?.emitUpdate !== false) emit("update:scrollTop", clampedTop);
 
-      const size = terminal.size();
-      const ownsFullRows = Math.floor(r.x) === 0 && Math.floor(r.w) >= size.cols;
-      const withinTerminalRows = r.y >= 0 && r.y + h <= size.rows;
-      const canUseScrollPlane =
-        (options?.strategy ?? "auto") === "auto" &&
-        props.rowScrollMode === "unsafe-full-row" &&
-        rendererCapabilities.value.scrollOperations &&
-        ownsFullRows &&
-        withinTerminalRows &&
-        !isClipped() &&
-        Math.abs(delta) < h &&
-        !dirtyRowsHint?.length;
-
-      if (canUseScrollPlane) {
-        render.unsafeScrollPlaneRows(plane.value, r.y, r.y + h, delta);
-        markRowsDirty(exposedRowsForDelta(r.y, h, delta));
-      } else {
-        markViewportDirty();
-      }
+      markScrollDamage(prevTop, clampedTop, options?.strategy);
 
       if (options?.emitScroll) emitScroll(clampedTop);
       return true;
@@ -473,7 +500,11 @@ export const TVirtualRows = defineComponent({
     }
 
     function invalidateRange(start: number, end: number): void {
-      if (!hasPaintableViewport()) return;
+      markItemRangeDirty(start, end);
+    }
+
+    function markItemRangeDirty(start: number, end: number): boolean {
+      if (!hasPaintableViewport()) return false;
       const r = normalizedRect();
       const { y: clipY } = clipOffsets();
       const top = currentScrollTop() + clipY;
@@ -484,9 +515,10 @@ export const TVirtualRows = defineComponent({
         const y = r.y + (index - top);
         if (y >= r.y && y < r.y + r.h) rows.push(y);
       }
-      if (!rows.length) return;
+      if (!rows.length) return true;
       markRowsDirty(rows);
       invalidateSelf("normal");
+      return true;
     }
 
     function invalidateIndex(index: number): void {
@@ -737,8 +769,9 @@ export const TVirtualRows = defineComponent({
           return;
         }
         cancelWheelScrollFrame();
+        const prevTop = controlledScrollTop.value;
         controlledScrollTop.value = nextTop;
-        markViewportDirty();
+        markScrollDamage(prevTop, nextTop);
         selection.refresh(pendingSelectionScrollFocusRemap ? { remapFocus: true } : undefined);
         pendingSelectionScrollFocusRemap = false;
         invalidateSelf("high");
@@ -763,7 +796,7 @@ export const TVirtualRows = defineComponent({
         () => absRect.value.w,
         () => absRect.value.h,
       ],
-      () => {
+      (next, prev) => {
         resetWheelScrollState(wheelState);
         const nextTop = clampScrollTop(currentScrollTop());
         if (isScrollControlled()) {
@@ -774,6 +807,28 @@ export const TVirtualRows = defineComponent({
         } else {
           setCurrentScrollTop(nextTop);
         }
+
+        const onlyItemVersionChanged = Boolean(
+          prev &&
+          next[0] === prev[0] &&
+          next[1] !== prev[1] &&
+          next[2] === prev[2] &&
+          next[3] === prev[3] &&
+          next[4] === prev[4] &&
+          next[5] === prev[5] &&
+          next[6] === prev[6] &&
+          next[7] === prev[7] &&
+          next[8] === prev[8] &&
+          next[9] === prev[9],
+        );
+        if (onlyItemVersionChanged) {
+          const changedRange = normalizeChangedRange(props.itemChangedRange?.(), itemCount.value);
+          if (changedRange) {
+            markItemRangeDirty(changedRange.start, changedRange.end);
+            return;
+          }
+        }
+
         markViewportDirty();
         invalidateSelf("normal");
       },
@@ -803,7 +858,6 @@ export const TVirtualRows = defineComponent({
         absRect.value,
         fullRect.value,
         itemCount.value,
-        props.itemVersion,
         props.getItem,
         props.paintItem,
         props.selectionSpanText,

--- a/src/vue/transcript/types.ts
+++ b/src/vue/transcript/types.ts
@@ -64,6 +64,7 @@ export type TTranscriptDataSource = Readonly<{
   getRow(index: number): TTranscriptRow;
   getRowKey?: (index: number) => string | number;
   getRowVersion?: (index: number) => string | number;
+  getChangedRange?: () => { start: number; end: number } | null | undefined;
   firstRowIndex?: () => number;
 }>;
 

--- a/test/p1-p2-components.test.ts
+++ b/test/p1-p2-components.test.ts
@@ -703,6 +703,129 @@ describe("P1/P2 public components", () => {
     }
   });
 
+  it("keeps signed zero row keys distinct for TTable multi-selection", async () => {
+    const mounted = await mountTerminal(
+      () =>
+        h(TTable, {
+          x: 0,
+          y: 0,
+          w: 16,
+          h: 4,
+          columns: [{ key: "name", label: "Name", width: 8 }],
+          rows: [
+            { id: -0, name: "Minus" },
+            { id: 0, name: "Zero" },
+          ],
+          rowKey: "id",
+          selectedRowKeys: [0],
+        }),
+      20,
+      6,
+    );
+
+    try {
+      await nextTick();
+      mounted.scheduler()?.flushNow();
+
+      expect(mounted.terminal.getCell(0, 2).style.inverse).not.toBe(true);
+      expect(mounted.terminal.getCell(0, 3).style.inverse).toBe(true);
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("indexes TTable selected row keys once for visible rows", async () => {
+    let selectedKeyReads = 0;
+    const selectedRowKeys: any[] = [];
+    selectedRowKeys.length = 20;
+    Object.defineProperty(selectedRowKeys, 10, {
+      get: () => {
+        selectedKeyReads++;
+        return "missing";
+      },
+    });
+    const mounted = await mountTerminal(
+      () =>
+        h(TTable, {
+          x: 0,
+          y: 0,
+          w: 16,
+          h: 5,
+          columns: [{ key: "name", label: "Name", width: 8 }],
+          rows: [
+            { id: "a", name: "Alpha" },
+            { id: "b", name: "Beta" },
+            { id: "c", name: "Gamma" },
+          ],
+          rowKey: "id",
+          selectedRowKeys,
+        }),
+      20,
+      7,
+    );
+
+    try {
+      await nextTick();
+      mounted.scheduler()?.flushNow();
+
+      expect(selectedKeyReads).toBe(1);
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("skips sparse TTable selected row key holes without dropping explicit undefined", async () => {
+    const sparseSelectedRowKeys: unknown[] = [];
+    sparseSelectedRowKeys.length = 2;
+    const sparse = await mountTerminal(
+      () =>
+        h(TTable, {
+          x: 0,
+          y: 0,
+          w: 16,
+          h: 3,
+          columns: [{ key: "name", label: "Name", width: 8 }],
+          rows: [{ id: undefined, name: "Unset" }],
+          rowKey: "id",
+          selectedRowKeys: sparseSelectedRowKeys,
+        }),
+      20,
+      5,
+    );
+
+    try {
+      await nextTick();
+      sparse.scheduler()?.flushNow();
+      expect(sparse.terminal.getCell(0, 2).style.inverse).not.toBe(true);
+    } finally {
+      sparse.unmount();
+    }
+
+    const explicit = await mountTerminal(
+      () =>
+        h(TTable, {
+          x: 0,
+          y: 0,
+          w: 16,
+          h: 3,
+          columns: [{ key: "name", label: "Name", width: 8 }],
+          rows: [{ id: undefined, name: "Unset" }],
+          rowKey: "id",
+          selectedRowKeys: [undefined],
+        }),
+      20,
+      5,
+    );
+
+    try {
+      await nextTick();
+      explicit.scheduler()?.flushNow();
+      expect(explicit.terminal.getCell(0, 2).style.inverse).toBe(true);
+    } finally {
+      explicit.unmount();
+    }
+  });
+
   it("keeps TDataTable rowSelect indices correct with scrollTop", async () => {
     const onRowSelect = vi.fn();
     const mounted = await mountTerminal(
@@ -1223,6 +1346,59 @@ describe("P1/P2 public components", () => {
     }
   });
 
+  it("keeps keyboard-active TDataTable row active after in-place key mutation", async () => {
+    const rows = ref([
+      { id: "a", name: "Alpha" },
+      { id: "b", name: "Beta" },
+    ]);
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TDataTable, {
+          x: 0,
+          y: 0,
+          w: 16,
+          h: 4,
+          columns: [{ key: "name", label: "Name", width: 8 }],
+          rows: rows.value,
+          rowKey: "id",
+          selectable: true,
+          activeStyle: { underline: true },
+        }),
+      20,
+      5,
+    );
+
+    try {
+      const container = mounted.container()!;
+      container.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 0, clientY: 2, bubbles: true }),
+      );
+      container.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "ArrowDown",
+          code: "ArrowDown",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      await nextTick();
+      mounted.scheduler()?.flushNow();
+
+      expect(mounted.terminal.snapshot().lines[3]).toContain("Beta");
+      expect(mounted.terminal.getCell(0, 3).style.underline).toBe(true);
+
+      rows.value[1]!.id = "z";
+      await nextTick();
+      mounted.scheduler()?.flushNow();
+
+      expect(mounted.terminal.snapshot().lines[3]).toContain("Beta");
+      expect(mounted.terminal.getCell(0, 3).style.underline).toBe(true);
+    } finally {
+      mounted.unmount();
+    }
+  });
+
   it("redistributes TTable auto width after maxWidth clamps a column", async () => {
     const mounted = await mountTerminal(
       () =>
@@ -1364,6 +1540,47 @@ describe("P1/P2 public components", () => {
           .debugNodes()
           .some((node) => node.visible && node.focusable && node.rect.x === 0 && node.rect.y === 0),
       ).toBe(false);
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("does not traverse tree nodes below the visible height", async () => {
+    let hiddenChildrenReads = 0;
+    const visibleRoot: any = { id: "visible", label: "Visible" };
+    Object.defineProperty(visibleRoot, "children", {
+      get: () => [{ id: "visible-child", label: "Visible child" }],
+    });
+    const hiddenRoots = Array.from({ length: 50 }, (_, index) => {
+      const node: any = { id: `hidden-${index}`, label: `Hidden ${index}` };
+      Object.defineProperty(node, "children", {
+        get: () => {
+          hiddenChildrenReads++;
+          return [{ id: `hidden-${index}-child`, label: `Hidden child ${index}` }];
+        },
+      });
+      return node;
+    });
+    const nodes = [visibleRoot, ...hiddenRoots];
+    const mounted = await mountTerminal(
+      () =>
+        h(TTree, {
+          x: 0,
+          y: 0,
+          w: 24,
+          h: 2,
+          expandedIds: nodes.map((node) => node.id),
+          nodes,
+        }),
+      30,
+      4,
+    );
+
+    try {
+      const lines = mounted.terminal.snapshot().lines;
+      expect(lines[0]).toContain("Visible");
+      expect(lines[1]).toContain("Visible child");
+      expect(hiddenChildrenReads).toBe(0);
     } finally {
       mounted.unmount();
     }
@@ -5159,6 +5376,79 @@ describe("P1/P2 public components", () => {
     }
   });
 
+  it("keeps default command palette substring matches in score buckets", async () => {
+    const items = [
+      { label: "keyword match A", keywords: ["target"] },
+      { label: "detail match A", detail: "target" },
+      { label: "label target A" },
+      { label: "Hidden group", kind: "group" as const },
+      { label: "label target B" },
+      { label: "detail match B", detail: "target" },
+    ];
+    const mounted = await mountTerminal(
+      () =>
+        h(TCommandPalette, {
+          modelValue: true,
+          w: 40,
+          h: 12,
+          initialQuery: "target",
+          maxVisibleItems: 5,
+          items,
+        }),
+      50,
+      14,
+    );
+
+    try {
+      await nextTick();
+      mounted.scheduler()?.flushNow();
+
+      const snapshot = mounted.terminal.snapshot().lines.join("\n");
+      const labelA = snapshot.indexOf("label target A");
+      const labelB = snapshot.indexOf("label target B");
+      const detailA = snapshot.indexOf("detail match A");
+      const detailB = snapshot.indexOf("detail match B");
+      const keywordA = snapshot.indexOf("keyword match A");
+
+      expect(labelA).toBeGreaterThanOrEqual(0);
+      expect(labelA).toBeLessThan(labelB);
+      expect(labelB).toBeLessThan(detailA);
+      expect(detailA).toBeLessThan(detailB);
+      expect(detailB).toBeLessThan(keywordA);
+      expect(snapshot).not.toContain("Hidden group");
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("keeps default command palette substring matching tolerant of non-string item text", async () => {
+    const items = [{ label: 42 }, { label: "By detail", detail: 42 }, { label: "Miss" }] as any;
+    const mounted = await mountTerminal(
+      () =>
+        h(TCommandPalette, {
+          modelValue: true,
+          w: 40,
+          h: 12,
+          initialQuery: "42",
+          items,
+        }),
+      50,
+      14,
+    );
+
+    try {
+      await nextTick();
+      mounted.scheduler()?.flushNow();
+
+      const snapshot = mounted.terminal.snapshot().lines.join("\n");
+      expect(snapshot).toContain("42");
+      expect(snapshot).toContain("By detail");
+      expect(snapshot).not.toContain("Miss");
+    } finally {
+      mounted.unmount();
+    }
+  });
+
   it("normalizes non-finite TCommandPalette numeric props before rendering and selecting", async () => {
     const onSelect = vi.fn();
 
@@ -6012,6 +6302,43 @@ describe("P1/P2 public components", () => {
 
       expect(onRowSelect).not.toHaveBeenCalled();
       expect(onUpdateSelectedRowKey).not.toHaveBeenCalled();
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("does not read hidden rows for unfiltered data tables", async () => {
+    let hiddenReads = 0;
+    const rows: any[] = [
+      { id: "0", name: "Alpha" },
+      { id: "1", name: "Beta" },
+    ];
+    rows.length = 50;
+    Object.defineProperty(rows, 25, {
+      get: () => {
+        hiddenReads++;
+        return { id: "25", name: "Hidden" };
+      },
+    });
+    const mounted = await mountTerminal(
+      () =>
+        h(TDataTable, {
+          x: 0,
+          y: 0,
+          w: 12,
+          h: 4,
+          columns: [{ key: "name", label: "Name", width: 6 }],
+          rows,
+          rowKey: "id",
+        }),
+      16,
+      5,
+    );
+
+    try {
+      expect(mounted.terminal.snapshot().lines[2]).toContain("Alpha");
+      expect(mounted.terminal.snapshot().lines[3]).toContain("Beta");
+      expect(hiddenReads).toBe(0);
     } finally {
       mounted.unmount();
     }

--- a/test/tlog-view.test.ts
+++ b/test/tlog-view.test.ts
@@ -601,7 +601,7 @@ describe("TLogView", () => {
     }
   });
 
-  it("repaints the viewport for full-row unsafe wrapped wheel scroll", async () => {
+  it("uses exposed dirty rows for full-row unsafe wrapped wheel scroll", async () => {
     const source: TLogDataSource = {
       lineCount: () => 100,
       getLine: (index) => `line-${index}-xxxxxxxxxxxxxxxxxxxxxxxx`,
@@ -644,7 +644,12 @@ describe("TLogView", () => {
       app.scheduler.flushNow();
 
       off();
-      expect(commits).toEqual([{ dirtyRows: [0, 1, 2, 3], scrollOperations: null }]);
+      expect(commits).toEqual([
+        {
+          dirtyRows: [0],
+          scrollOperations: [{ startY: 0, endY: 4, delta: -1 }],
+        },
+      ]);
       expect([0, 1, 2, 3].map((y) => rowText(app, y))).toEqual([
         "xxxxxxxxxxxx",
         "line-98-xxxxxxxxxxxx",
@@ -1147,6 +1152,60 @@ describe("TLogView", () => {
       expect(rowText(app, 0)).toBe("abcd");
     } finally {
       app.dispose();
+    }
+  });
+
+  it("counts non-ANSI wrapped wide graphemes like rendered rows", async () => {
+    const raf = installManualRaf();
+    const source: TLogDataSource = {
+      lineCount: () => 2,
+      getLine: (index) => (index === 0 ? "界" : "A"),
+      getLineKey: (index) => index,
+    };
+    const logView = ref<TLogViewHandle | null>(null);
+
+    const App = defineComponent({
+      name: "TLogViewPlainWideWrapCountApp",
+      setup() {
+        return () =>
+          h(TLogView, {
+            ref: logView,
+            x: 0,
+            y: 0,
+            w: 1,
+            h: 1,
+            source,
+            version: 1,
+            wrap: true,
+            ansi: false,
+            defaultScrollTop: 0,
+            autoStickToBottom: false,
+            visualIndexMode: "exact",
+          });
+      },
+    });
+
+    const app = createTerminalApp({ cols: 2, rows: 2, component: App });
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      await flushVisualIndex(logView.value!, raf);
+      app.scheduler.flushNow();
+
+      expect(logView.value!.getScrollMetrics()).toMatchObject({
+        visualIndexStatus: "exact",
+        visualRowCount: 2,
+        maxScrollTop: 1,
+      });
+
+      logView.value!.scrollToBottom();
+      await nextTick();
+      app.scheduler.flushNow();
+      expect(rowText(app, 0)).toBe("A");
+    } finally {
+      app.dispose();
+      raf.restore();
     }
   });
 
@@ -6114,7 +6173,7 @@ describe("TLogView", () => {
     mounted.unmount();
   });
 
-  it("repaints wrapped visual rows when appending at bottom in full-row unsafe mode", async () => {
+  it("uses exposed dirty rows for wrapped append at bottom in full-row unsafe mode", async () => {
     const log = createAppendOnlyLogStore();
     log.appendLines(["line-0", "line-1", "line-2", "line-3"]);
 
@@ -6154,7 +6213,10 @@ describe("TLogView", () => {
       await nextTick();
 
       off();
-      expect(commits).toContainEqual({ dirtyRows: [0, 1, 2, 3], scrollOperations: null });
+      expect(commits).toContainEqual({
+        dirtyRows: [2, 3],
+        scrollOperations: [{ startY: 0, endY: 4, delta: 2 }],
+      });
       expect([0, 1, 2, 3].map((y) => rowText(app, y))).toEqual([
         "line-2",
         "line-3",

--- a/test/transcript-view.test.ts
+++ b/test/transcript-view.test.ts
@@ -248,6 +248,71 @@ describe("TTranscriptView", () => {
     }
   });
 
+  it("uses row scroll operations for parent-controlled full-row scroll", async () => {
+    const raf = installManualRaf();
+    const scrollTop = ref(0);
+    const rows = Array.from(
+      { length: 20 },
+      (_, index): TTranscriptRow => ({
+        kind: "message",
+        key: index,
+        segments: [{ text: `row-${index}` }],
+      }),
+    );
+    const App = defineComponent({
+      name: "TranscriptControlledScrollOperationApp",
+      setup() {
+        return () =>
+          h(TTranscriptView, {
+            x: 0,
+            y: 0,
+            w: 10,
+            h: 3,
+            source: createSource(rows),
+            version: 1,
+            scrollTop: scrollTop.value,
+            autoFocus: true,
+            rowScrollMode: "unsafe-full-row",
+            "onUpdate:scrollTop": (value: number) => {
+              scrollTop.value = value;
+            },
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 10, rows: 5, component: App });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      expect(rowText(app, 0)).toBe("row-0");
+
+      const commits: Array<{
+        dirtyRows: readonly number[] | null;
+        scrollOperations: unknown;
+      }> = [];
+      const off = app.terminal.on("commit", ({ dirtyRows, scrollOperations }) => {
+        commits.push({ dirtyRows, scrollOperations: scrollOperations ?? null });
+      });
+
+      app.events.dispatch({ type: "wheel", cellX: 0, cellY: 0, deltaY: 100, time: 1_000 });
+      expect(raf.pending()).toBe(1);
+      raf.runNext();
+      await nextTick();
+      app.scheduler.flushNow();
+
+      off();
+      expect(rowText(app, 0)).toBe("row-1");
+      expect(rowText(app, 2)).toBe("row-3");
+      expect(commits).toEqual([
+        { dirtyRows: [2], scrollOperations: [{ startY: 0, endY: 3, delta: 1 }] },
+      ]);
+    } finally {
+      app.dispose();
+      raf.restore();
+    }
+  });
+
   it("does not focus or click disabled actions", async () => {
     const actionClick = vi.fn();
     const viewRef = ref<TTranscriptViewHandle | null>(null);
@@ -626,6 +691,7 @@ describe("TTranscriptView", () => {
             h: 1,
             source: createSource(rows),
             version: 1,
+            wrap: true,
           });
       },
     });
@@ -774,12 +840,466 @@ describe("TTranscriptView", () => {
         .slice()
         .reverse()
         .find((sample) => sample.name === "TTranscriptView" && sample.phase === "layout");
-      expect(rowBuilds).toBe(lines.length);
+      expect(rowBuilds).toBe(0);
       expect(transcriptSample).toMatchObject({
         itemCount: lines.length,
         cacheHit: lines.length,
         cacheMiss: 0,
         width: 44,
+      });
+
+      componentSamples.length = 0;
+      rowBuilds = 0;
+      lines[1]!.text = "Assistant: streamed update";
+      lines[1]!.version++;
+      transcriptVersion.value++;
+      await nextTick();
+      app.scheduler.flushNow();
+
+      const updatedTranscriptSample = componentSamples
+        .slice()
+        .reverse()
+        .find((sample) => sample.name === "TTranscriptView" && sample.phase === "layout");
+      expect(rowText(app, 2)).toContain("Assistant: streamed update");
+      expect(rowBuilds).toBe(1);
+      expect(updatedTranscriptSample).toMatchObject({
+        itemCount: lines.length,
+        cacheHit: lines.length - 1,
+        cacheMiss: 1,
+        width: 44,
+      });
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("only reads visible fixed-height transcript rows after version updates", async () => {
+    const lines = Array.from({ length: 1000 }, (_, index) => ({
+      key: `line-${index}`,
+      version: 1,
+      text: `row-${index}`,
+    }));
+    const transcriptVersion = ref(1);
+    let rowBuilds = 0;
+    let rowVersionRequests = 0;
+
+    const source: TTranscriptDataSource = {
+      rowCount: () => lines.length,
+      getRow: (index) => {
+        rowBuilds++;
+        const line = lines[index]!;
+        return {
+          kind: "message",
+          key: line.key,
+          segments: [{ text: line.text }],
+          selectableText: line.text,
+        };
+      },
+      getRowKey: (index) => lines[index]!.key,
+      getRowVersion: (index) => {
+        rowVersionRequests++;
+        return lines[index]!.version;
+      },
+    };
+
+    const App = defineComponent({
+      name: "TranscriptFixedHeightWindowProbe",
+      setup() {
+        return () =>
+          h(TTranscriptView, {
+            x: 0,
+            y: 0,
+            w: 16,
+            h: 4,
+            source,
+            version: transcriptVersion.value,
+            scrollTop: 500,
+            wrap: false,
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 16, rows: 6, component: App });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      expect(rowText(app, 0)).toBe("row-500");
+
+      rowBuilds = 0;
+      rowVersionRequests = 0;
+      lines[20]!.text = "offscreen update";
+      lines[20]!.version++;
+      transcriptVersion.value++;
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(rowText(app, 0)).toBe("row-500");
+      expect(rowBuilds).toBe(0);
+      expect(rowVersionRequests).toBeLessThanOrEqual(4);
+
+      rowBuilds = 0;
+      rowVersionRequests = 0;
+      lines[502]!.text = "visible update";
+      lines[502]!.version++;
+      transcriptVersion.value++;
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(rowText(app, 2)).toBe("visible update");
+      expect(rowBuilds).toBe(1);
+      expect(rowVersionRequests).toBeLessThanOrEqual(4);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("uses changed ranges to limit fixed-height transcript repaints", async () => {
+    const lines = Array.from({ length: 1000 }, (_, index) => ({
+      key: `line-${index}`,
+      version: 1,
+      text: `row-${index}`,
+    }));
+    const transcriptVersion = ref(1);
+    let changedRange: { start: number; end: number } | null = null;
+
+    const source: TTranscriptDataSource = {
+      rowCount: () => lines.length,
+      getRow: (index) => {
+        const line = lines[index]!;
+        return {
+          kind: "message",
+          key: line.key,
+          segments: [{ text: line.text }],
+          selectableText: line.text,
+        };
+      },
+      getRowKey: (index) => lines[index]!.key,
+      getRowVersion: (index) => lines[index]!.version,
+      getChangedRange: () => changedRange,
+    };
+
+    const App = defineComponent({
+      name: "TranscriptFixedHeightChangedRangePaintProbe",
+      setup() {
+        return () =>
+          h(TTranscriptView, {
+            x: 0,
+            y: 0,
+            w: 16,
+            h: 4,
+            source,
+            version: transcriptVersion.value,
+            scrollTop: 500,
+            wrap: false,
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 16, rows: 6, component: App });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      expect(rowText(app, 0)).toBe("row-500");
+
+      const commits: Array<{
+        dirtyRows: readonly number[] | null;
+        scrollOperations: unknown;
+      }> = [];
+      const off = app.terminal.on("commit", ({ dirtyRows, scrollOperations }) => {
+        commits.push({ dirtyRows, scrollOperations: scrollOperations ?? null });
+      });
+
+      changedRange = { start: 20, end: 21 };
+      lines[20]!.text = "offscreen update";
+      lines[20]!.version++;
+      transcriptVersion.value++;
+      await nextTick();
+      app.scheduler.flushNow();
+      expect(commits).toEqual([]);
+
+      changedRange = { start: 502, end: 503 };
+      lines[502]!.text = "visible update";
+      lines[502]!.version++;
+      transcriptVersion.value++;
+      await nextTick();
+      app.scheduler.flushNow();
+
+      off();
+      expect(rowText(app, 2)).toBe("visible update");
+      expect(commits).toEqual([{ dirtyRows: [2], scrollOperations: null }]);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("uses changed ranges to avoid scanning unchanged wrapped transcript rows", async () => {
+    const lines = Array.from({ length: 1000 }, (_, index) => ({
+      key: `line-${index}`,
+      version: 1,
+      text: `row-${index}`,
+    }));
+    const transcriptVersion = ref(1);
+    let changedRange: { start: number; end: number } | null = null;
+    let rowBuilds = 0;
+    let rowVersionRequests = 0;
+
+    const source: TTranscriptDataSource = {
+      rowCount: () => lines.length,
+      getRow: (index) => {
+        rowBuilds++;
+        const line = lines[index]!;
+        return {
+          kind: "message",
+          key: line.key,
+          segments: [{ text: line.text }],
+          selectableText: line.text,
+        };
+      },
+      getRowKey: (index) => lines[index]!.key,
+      getRowVersion: (index) => {
+        rowVersionRequests++;
+        return lines[index]!.version;
+      },
+      getChangedRange: () => changedRange,
+    };
+
+    const App = defineComponent({
+      name: "TranscriptWrappedChangedRangeProbe",
+      setup() {
+        return () =>
+          h(TTranscriptView, {
+            x: 0,
+            y: 0,
+            w: 16,
+            h: 4,
+            source,
+            version: transcriptVersion.value,
+            scrollTop: 0,
+            wrap: true,
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 16, rows: 6, component: App });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      expect(rowText(app, 0)).toBe("row-0");
+
+      rowBuilds = 0;
+      rowVersionRequests = 0;
+      changedRange = { start: 20, end: 21 };
+      lines[20]!.text = "offscreen update";
+      lines[20]!.version++;
+      transcriptVersion.value++;
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(rowText(app, 0)).toBe("row-0");
+      expect(rowBuilds).toBe(1);
+      expect(rowVersionRequests).toBe(1);
+
+      rowBuilds = 0;
+      rowVersionRequests = 0;
+      changedRange = { start: 2, end: 3 };
+      lines[2]!.text = "visible update";
+      lines[2]!.version++;
+      transcriptVersion.value++;
+      await nextTick();
+      app.scheduler.flushNow();
+
+      expect(rowText(app, 2)).toBe("visible update");
+      expect(rowBuilds).toBe(1);
+      expect(rowVersionRequests).toBe(1);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("repaints wrapped transcript viewport when a changed range changes visual height", async () => {
+    const lines = [
+      { key: "line-0", version: 1, text: "aaaa" },
+      { key: "line-1", version: 1, text: "b" },
+      { key: "line-2", version: 1, text: "c" },
+      { key: "line-3", version: 1, text: "d" },
+      { key: "line-4", version: 1, text: "e" },
+    ];
+    const transcriptVersion = ref(1);
+    let changedRange: { start: number; end: number } | null = null;
+
+    const source: TTranscriptDataSource = {
+      rowCount: () => lines.length,
+      getRow: (index) => {
+        const line = lines[index]!;
+        return {
+          kind: "message",
+          key: line.key,
+          segments: [{ text: line.text }],
+          selectableText: line.text,
+        };
+      },
+      getRowKey: (index) => lines[index]!.key,
+      getRowVersion: (index) => lines[index]!.version,
+      getChangedRange: () => changedRange,
+    };
+
+    const App = defineComponent({
+      name: "TranscriptWrappedChangedRangeHeightChangeProbe",
+      setup() {
+        return () =>
+          h(TTranscriptView, {
+            x: 0,
+            y: 0,
+            w: 4,
+            h: 5,
+            source,
+            version: transcriptVersion.value,
+            scrollTop: 0,
+            wrap: true,
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 4, rows: 6, component: App });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      expect([0, 1, 2, 3, 4].map((y) => rowText(app, y))).toEqual(["aaaa", "b", "c", "d", "e"]);
+
+      const commits: Array<{
+        dirtyRows: readonly number[] | null;
+        scrollOperations: unknown;
+      }> = [];
+      const off = app.terminal.on("commit", ({ dirtyRows, scrollOperations }) => {
+        commits.push({ dirtyRows, scrollOperations: scrollOperations ?? null });
+      });
+
+      changedRange = { start: 1, end: 2 };
+      lines[1]!.text = "bbbbccccdddd";
+      lines[1]!.version++;
+      transcriptVersion.value++;
+      await nextTick();
+      app.scheduler.flushNow();
+
+      off();
+      expect([0, 1, 2, 3, 4].map((y) => rowText(app, y))).toEqual([
+        "aaaa",
+        "bbbb",
+        "cccc",
+        "dddd",
+        "c",
+      ]);
+      expect(commits).toEqual([{ dirtyRows: [0, 1, 2, 3, 4], scrollOperations: null }]);
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("reuses keyed stable rows when a transcript source window shifts", async () => {
+    const lines = Array.from({ length: 4 }, (_, index) => ({
+      key: `line-${index}`,
+      version: 1,
+      text: `row-${index}`,
+    }));
+    const offset = ref(0);
+    const transcriptVersion = ref(1);
+    const componentSamples: any[] = [];
+    let rowBuilds = 0;
+
+    function rowAt(index: number): TTranscriptRow {
+      rowBuilds++;
+      const line = lines[offset.value + index];
+      return {
+        kind: "message",
+        key: line?.key ?? `empty-${offset.value + index}`,
+        segments: [{ text: line?.text ?? "" }],
+        selectableText: line?.text ?? "",
+      };
+    }
+
+    const source: TTranscriptDataSource = {
+      rowCount: () => 3,
+      getRow: rowAt,
+      getRowKey: (index) => lines[offset.value + index]?.key ?? `empty-${offset.value + index}`,
+      getRowVersion: (index) => lines[offset.value + index]?.version ?? 0,
+      firstRowIndex: () => offset.value,
+    };
+
+    const App = defineComponent({
+      name: "TranscriptShiftedWindowProbe",
+      setup() {
+        const { observability } = useTerminal();
+        observability.framePerf.enabled.value = true;
+        observability.framePerf.addSink({
+          onFramePerf: () => {},
+          onComponentPerf: (sample) => componentSamples.push(sample),
+        });
+        return () =>
+          h(TTranscriptView, {
+            x: 0,
+            y: 0,
+            w: 16,
+            h: 3,
+            source,
+            version: transcriptVersion.value,
+          });
+      },
+    });
+    const app = createTerminalApp({ cols: 16, rows: 4, component: App });
+
+    try {
+      app.mount();
+      await nextTick();
+      app.scheduler.flushNow();
+      expect(rowText(app, 0)).toBe("row-0");
+      expect(rowBuilds).toBe(3);
+
+      componentSamples.length = 0;
+      rowBuilds = 0;
+      offset.value = 1;
+      transcriptVersion.value++;
+      await nextTick();
+      app.scheduler.flushNow();
+
+      const shiftedSample = componentSamples
+        .slice()
+        .reverse()
+        .find((sample) => sample.name === "TTranscriptView" && sample.phase === "layout");
+      expect(rowText(app, 0)).toBe("row-1");
+      expect(rowText(app, 1)).toBe("row-2");
+      expect(rowText(app, 2)).toBe("row-3");
+      expect(rowBuilds).toBe(1);
+      expect(shiftedSample).toMatchObject({
+        itemCount: 3,
+        cacheHit: 2,
+        cacheMiss: 1,
+        width: 16,
+      });
+
+      componentSamples.length = 0;
+      rowBuilds = 0;
+      offset.value = 0;
+      transcriptVersion.value++;
+      await nextTick();
+      app.scheduler.flushNow();
+
+      const restoredSample = componentSamples
+        .slice()
+        .reverse()
+        .find((sample) => sample.name === "TTranscriptView" && sample.phase === "layout");
+      expect(rowText(app, 0)).toBe("row-0");
+      expect(rowText(app, 1)).toBe("row-1");
+      expect(rowText(app, 2)).toBe("row-2");
+      expect(rowBuilds).toBe(0);
+      expect(restoredSample).toMatchObject({
+        itemCount: 3,
+        cacheHit: 3,
+        cacheMiss: 0,
+        width: 16,
       });
     } finally {
       app.dispose();

--- a/test/ui-regressions-portal-select-text.test.ts
+++ b/test/ui-regressions-portal-select-text.test.ts
@@ -812,6 +812,43 @@ describe("ui regressions portal select and text", () => {
     mounted.unmount();
   });
 
+  it('TSelect indexes valueMode="value" multi-select values for large option lists', async () => {
+    let valueReads = 0;
+    const options = Array.from({ length: 100 }, (_, index) => {
+      const option: { label: string; value?: number } = { label: `Item ${index}` };
+      Object.defineProperty(option, "value", {
+        enumerable: true,
+        get() {
+          valueReads++;
+          return index;
+        },
+      });
+      return option;
+    });
+    const selected = Array.from({ length: 30 }, (_, index) => 70 + index);
+
+    const mounted = await mountTerminal(() =>
+      h(TSelect, {
+        x: 0,
+        y: 0,
+        w: 18,
+        h: 8,
+        multiple: true,
+        valueMode: "value",
+        modelValue: selected,
+        options,
+      }),
+    );
+
+    await nextTick();
+    valueReads = 0;
+    mounted.scheduler()!.flushNow();
+
+    expect(valueReads).toBeLessThan(140);
+
+    mounted.unmount();
+  });
+
   it("dims disabled TSelect options", async () => {
     const mounted = await mountTerminal(
       () =>


### PR DESCRIPTION
## Summary
- add shared changed-range repaint support to TVirtualRows and TTranscriptView
- let parent-controlled full-row transcript scrolling use terminal row scroll operations
- reduce repeated row/layout work across transcript, log, tree, table, select, and command palette render paths

## Validation
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm vitest run test/transcript-view.test.ts test/virtual-list.test.ts test/tlog-view.test.ts
- pnpm build:fast
- pnpm bench:phase2

## Data
In the linked CLI long-context/subagent scenario after this shared rendering work plus CLI integration, wheel event handler time under active subagent updates dropped from 83.86ms total / 7.23ms max to 1.57ms total / 0.11ms max for 24 round-trip wheel events.