### PR TITLE
Fix source-first Mermaid rendering

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -858,9 +858,9 @@ Markdown renderer for static or streaming text content。它走独立的 `parser
 >
 > 需要安装依赖后零配置使用内置 renderer 时，请从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 导入 `TMermaidText` / `TMermaid`。
 >
-> Mermaid 组件默认使用 size guard + simple-flowchart-only guard；`final=true` 后仅对简单 flowchart 尝试渲染。renderer 成功时原子替换为渲染结果；复杂 Mermaid、大 Mermaid、renderer 失败、超时或返回空白时保持源码显示。
+> `@simon_he/vue-tui/mermaid` 和 `@simon_he/vue-tui/agent/mermaid` 的内置 beautiful-mermaid wrapper 默认使用 size guard + simple-flowchart-only guard；`final=true` 后仅对简单 flowchart 尝试渲染。renderer 成功时原子替换为渲染结果；复杂 Mermaid、大 Mermaid、renderer 失败、超时或返回空白时保持源码显示。
 >
-> 需要显式让自定义 renderer 尝试复杂 Mermaid 时，传入 `shouldRenderSource={() => true}`。
+> `@simon_he/vue-tui/vue` 和 `@simon_he/vue-tui/agent` 导出的 renderer-agnostic primitive 不会默认拦截复杂 Mermaid；如果需要限制 custom renderer，只传入 `shouldRenderSource={isSimpleMermaidFlowchartSource}` 或自定义 guard。
 >
 > 注意：Markdown 里的 `mermaid` code fence 当前只保留 `code_block.language` metadata，尚未自动走 `TMermaidText` 的 async render/cache 路径。
 
@@ -933,7 +933,7 @@ const diagram = `graph TD
 - `ascii` `(boolean)`：使用纯 ASCII 而不是 Unicode box drawing
 - `options` `(TMermaidAsciiOptions?)`：传给 renderer 的 spacing/theme options；组件始终强制 `colorMode: "none"`
 - `renderer` `(TMermaidRenderer?)`：自定义 renderer，适合测试或替换 Mermaid engine
-- `shouldRenderSource` `(TMermaidRenderEligibility?)`：可选 renderer eligibility guard；返回 `false` 时保持源码，不调用 renderer。不传时默认使用 `isSimpleMermaidFlowchartSource`，即只尝试简单 flowchart。需要强制尝试复杂 Mermaid 时可传 `() => true`。
+- `shouldRenderSource` `(TMermaidRenderEligibility?)`：可选 renderer eligibility guard；返回 `false` 时保持源码，不调用 renderer。primitive 不传时不额外限制；beautiful-mermaid wrapper 不传时默认使用 `isSimpleMermaidFlowchartSource`，即只尝试简单 flowchart。
 - `isTransientError` `(TMermaidTransientErrorClassifier?)`：保留的 renderer error 分类 prop；source-first 渲染失败/超时时保持源码显示，不再根据分类显示 `incompleteText` / `errorText`
 - `markMermaidRenderErrorFatal(error)`：从 `@simon_he/vue-tui/vue` 或 `@simon_he/vue-tui/agent` 导入；source-first 渲染失败时仍保持源码显示
 - `streaming` `(boolean)`：streaming 更新时使用低优先级 frame task 合并重算

--- a/docs/components.md
+++ b/docs/components.md
@@ -858,7 +858,7 @@ Markdown renderer for static or streaming text content。它走独立的 `parser
 >
 > 需要安装依赖后零配置使用内置 renderer 时，请从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 导入 `TMermaidText` / `TMermaid`。
 >
-> 默认只会尝试渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。显式传入自定义 `renderer` 时也遵循同一个默认 guard；如果确实要让自定义 renderer 接管复杂 Mermaid，请传入 `shouldRenderSource={() => true}` 或更精细的自定义 guard。
+> 默认只做 size guard；`final=true` 后会把源码交给 renderer 尝试渲染。renderer 成功时原子替换为渲染结果；renderer 失败、超时、返回空白，或显式 `shouldRenderSource` 返回 `false` 时保持源码显示。需要 simple-flowchart-only 策略时，可显式传入 `shouldRenderSource={isSimpleMermaidFlowchartSource}`。
 
 ## TMermaidText
 
@@ -929,7 +929,7 @@ const diagram = `graph TD
 - `ascii` `(boolean)`：使用纯 ASCII 而不是 Unicode box drawing
 - `options` `(TMermaidAsciiOptions?)`：传给 renderer 的 spacing/theme options；组件始终强制 `colorMode: "none"`
 - `renderer` `(TMermaidRenderer?)`：自定义 renderer，适合测试或替换 Mermaid engine
-- `shouldRenderSource` `(TMermaidRenderEligibility?)`：自定义 renderer eligibility；返回 `false` 时保持源码，不调用 renderer。默认使用 `isSimpleMermaidFlowchartSource`，所以复杂 Mermaid 默认保持源码；需要强制渲染时可传 `() => true`。
+- `shouldRenderSource` `(TMermaidRenderEligibility?)`：可选 renderer eligibility guard；返回 `false` 时保持源码，不调用 renderer。不传时仅应用 size guard，并让 renderer 判断当前 Mermaid source 能否渲染。需要 simple-flowchart-only 策略时可传 `isSimpleMermaidFlowchartSource`。
 - `isTransientError` `(TMermaidTransientErrorClassifier?)`：自定义 renderer error 分类；`final=false` 时组件不调用 renderer，optional peer 缺失这类集成错误应该返回 `false`
 - `markMermaidRenderErrorFatal(error)`：从 `@simon_he/vue-tui/vue` 或 `@simon_he/vue-tui/agent` 导入，给自定义 renderer 标记缺依赖、renderer 初始化失败、wasm 加载失败等不应被当作 AI 中间态的 hard error
 - `streaming` `(boolean)`：streaming 更新时使用低优先级 frame task 合并重算
@@ -940,7 +940,7 @@ const diagram = `graph TD
 AI 输出 Mermaid fence 时经常会先产生不完整源码。`final=false` 下组件只显示源码，不调用 renderer。`final=true` 后：
 
 - 如果当前源码能渲染，则显示渲染结果。
-- 如果当前源码不符合传入的 eligibility、超出 size guard，或 renderer 失败，则保持源码显示。
+- 如果当前源码超出 size guard、显式 eligibility 返回 `false`，或 renderer 失败/超时/返回空白，则保持源码显示。
 - 缺少 renderer、optional peer 或 renderer setup failure 属于集成错误，不作为流式中间态吞掉。
 
 ## TVirtualMarkdown

--- a/docs/components.md
+++ b/docs/components.md
@@ -858,7 +858,7 @@ Markdown renderer for static or streaming text content。它走独立的 `parser
 >
 > 需要安装依赖后零配置使用内置 renderer 时，请从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 导入 `TMermaidText` / `TMermaid`。
 >
-> 内置 `beautiful-mermaid` bridge 默认只渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。基础组件不会做这个限制，自定义 renderer 可通过 `shouldRenderSource` 自行决定。
+> 从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 使用默认内置 renderer 时，只会渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。传入自定义 `renderer` 时不会自动套这个限制，仍可通过 `shouldRenderSource` 显式控制 eligibility。
 
 ## TMermaidText
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -858,7 +858,7 @@ Markdown renderer for static or streaming text content。它走独立的 `parser
 >
 > 需要安装依赖后零配置使用内置 renderer 时，请从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 导入 `TMermaidText` / `TMermaid`。
 >
-> 从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 使用默认内置 renderer 时，只会渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。传入自定义 `renderer` 时不会自动套这个限制，仍可通过 `shouldRenderSource` 显式控制 eligibility。
+> 默认只会渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。即使传入自定义 `renderer`，也默认套用这个限制；如果确实要渲染复杂 Mermaid source，请显式传入 `shouldRenderSource={() => true}`。
 
 ## TMermaidText
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -858,7 +858,7 @@ Markdown renderer for static or streaming text content。它走独立的 `parser
 >
 > 需要安装依赖后零配置使用内置 renderer 时，请从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 导入 `TMermaidText` / `TMermaid`。
 >
-> `@simon_he/vue-tui/mermaid` 和 `@simon_he/vue-tui/agent/mermaid` 的内置 beautiful-mermaid renderer 默认只会尝试渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。显式传入自定义 `renderer` 时，组件默认信任该 renderer；仍需跳过复杂 source 时，请传入 `shouldRenderSource`。
+> Mermaid 渲染默认只会尝试渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。即使显式传入自定义 `renderer`，也会沿用这个默认 eligibility。确实要让自定义 renderer 接管复杂 Mermaid 时，请传入 `shouldRenderSource={() => true}`。
 
 ## TMermaidText
 
@@ -929,7 +929,7 @@ const diagram = `graph TD
 - `ascii` `(boolean)`：使用纯 ASCII 而不是 Unicode box drawing
 - `options` `(TMermaidAsciiOptions?)`：传给 renderer 的 spacing/theme options；组件始终强制 `colorMode: "none"`
 - `renderer` `(TMermaidRenderer?)`：自定义 renderer，适合测试或替换 Mermaid engine
-- `shouldRenderSource` `(TMermaidRenderEligibility?)`：自定义 renderer eligibility；返回 `false` 时保持源码，不调用 renderer。基础组件不传时不会额外限制；内置 beautiful-mermaid bridge 默认使用 `isSimpleMermaidFlowchartSource`
+- `shouldRenderSource` `(TMermaidRenderEligibility?)`：自定义 renderer eligibility；不传时默认使用 `isSimpleMermaidFlowchartSource`；返回 `false` 时保持源码，不调用 renderer。确实要渲染复杂 Mermaid 时，可显式传入 `shouldRenderSource={() => true}`
 - `isTransientError` `(TMermaidTransientErrorClassifier?)`：自定义 renderer error 分类；`final=false` 时组件不调用 renderer，optional peer 缺失这类集成错误应该返回 `false`
 - `markMermaidRenderErrorFatal(error)`：从 `@simon_he/vue-tui/vue` 或 `@simon_he/vue-tui/agent` 导入，给自定义 renderer 标记缺依赖、renderer 初始化失败、wasm 加载失败等不应被当作 AI 中间态的 hard error
 - `streaming` `(boolean)`：streaming 更新时使用低优先级 frame task 合并重算

--- a/docs/components.md
+++ b/docs/components.md
@@ -858,9 +858,9 @@ Markdown renderer for static or streaming text content。它走独立的 `parser
 >
 > 需要安装依赖后零配置使用内置 renderer 时，请从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 导入 `TMermaidText` / `TMermaid`。
 >
-> `@simon_he/vue-tui/mermaid` / `@simon_he/vue-tui/agent/mermaid` 默认使用 size guard + simple-flowchart-only guard；`final=true` 后仅对简单 flowchart 尝试内置 `beautiful-mermaid` 渲染。renderer 成功时原子替换为渲染结果；复杂 Mermaid、大 Mermaid、renderer 失败、超时或返回空白时保持源码显示。
+> Mermaid 组件默认使用 size guard + simple-flowchart-only guard；`final=true` 后仅对简单 flowchart 尝试渲染。renderer 成功时原子替换为渲染结果；复杂 Mermaid、大 Mermaid、renderer 失败、超时或返回空白时保持源码显示。
 >
-> `@simon_he/vue-tui/vue` 和 `@simon_he/vue-tui/agent` 导出的 renderer-agnostic `TMermaidText` 不会默认套 simple-flowchart guard；传入自定义 `renderer` 后会在 `final=true` 时尝试渲染。需要跳过复杂 source 时传入 `shouldRenderSource={isSimpleMermaidFlowchartSource}`。
+> 需要显式让自定义 renderer 尝试复杂 Mermaid 时，传入 `shouldRenderSource={() => true}`。
 >
 > 注意：Markdown 里的 `mermaid` code fence 当前只保留 `code_block.language` metadata，尚未自动走 `TMermaidText` 的 async render/cache 路径。
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -927,7 +927,7 @@ const diagram = `graph TD
 - `x`/`y`/`w` `(number, required)`：渲染区域左上角与宽度
 - `h` `(number?)`：固定高度；不传时按渲染行数自适应
 - `content` / `code` `(string?)`：Mermaid source；同时传入时 `code` 优先
-- `final` `(boolean)`：Mermaid source 是否已经结束；`final=false` 时只显示 source，不调用 renderer；`final=true` 后才尝试渲染并在成功时原子替换 source
+- `final` `(boolean)`：Mermaid source 是否已经结束；`streaming=true && final=false` 时只显示 source，不调用 renderer；非 streaming 或 `final=true` 时才尝试渲染并在成功时原子替换 source
 - `ascii` `(boolean)`：使用纯 ASCII 而不是 Unicode box drawing
 - `options` `(TMermaidAsciiOptions?)`：传给 renderer 的 spacing/theme options；组件始终强制 `colorMode: "none"`
 - `renderer` `(TMermaidRenderer?)`：自定义 renderer，适合测试或替换 Mermaid engine
@@ -939,7 +939,7 @@ const diagram = `graph TD
 
 ### Streaming error policy
 
-AI 输出 Mermaid fence 时经常会先产生不完整源码。`final=false` 下组件只显示源码，不调用 renderer。`final=true` 后：
+AI 输出 Mermaid fence 时经常会先产生不完整源码。`streaming=true && final=false` 下组件只显示源码，不调用 renderer。非 streaming 或 `final=true` 后：
 
 - 如果当前源码通过 size guard 和 eligibility guard，且 renderer 成功，则显示渲染结果。
 - 如果当前源码是复杂 Mermaid、超出 size guard、显式 eligibility 返回 `false`，或 renderer 失败/超时/返回空白，则保持源码显示。

--- a/docs/components.md
+++ b/docs/components.md
@@ -858,7 +858,9 @@ Markdown renderer for static or streaming text content。它走独立的 `parser
 >
 > 需要安装依赖后零配置使用内置 renderer 时，请从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 导入 `TMermaidText` / `TMermaid`。
 >
-> 默认使用 size guard + simple-flowchart-only guard；`final=true` 后仅对简单 flowchart 尝试渲染。renderer 成功时原子替换为渲染结果；复杂 Mermaid、大 Mermaid、renderer 失败、超时、返回空白，或显式 `shouldRenderSource` 返回 `false` 时保持源码显示。需要强制尝试复杂 Mermaid 时，可显式传入 `shouldRenderSource={() => true}`。
+> `TMermaidText` 默认使用 size guard + simple-flowchart-only guard；`final=true` 后仅对简单 flowchart 尝试渲染。renderer 成功时原子替换为渲染结果；复杂 Mermaid、大 Mermaid、renderer 失败、超时、返回空白，或显式 `shouldRenderSource` 返回 `false` 时保持源码显示。需要强制尝试复杂 Mermaid 时，可显式传入 `shouldRenderSource={() => true}`。
+>
+> 注意：Markdown 里的 `mermaid` code fence 当前只保留 `code_block.language` metadata，尚未自动走 `TMermaidText` 的 async render/cache 路径。
 
 ## TMermaidText
 
@@ -930,8 +932,8 @@ const diagram = `graph TD
 - `options` `(TMermaidAsciiOptions?)`：传给 renderer 的 spacing/theme options；组件始终强制 `colorMode: "none"`
 - `renderer` `(TMermaidRenderer?)`：自定义 renderer，适合测试或替换 Mermaid engine
 - `shouldRenderSource` `(TMermaidRenderEligibility?)`：可选 renderer eligibility guard；返回 `false` 时保持源码，不调用 renderer。不传时默认使用 `isSimpleMermaidFlowchartSource`，即只尝试简单 flowchart。需要强制尝试复杂 Mermaid 时可传 `() => true`。
-- `isTransientError` `(TMermaidTransientErrorClassifier?)`：自定义 renderer error 分类；`final=false` 时组件不调用 renderer，optional peer 缺失这类集成错误应该返回 `false`
-- `markMermaidRenderErrorFatal(error)`：从 `@simon_he/vue-tui/vue` 或 `@simon_he/vue-tui/agent` 导入，给自定义 renderer 标记缺依赖、renderer 初始化失败、wasm 加载失败等不应被当作 AI 中间态的 hard error
+- `isTransientError` `(TMermaidTransientErrorClassifier?)`：保留的 renderer error 分类 prop；source-first 渲染失败/超时时保持源码显示，不再根据分类显示 `incompleteText` / `errorText`
+- `markMermaidRenderErrorFatal(error)`：从 `@simon_he/vue-tui/vue` 或 `@simon_he/vue-tui/agent` 导入；source-first 渲染失败时仍保持源码显示
 - `streaming` `(boolean)`：streaming 更新时使用低优先级 frame task 合并重算
 - `incompleteText` `(string)`：保留的文案 prop；当前渲染路径在未完成或失败时保持 source 显示
 
@@ -941,7 +943,7 @@ AI 输出 Mermaid fence 时经常会先产生不完整源码。`final=false` 下
 
 - 如果当前源码通过 size guard 和 eligibility guard，且 renderer 成功，则显示渲染结果。
 - 如果当前源码是复杂 Mermaid、超出 size guard、显式 eligibility 返回 `false`，或 renderer 失败/超时/返回空白，则保持源码显示。
-- 缺少 renderer、optional peer 或 renderer setup failure 属于集成错误，不作为流式中间态吞掉。
+- 缺少 renderer 时也保持源码显示，不显示 loading/error/incomplete 文案。
 
 ## TVirtualMarkdown
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -858,7 +858,9 @@ Markdown renderer for static or streaming text content。它走独立的 `parser
 >
 > 需要安装依赖后零配置使用内置 renderer 时，请从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 导入 `TMermaidText` / `TMermaid`。
 >
-> 默认只会渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。即使传入自定义 `renderer`，也默认套用这个限制；如果确实要渲染复杂 Mermaid source，请显式传入 `shouldRenderSource={() => true}`。
+> `@simon_he/vue-tui/mermaid` 和 `@simon_he/vue-tui/agent/mermaid` 的内置 `beautiful-mermaid` wrapper 默认只会渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。
+>
+> renderer-agnostic 的 `@simon_he/vue-tui/vue` / `@simon_he/vue-tui/agent` 版本在传入自定义 `renderer` 时不会默认套用 simple-flowchart 限制；需要限制时请显式传入 `shouldRenderSource={isSimpleMermaidFlowchartSource}`。
 
 ## TMermaidText
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -934,10 +934,11 @@ const diagram = `graph TD
 - `options` `(TMermaidAsciiOptions?)`：传给 renderer 的 spacing/theme options；组件始终强制 `colorMode: "none"`
 - `renderer` `(TMermaidRenderer?)`：自定义 renderer，适合测试或替换 Mermaid engine
 - `shouldRenderSource` `(TMermaidRenderEligibility?)`：可选 renderer eligibility guard；返回 `false` 时保持源码，不调用 renderer。primitive 不传时不额外限制；beautiful-mermaid wrapper 不传时默认使用 `isSimpleMermaidFlowchartSource`，即只尝试简单 flowchart。
-- `isTransientError` `(TMermaidTransientErrorClassifier?)`：保留的 renderer error 分类 prop；source-first 渲染失败/超时时保持源码显示，不再根据分类显示 `incompleteText` / `errorText`
+- `isTransientError` `(TMermaidTransientErrorClassifier?)`：source-first 兼容遗留 prop；当前不会影响显示，渲染失败/超时时始终保持 source 显示
 - `markMermaidRenderErrorFatal(error)`：从 `@simon_he/vue-tui/vue` 或 `@simon_he/vue-tui/agent` 导入；source-first 渲染失败时仍保持源码显示
 - `streaming` `(boolean)`：streaming 更新时使用低优先级 frame task 合并重算
-- `incompleteText` `(string)`：保留的文案 prop；当前渲染路径在未完成或失败时保持 source 显示
+- `loadingText` / `incompleteText` / `missingDependencyText` / `errorText` `(string)`：source-first 兼容遗留 prop；当前不会影响显示，失败/未完成时始终保持 source 显示
+- `showErrorDetails` `(boolean)`：source-first 兼容遗留 prop；当前渲染路径不会绘制错误详情
 
 ### Streaming error policy
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -858,7 +858,7 @@ Markdown renderer for static or streaming text content。它走独立的 `parser
 >
 > 需要安装依赖后零配置使用内置 renderer 时，请从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 导入 `TMermaidText` / `TMermaid`。
 >
-> 默认只做 size guard；`final=true` 后会把源码交给 renderer 尝试渲染。renderer 成功时原子替换为渲染结果；renderer 失败、超时、返回空白，或显式 `shouldRenderSource` 返回 `false` 时保持源码显示。需要 simple-flowchart-only 策略时，可显式传入 `shouldRenderSource={isSimpleMermaidFlowchartSource}`。
+> 默认使用 size guard + simple-flowchart-only guard；`final=true` 后仅对简单 flowchart 尝试渲染。renderer 成功时原子替换为渲染结果；复杂 Mermaid、大 Mermaid、renderer 失败、超时、返回空白，或显式 `shouldRenderSource` 返回 `false` 时保持源码显示。需要强制尝试复杂 Mermaid 时，可显式传入 `shouldRenderSource={() => true}`。
 
 ## TMermaidText
 
@@ -929,7 +929,7 @@ const diagram = `graph TD
 - `ascii` `(boolean)`：使用纯 ASCII 而不是 Unicode box drawing
 - `options` `(TMermaidAsciiOptions?)`：传给 renderer 的 spacing/theme options；组件始终强制 `colorMode: "none"`
 - `renderer` `(TMermaidRenderer?)`：自定义 renderer，适合测试或替换 Mermaid engine
-- `shouldRenderSource` `(TMermaidRenderEligibility?)`：可选 renderer eligibility guard；返回 `false` 时保持源码，不调用 renderer。不传时仅应用 size guard，并让 renderer 判断当前 Mermaid source 能否渲染。需要 simple-flowchart-only 策略时可传 `isSimpleMermaidFlowchartSource`。
+- `shouldRenderSource` `(TMermaidRenderEligibility?)`：可选 renderer eligibility guard；返回 `false` 时保持源码，不调用 renderer。不传时默认使用 `isSimpleMermaidFlowchartSource`，即只尝试简单 flowchart。需要强制尝试复杂 Mermaid 时可传 `() => true`。
 - `isTransientError` `(TMermaidTransientErrorClassifier?)`：自定义 renderer error 分类；`final=false` 时组件不调用 renderer，optional peer 缺失这类集成错误应该返回 `false`
 - `markMermaidRenderErrorFatal(error)`：从 `@simon_he/vue-tui/vue` 或 `@simon_he/vue-tui/agent` 导入，给自定义 renderer 标记缺依赖、renderer 初始化失败、wasm 加载失败等不应被当作 AI 中间态的 hard error
 - `streaming` `(boolean)`：streaming 更新时使用低优先级 frame task 合并重算
@@ -939,8 +939,8 @@ const diagram = `graph TD
 
 AI 输出 Mermaid fence 时经常会先产生不完整源码。`final=false` 下组件只显示源码，不调用 renderer。`final=true` 后：
 
-- 如果当前源码能渲染，则显示渲染结果。
-- 如果当前源码超出 size guard、显式 eligibility 返回 `false`，或 renderer 失败/超时/返回空白，则保持源码显示。
+- 如果当前源码通过 size guard 和 eligibility guard，且 renderer 成功，则显示渲染结果。
+- 如果当前源码是复杂 Mermaid、超出 size guard、显式 eligibility 返回 `false`，或 renderer 失败/超时/返回空白，则保持源码显示。
 - 缺少 renderer、optional peer 或 renderer setup failure 属于集成错误，不作为流式中间态吞掉。
 
 ## TVirtualMarkdown

--- a/docs/components.md
+++ b/docs/components.md
@@ -858,9 +858,9 @@ Markdown renderer for static or streaming text content。它走独立的 `parser
 >
 > 需要安装依赖后零配置使用内置 renderer 时，请从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 导入 `TMermaidText` / `TMermaid`。
 >
-> 内置 `beautiful-mermaid` wrapper 默认只会尝试渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。
+> `TMermaidText` 默认只会尝试渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。
 >
-> renderer-agnostic primitive 或显式自定义 renderer 默认不做语法 guard；如果想让自定义 renderer 也跳过复杂 Mermaid，请显式传入 `shouldRenderSource={isSimpleMermaidFlowchartSource}` 或自己的判定函数。
+> 显式自定义 renderer 也会走同一 eligibility guard；如果确实要让自定义 renderer 渲染复杂 Mermaid，请显式传入 `shouldRenderSource={() => true}` 或自己的判定函数。
 
 ## TMermaidText
 
@@ -919,7 +919,6 @@ const diagram = `graph TD
   :content="diagram"
   :streaming="message.streaming"
   :final="message.final"
-  incompleteText="waiting for complete diagram"
 />
 ```
 
@@ -928,24 +927,22 @@ const diagram = `graph TD
 - `x`/`y`/`w` `(number, required)`：渲染区域左上角与宽度
 - `h` `(number?)`：固定高度；不传时按渲染行数自适应
 - `content` / `code` `(string?)`：Mermaid source；同时传入时 `code` 优先
-- `final` `(boolean)`：AI 流式 Mermaid source 是否已经结束；`streaming=true && final=false` 时，渲染错误默认视为中间态，不会覆盖最后一次成功图
+- `final` `(boolean)`：Mermaid source 是否已经结束；`final=false` 时只显示 source，不调用 renderer；`final=true` 后才尝试渲染并在成功时原子替换 source
 - `ascii` `(boolean)`：使用纯 ASCII 而不是 Unicode box drawing
 - `options` `(TMermaidAsciiOptions?)`：传给 renderer 的 spacing/theme options；组件始终强制 `colorMode: "none"`
 - `renderer` `(TMermaidRenderer?)`：自定义 renderer，适合测试或替换 Mermaid engine
-- `shouldRenderSource` `(TMermaidRenderEligibility?)`：自定义 renderer eligibility；返回 `false` 时保持源码，不调用 renderer。内置 `beautiful-mermaid` wrapper 默认使用 `isSimpleMermaidFlowchartSource`
-- `isTransientError` `(TMermaidTransientErrorClassifier?)`：自定义哪些 renderer error 可以在 `final=false` 时被忽略；optional peer 缺失这类集成错误应该返回 `false`
+- `shouldRenderSource` `(TMermaidRenderEligibility?)`：自定义 renderer eligibility；返回 `false` 时保持源码，不调用 renderer。默认使用 `isSimpleMermaidFlowchartSource`
+- `isTransientError` `(TMermaidTransientErrorClassifier?)`：自定义 renderer error 分类；`final=false` 时组件不调用 renderer，optional peer 缺失这类集成错误应该返回 `false`
 - `markMermaidRenderErrorFatal(error)`：从 `@simon_he/vue-tui/vue` 或 `@simon_he/vue-tui/agent` 导入，给自定义 renderer 标记缺依赖、renderer 初始化失败、wasm 加载失败等不应被当作 AI 中间态的 hard error
 - `streaming` `(boolean)`：streaming 更新时使用低优先级 frame task 合并重算
-- `incompleteText` `(string)`：流式中间态且还没有任何成功渲染时显示的占位文本
+- `incompleteText` `(string)`：保留的文案 prop；当前渲染路径在未完成或失败时保持 source 显示
 
 ### Streaming error policy
 
-AI 输出 Mermaid fence 时经常会先产生不完整源码。`streaming=true && final=false` 下：
+AI 输出 Mermaid fence 时经常会先产生不完整源码。`final=false` 下组件只显示源码，不调用 renderer。`final=true` 后：
 
-- 如果当前源码能渲染，则立即显示并缓存为最后一次成功图。
-- 如果当前源码暂时不能渲染，但之前有成功图，则继续显示最后一次成功图。
-- 如果当前源码暂时不能渲染，且之前没有成功图，则显示 `incompleteText`。
-- 当 `final=true` 后仍然渲染失败，才显示 `errorText` 和错误详情。
+- 如果当前源码能渲染，则显示渲染结果。
+- 如果当前源码不符合默认 eligibility、超出 size guard，或 renderer 失败，则保持源码显示。
 - 缺少 renderer、optional peer 或 renderer setup failure 属于集成错误，不作为流式中间态吞掉。
 
 ## TVirtualMarkdown

--- a/docs/components.md
+++ b/docs/components.md
@@ -858,9 +858,7 @@ Markdown renderer for static or streaming text content。它走独立的 `parser
 >
 > 需要安装依赖后零配置使用内置 renderer 时，请从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 导入 `TMermaidText` / `TMermaid`。
 >
-> 从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 导入并使用内置 `beautiful-mermaid` renderer 时，`TMermaidText` 默认只会尝试渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。
->
-> 从 renderer-agnostic entry 导入或显式传入自定义 renderer 时，默认不会套用 simple-flowchart eligibility guard；需要限制渲染范围时，请传入 `shouldRenderSource`。
+> 所有 `TMermaidText` entry 默认只会尝试渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。确实需要渲染复杂 Mermaid 时，请显式传入 `shouldRenderSource: () => true` 或自定义 eligibility。
 
 ## TMermaidText
 
@@ -931,7 +929,7 @@ const diagram = `graph TD
 - `ascii` `(boolean)`：使用纯 ASCII 而不是 Unicode box drawing
 - `options` `(TMermaidAsciiOptions?)`：传给 renderer 的 spacing/theme options；组件始终强制 `colorMode: "none"`
 - `renderer` `(TMermaidRenderer?)`：自定义 renderer，适合测试或替换 Mermaid engine
-- `shouldRenderSource` `(TMermaidRenderEligibility?)`：自定义 renderer eligibility；返回 `false` 时保持源码，不调用 renderer。renderer-agnostic entry 默认为不限制；内置 `beautiful-mermaid` renderer 默认使用 `isSimpleMermaidFlowchartSource`
+- `shouldRenderSource` `(TMermaidRenderEligibility?)`：自定义 renderer eligibility；返回 `false` 时保持源码，不调用 renderer。默认使用 `isSimpleMermaidFlowchartSource`，即只渲染 simple flowchart
 - `isTransientError` `(TMermaidTransientErrorClassifier?)`：自定义 renderer error 分类；`final=false` 时组件不调用 renderer，optional peer 缺失这类集成错误应该返回 `false`
 - `markMermaidRenderErrorFatal(error)`：从 `@simon_he/vue-tui/vue` 或 `@simon_he/vue-tui/agent` 导入，给自定义 renderer 标记缺依赖、renderer 初始化失败、wasm 加载失败等不应被当作 AI 中间态的 hard error
 - `streaming` `(boolean)`：streaming 更新时使用低优先级 frame task 合并重算

--- a/docs/components.md
+++ b/docs/components.md
@@ -858,9 +858,9 @@ Markdown renderer for static or streaming text content。它走独立的 `parser
 >
 > 需要安装依赖后零配置使用内置 renderer 时，请从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 导入 `TMermaidText` / `TMermaid`。
 >
-> `TMermaidText` 默认只会尝试渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。
+> 从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 导入并使用内置 `beautiful-mermaid` renderer 时，`TMermaidText` 默认只会尝试渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。
 >
-> 显式自定义 renderer 也会走同一 eligibility guard；如果确实要让自定义 renderer 渲染复杂 Mermaid，请显式传入 `shouldRenderSource={() => true}` 或自己的判定函数。
+> 从 renderer-agnostic entry 导入或显式传入自定义 renderer 时，默认不会套用 simple-flowchart eligibility guard；需要限制渲染范围时，请传入 `shouldRenderSource`。
 
 ## TMermaidText
 
@@ -931,7 +931,7 @@ const diagram = `graph TD
 - `ascii` `(boolean)`：使用纯 ASCII 而不是 Unicode box drawing
 - `options` `(TMermaidAsciiOptions?)`：传给 renderer 的 spacing/theme options；组件始终强制 `colorMode: "none"`
 - `renderer` `(TMermaidRenderer?)`：自定义 renderer，适合测试或替换 Mermaid engine
-- `shouldRenderSource` `(TMermaidRenderEligibility?)`：自定义 renderer eligibility；返回 `false` 时保持源码，不调用 renderer。默认使用 `isSimpleMermaidFlowchartSource`
+- `shouldRenderSource` `(TMermaidRenderEligibility?)`：自定义 renderer eligibility；返回 `false` 时保持源码，不调用 renderer。renderer-agnostic entry 默认为不限制；内置 `beautiful-mermaid` renderer 默认使用 `isSimpleMermaidFlowchartSource`
 - `isTransientError` `(TMermaidTransientErrorClassifier?)`：自定义 renderer error 分类；`final=false` 时组件不调用 renderer，optional peer 缺失这类集成错误应该返回 `false`
 - `markMermaidRenderErrorFatal(error)`：从 `@simon_he/vue-tui/vue` 或 `@simon_he/vue-tui/agent` 导入，给自定义 renderer 标记缺依赖、renderer 初始化失败、wasm 加载失败等不应被当作 AI 中间态的 hard error
 - `streaming` `(boolean)`：streaming 更新时使用低优先级 frame task 合并重算

--- a/docs/components.md
+++ b/docs/components.md
@@ -858,7 +858,9 @@ Markdown renderer for static or streaming text content。它走独立的 `parser
 >
 > 需要安装依赖后零配置使用内置 renderer 时，请从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 导入 `TMermaidText` / `TMermaid`。
 >
-> `TMermaidText` 默认使用 size guard + simple-flowchart-only guard；`final=true` 后仅对简单 flowchart 尝试渲染。renderer 成功时原子替换为渲染结果；复杂 Mermaid、大 Mermaid、renderer 失败、超时、返回空白，或显式 `shouldRenderSource` 返回 `false` 时保持源码显示。需要强制尝试复杂 Mermaid 时，可显式传入 `shouldRenderSource={() => true}`。
+> `@simon_he/vue-tui/mermaid` / `@simon_he/vue-tui/agent/mermaid` 默认使用 size guard + simple-flowchart-only guard；`final=true` 后仅对简单 flowchart 尝试内置 `beautiful-mermaid` 渲染。renderer 成功时原子替换为渲染结果；复杂 Mermaid、大 Mermaid、renderer 失败、超时或返回空白时保持源码显示。
+>
+> `@simon_he/vue-tui/vue` 和 `@simon_he/vue-tui/agent` 导出的 renderer-agnostic `TMermaidText` 不会默认套 simple-flowchart guard；传入自定义 `renderer` 后会在 `final=true` 时尝试渲染。需要跳过复杂 source 时传入 `shouldRenderSource={isSimpleMermaidFlowchartSource}`。
 >
 > 注意：Markdown 里的 `mermaid` code fence 当前只保留 `code_block.language` metadata，尚未自动走 `TMermaidText` 的 async render/cache 路径。
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -858,7 +858,7 @@ Markdown renderer for static or streaming text content。它走独立的 `parser
 >
 > 需要安装依赖后零配置使用内置 renderer 时，请从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 导入 `TMermaidText` / `TMermaid`。
 >
-> 从 `@simon_he/vue-tui/mermaid` / `@simon_he/vue-tui/agent/mermaid` 使用内置 `beautiful-mermaid` renderer 时，默认只会尝试渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。显式传入自定义 `renderer` 时，组件默认信任该 renderer，并在 `final=true` 后尝试渲染；需要跳过复杂 Mermaid 时，请传入 `shouldRenderSource={isSimpleMermaidFlowchartSource}` 或自定义 guard。
+> 默认只会尝试渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。显式传入自定义 `renderer` 时也遵循同一个默认 guard；如果确实要让自定义 renderer 接管复杂 Mermaid，请传入 `shouldRenderSource={() => true}` 或更精细的自定义 guard。
 
 ## TMermaidText
 
@@ -929,7 +929,7 @@ const diagram = `graph TD
 - `ascii` `(boolean)`：使用纯 ASCII 而不是 Unicode box drawing
 - `options` `(TMermaidAsciiOptions?)`：传给 renderer 的 spacing/theme options；组件始终强制 `colorMode: "none"`
 - `renderer` `(TMermaidRenderer?)`：自定义 renderer，适合测试或替换 Mermaid engine
-- `shouldRenderSource` `(TMermaidRenderEligibility?)`：自定义 renderer eligibility；返回 `false` 时保持源码，不调用 renderer。内置 `beautiful-mermaid` bridge 不传自定义 `renderer` 时默认使用 `isSimpleMermaidFlowchartSource`。
+- `shouldRenderSource` `(TMermaidRenderEligibility?)`：自定义 renderer eligibility；返回 `false` 时保持源码，不调用 renderer。默认使用 `isSimpleMermaidFlowchartSource`，所以复杂 Mermaid 默认保持源码；需要强制渲染时可传 `() => true`。
 - `isTransientError` `(TMermaidTransientErrorClassifier?)`：自定义 renderer error 分类；`final=false` 时组件不调用 renderer，optional peer 缺失这类集成错误应该返回 `false`
 - `markMermaidRenderErrorFatal(error)`：从 `@simon_he/vue-tui/vue` 或 `@simon_he/vue-tui/agent` 导入，给自定义 renderer 标记缺依赖、renderer 初始化失败、wasm 加载失败等不应被当作 AI 中间态的 hard error
 - `streaming` `(boolean)`：streaming 更新时使用低优先级 frame task 合并重算

--- a/docs/components.md
+++ b/docs/components.md
@@ -857,6 +857,8 @@ Markdown renderer for static or streaming text content。它走独立的 `parser
 > 注意：`@simon_he/vue-tui/vue` 和 `@simon_he/vue-tui/agent` 导出的 `TMermaidText` 是 renderer-agnostic primitive，不会自动 import `beautiful-mermaid`。
 >
 > 需要安装依赖后零配置使用内置 renderer 时，请从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 导入 `TMermaidText` / `TMermaid`。
+>
+> 内置 `beautiful-mermaid` bridge 默认只渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。基础组件不会做这个限制，自定义 renderer 可通过 `shouldRenderSource` 自行决定。
 
 ## TMermaidText
 
@@ -928,6 +930,7 @@ const diagram = `graph TD
 - `ascii` `(boolean)`：使用纯 ASCII 而不是 Unicode box drawing
 - `options` `(TMermaidAsciiOptions?)`：传给 renderer 的 spacing/theme options；组件始终强制 `colorMode: "none"`
 - `renderer` `(TMermaidRenderer?)`：自定义 renderer，适合测试或替换 Mermaid engine
+- `shouldRenderSource` `(TMermaidRenderEligibility?)`：自定义 renderer eligibility；返回 `false` 时保持源码，不调用 renderer
 - `isTransientError` `(TMermaidTransientErrorClassifier?)`：自定义哪些 renderer error 可以在 `final=false` 时被忽略；optional peer 缺失这类集成错误应该返回 `false`
 - `markMermaidRenderErrorFatal(error)`：从 `@simon_he/vue-tui/vue` 或 `@simon_he/vue-tui/agent` 导入，给自定义 renderer 标记缺依赖、renderer 初始化失败、wasm 加载失败等不应被当作 AI 中间态的 hard error
 - `streaming` `(boolean)`：streaming 更新时使用低优先级 frame task 合并重算

--- a/docs/components.md
+++ b/docs/components.md
@@ -858,7 +858,7 @@ Markdown renderer for static or streaming text content。它走独立的 `parser
 >
 > 需要安装依赖后零配置使用内置 renderer 时，请从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 导入 `TMermaidText` / `TMermaid`。
 >
-> Mermaid 渲染默认只会尝试渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。即使显式传入自定义 `renderer`，也会沿用这个默认 eligibility。确实要让自定义 renderer 接管复杂 Mermaid 时，请传入 `shouldRenderSource={() => true}`。
+> 从 `@simon_he/vue-tui/mermaid` / `@simon_he/vue-tui/agent/mermaid` 使用内置 `beautiful-mermaid` renderer 时，默认只会尝试渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。显式传入自定义 `renderer` 时，组件默认信任该 renderer，并在 `final=true` 后尝试渲染；需要跳过复杂 Mermaid 时，请传入 `shouldRenderSource={isSimpleMermaidFlowchartSource}` 或自定义 guard。
 
 ## TMermaidText
 
@@ -929,7 +929,7 @@ const diagram = `graph TD
 - `ascii` `(boolean)`：使用纯 ASCII 而不是 Unicode box drawing
 - `options` `(TMermaidAsciiOptions?)`：传给 renderer 的 spacing/theme options；组件始终强制 `colorMode: "none"`
 - `renderer` `(TMermaidRenderer?)`：自定义 renderer，适合测试或替换 Mermaid engine
-- `shouldRenderSource` `(TMermaidRenderEligibility?)`：自定义 renderer eligibility；不传时默认使用 `isSimpleMermaidFlowchartSource`；返回 `false` 时保持源码，不调用 renderer。确实要渲染复杂 Mermaid 时，可显式传入 `shouldRenderSource={() => true}`
+- `shouldRenderSource` `(TMermaidRenderEligibility?)`：自定义 renderer eligibility；返回 `false` 时保持源码，不调用 renderer。内置 `beautiful-mermaid` bridge 不传自定义 `renderer` 时默认使用 `isSimpleMermaidFlowchartSource`。
 - `isTransientError` `(TMermaidTransientErrorClassifier?)`：自定义 renderer error 分类；`final=false` 时组件不调用 renderer，optional peer 缺失这类集成错误应该返回 `false`
 - `markMermaidRenderErrorFatal(error)`：从 `@simon_he/vue-tui/vue` 或 `@simon_he/vue-tui/agent` 导入，给自定义 renderer 标记缺依赖、renderer 初始化失败、wasm 加载失败等不应被当作 AI 中间态的 hard error
 - `streaming` `(boolean)`：streaming 更新时使用低优先级 frame task 合并重算
@@ -940,7 +940,7 @@ const diagram = `graph TD
 AI 输出 Mermaid fence 时经常会先产生不完整源码。`final=false` 下组件只显示源码，不调用 renderer。`final=true` 后：
 
 - 如果当前源码能渲染，则显示渲染结果。
-- 如果当前源码不符合默认 eligibility、超出 size guard，或 renderer 失败，则保持源码显示。
+- 如果当前源码不符合传入的 eligibility、超出 size guard，或 renderer 失败，则保持源码显示。
 - 缺少 renderer、optional peer 或 renderer setup failure 属于集成错误，不作为流式中间态吞掉。
 
 ## TVirtualMarkdown

--- a/docs/components.md
+++ b/docs/components.md
@@ -858,9 +858,9 @@ Markdown renderer for static or streaming text content。它走独立的 `parser
 >
 > 需要安装依赖后零配置使用内置 renderer 时，请从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 导入 `TMermaidText` / `TMermaid`。
 >
-> `@simon_he/vue-tui/mermaid` 和 `@simon_he/vue-tui/agent/mermaid` 的内置 `beautiful-mermaid` wrapper 默认只会渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。
+> 默认所有 `TMermaidText` / `TMermaid` 都只会渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。
 >
-> renderer-agnostic 的 `@simon_he/vue-tui/vue` / `@simon_he/vue-tui/agent` 版本在传入自定义 `renderer` 时不会默认套用 simple-flowchart 限制；需要限制时请显式传入 `shouldRenderSource={isSimpleMermaidFlowchartSource}`。
+> 如果你明确要用自定义 renderer 渲染复杂 Mermaid，请显式传入 `shouldRenderSource={() => true}`；如果只想调整判定规则，请传入自己的 `shouldRenderSource`。
 
 ## TMermaidText
 
@@ -932,7 +932,7 @@ const diagram = `graph TD
 - `ascii` `(boolean)`：使用纯 ASCII 而不是 Unicode box drawing
 - `options` `(TMermaidAsciiOptions?)`：传给 renderer 的 spacing/theme options；组件始终强制 `colorMode: "none"`
 - `renderer` `(TMermaidRenderer?)`：自定义 renderer，适合测试或替换 Mermaid engine
-- `shouldRenderSource` `(TMermaidRenderEligibility?)`：自定义 renderer eligibility；返回 `false` 时保持源码，不调用 renderer
+- `shouldRenderSource` `(TMermaidRenderEligibility?)`：自定义 renderer eligibility，默认只允许 simple flowchart；返回 `false` 时保持源码，不调用 renderer
 - `isTransientError` `(TMermaidTransientErrorClassifier?)`：自定义哪些 renderer error 可以在 `final=false` 时被忽略；optional peer 缺失这类集成错误应该返回 `false`
 - `markMermaidRenderErrorFatal(error)`：从 `@simon_he/vue-tui/vue` 或 `@simon_he/vue-tui/agent` 导入，给自定义 renderer 标记缺依赖、renderer 初始化失败、wasm 加载失败等不应被当作 AI 中间态的 hard error
 - `streaming` `(boolean)`：streaming 更新时使用低优先级 frame task 合并重算

--- a/docs/components.md
+++ b/docs/components.md
@@ -858,9 +858,9 @@ Markdown renderer for static or streaming text content。它走独立的 `parser
 >
 > 需要安装依赖后零配置使用内置 renderer 时，请从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 导入 `TMermaidText` / `TMermaid`。
 >
-> 默认所有 `TMermaidText` / `TMermaid` 都只会渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。
+> 内置 `beautiful-mermaid` wrapper 默认只会尝试渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。
 >
-> 如果你明确要用自定义 renderer 渲染复杂 Mermaid，请显式传入 `shouldRenderSource={() => true}`；如果只想调整判定规则，请传入自己的 `shouldRenderSource`。
+> renderer-agnostic primitive 或显式自定义 renderer 默认不做语法 guard；如果想让自定义 renderer 也跳过复杂 Mermaid，请显式传入 `shouldRenderSource={isSimpleMermaidFlowchartSource}` 或自己的判定函数。
 
 ## TMermaidText
 
@@ -932,7 +932,7 @@ const diagram = `graph TD
 - `ascii` `(boolean)`：使用纯 ASCII 而不是 Unicode box drawing
 - `options` `(TMermaidAsciiOptions?)`：传给 renderer 的 spacing/theme options；组件始终强制 `colorMode: "none"`
 - `renderer` `(TMermaidRenderer?)`：自定义 renderer，适合测试或替换 Mermaid engine
-- `shouldRenderSource` `(TMermaidRenderEligibility?)`：自定义 renderer eligibility，默认只允许 simple flowchart；返回 `false` 时保持源码，不调用 renderer
+- `shouldRenderSource` `(TMermaidRenderEligibility?)`：自定义 renderer eligibility；返回 `false` 时保持源码，不调用 renderer。内置 `beautiful-mermaid` wrapper 默认使用 `isSimpleMermaidFlowchartSource`
 - `isTransientError` `(TMermaidTransientErrorClassifier?)`：自定义哪些 renderer error 可以在 `final=false` 时被忽略；optional peer 缺失这类集成错误应该返回 `false`
 - `markMermaidRenderErrorFatal(error)`：从 `@simon_he/vue-tui/vue` 或 `@simon_he/vue-tui/agent` 导入，给自定义 renderer 标记缺依赖、renderer 初始化失败、wasm 加载失败等不应被当作 AI 中间态的 hard error
 - `streaming` `(boolean)`：streaming 更新时使用低优先级 frame task 合并重算

--- a/docs/components.md
+++ b/docs/components.md
@@ -858,7 +858,7 @@ Markdown renderer for static or streaming text content。它走独立的 `parser
 >
 > 需要安装依赖后零配置使用内置 renderer 时，请从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 导入 `TMermaidText` / `TMermaid`。
 >
-> 所有 `TMermaidText` entry 默认只会尝试渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。确实需要渲染复杂 Mermaid 时，请显式传入 `shouldRenderSource: () => true` 或自定义 eligibility。
+> `@simon_he/vue-tui/mermaid` 和 `@simon_he/vue-tui/agent/mermaid` 的内置 beautiful-mermaid renderer 默认只会尝试渲染 `isSimpleMermaidFlowchartSource()` 接受的 simple flowchart；其他 Mermaid source 会保持源码显示。显式传入自定义 `renderer` 时，组件默认信任该 renderer；仍需跳过复杂 source 时，请传入 `shouldRenderSource`。
 
 ## TMermaidText
 
@@ -929,7 +929,7 @@ const diagram = `graph TD
 - `ascii` `(boolean)`：使用纯 ASCII 而不是 Unicode box drawing
 - `options` `(TMermaidAsciiOptions?)`：传给 renderer 的 spacing/theme options；组件始终强制 `colorMode: "none"`
 - `renderer` `(TMermaidRenderer?)`：自定义 renderer，适合测试或替换 Mermaid engine
-- `shouldRenderSource` `(TMermaidRenderEligibility?)`：自定义 renderer eligibility；返回 `false` 时保持源码，不调用 renderer。默认使用 `isSimpleMermaidFlowchartSource`，即只渲染 simple flowchart
+- `shouldRenderSource` `(TMermaidRenderEligibility?)`：自定义 renderer eligibility；返回 `false` 时保持源码，不调用 renderer。基础组件不传时不会额外限制；内置 beautiful-mermaid bridge 默认使用 `isSimpleMermaidFlowchartSource`
 - `isTransientError` `(TMermaidTransientErrorClassifier?)`：自定义 renderer error 分类；`final=false` 时组件不调用 renderer，optional peer 缺失这类集成错误应该返回 `false`
 - `markMermaidRenderErrorFatal(error)`：从 `@simon_he/vue-tui/vue` 或 `@simon_he/vue-tui/agent` 导入，给自定义 renderer 标记缺依赖、renderer 初始化失败、wasm 加载失败等不应被当作 AI 中间态的 hard error
 - `streaming` `(boolean)`：streaming 更新时使用低优先级 frame task 合并重算

--- a/docs/generated/api-manifest.json
+++ b/docs/generated/api-manifest.json
@@ -5882,7 +5882,7 @@
           "name": "shouldRenderSource",
           "type": "TMermaidRenderEligibility",
           "required": false,
-          "defaultValue": "undefined"
+          "defaultValue": "isSimpleMermaidFlowchartSource"
         },
         {
           "name": "loadingText",
@@ -6101,7 +6101,7 @@
           "name": "shouldRenderSource",
           "type": "TMermaidRenderEligibility",
           "required": false,
-          "defaultValue": "undefined"
+          "defaultValue": "isSimpleMermaidFlowchartSource"
         },
         {
           "name": "loadingText",

--- a/docs/generated/api-manifest.json
+++ b/docs/generated/api-manifest.json
@@ -242,6 +242,7 @@
         "TLogViewVisualIndexStatus",
         "TMermaidAsciiOptions",
         "TMermaidAsciiTheme",
+        "TMermaidCopyPayload",
         "TMermaidRenderer",
         "TMermaidResolvedAsciiOptions",
         "TMermaidTextProps",
@@ -303,6 +304,7 @@
       "typeExports": [
         "TMermaidAsciiOptions",
         "TMermaidAsciiTheme",
+        "TMermaidCopyPayload",
         "TMermaidRenderer",
         "TMermaidResolvedAsciiOptions",
         "TMermaidTextProps",
@@ -650,6 +652,7 @@
       "typeExports": [
         "TMermaidAsciiOptions",
         "TMermaidAsciiTheme",
+        "TMermaidCopyPayload",
         "TMermaidRenderer",
         "TMermaidResolvedAsciiOptions",
         "TMermaidTextProps",
@@ -883,6 +886,7 @@
         "TLinkifySegment",
         "TMermaidAsciiOptions",
         "TMermaidAsciiTheme",
+        "TMermaidCopyPayload",
         "TMermaidRenderer",
         "TMermaidResolvedAsciiOptions",
         "TMermaidTextProps",
@@ -5892,9 +5896,44 @@
           "type": "boolean",
           "required": false,
           "defaultValue": "true"
+        },
+        {
+          "name": "box",
+          "type": "boolean",
+          "required": false,
+          "defaultValue": "true"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "required": false,
+          "defaultValue": "\"mermaid\""
+        },
+        {
+          "name": "copyButton",
+          "type": "boolean",
+          "required": false,
+          "defaultValue": "true"
+        },
+        {
+          "name": "copyText",
+          "type": "string",
+          "required": false,
+          "defaultValue": "\"copy\""
+        },
+        {
+          "name": "copiedText",
+          "type": "string",
+          "required": false,
+          "defaultValue": "\"copied\""
         }
       ],
-      "events": []
+      "events": [
+        {
+          "name": "copy",
+          "payload": "TMermaidCopyPayload"
+        }
+      ]
     },
     "TMermaidText": {
       "entrypoint": "@simon_he/vue-tui/vue",
@@ -6046,9 +6085,44 @@
           "type": "boolean",
           "required": false,
           "defaultValue": "true"
+        },
+        {
+          "name": "box",
+          "type": "boolean",
+          "required": false,
+          "defaultValue": "true"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "required": false,
+          "defaultValue": "\"mermaid\""
+        },
+        {
+          "name": "copyButton",
+          "type": "boolean",
+          "required": false,
+          "defaultValue": "true"
+        },
+        {
+          "name": "copyText",
+          "type": "string",
+          "required": false,
+          "defaultValue": "\"copy\""
+        },
+        {
+          "name": "copiedText",
+          "type": "string",
+          "required": false,
+          "defaultValue": "\"copied\""
         }
       ],
-      "events": []
+      "events": [
+        {
+          "name": "copy",
+          "payload": "TMermaidCopyPayload"
+        }
+      ]
     },
     "TMultilineModal": {
       "entrypoint": "@simon_he/vue-tui/vue",

--- a/docs/generated/api-manifest.json
+++ b/docs/generated/api-manifest.json
@@ -5926,6 +5926,30 @@
           "type": "string",
           "required": false,
           "defaultValue": "\"copied\""
+        },
+        {
+          "name": "renderTimeoutMs",
+          "type": "number",
+          "required": false,
+          "defaultValue": "DEFAULT_MERMAID_RENDER_TIMEOUT_MS"
+        },
+        {
+          "name": "maxRenderSourceChars",
+          "type": "number",
+          "required": false,
+          "defaultValue": "DEFAULT_MERMAID_MAX_RENDER_SOURCE_CHARS"
+        },
+        {
+          "name": "maxRenderSourceLines",
+          "type": "number",
+          "required": false,
+          "defaultValue": "DEFAULT_MERMAID_MAX_RENDER_SOURCE_LINES"
+        },
+        {
+          "name": "copiedDurationMs",
+          "type": "number",
+          "required": false,
+          "defaultValue": "DEFAULT_MERMAID_COPIED_DURATION_MS"
         }
       ],
       "events": [
@@ -6115,6 +6139,30 @@
           "type": "string",
           "required": false,
           "defaultValue": "\"copied\""
+        },
+        {
+          "name": "renderTimeoutMs",
+          "type": "number",
+          "required": false,
+          "defaultValue": "DEFAULT_MERMAID_RENDER_TIMEOUT_MS"
+        },
+        {
+          "name": "maxRenderSourceChars",
+          "type": "number",
+          "required": false,
+          "defaultValue": "DEFAULT_MERMAID_MAX_RENDER_SOURCE_CHARS"
+        },
+        {
+          "name": "maxRenderSourceLines",
+          "type": "number",
+          "required": false,
+          "defaultValue": "DEFAULT_MERMAID_MAX_RENDER_SOURCE_LINES"
+        },
+        {
+          "name": "copiedDurationMs",
+          "type": "number",
+          "required": false,
+          "defaultValue": "DEFAULT_MERMAID_COPIED_DURATION_MS"
         }
       ],
       "events": [

--- a/docs/generated/api-manifest.json
+++ b/docs/generated/api-manifest.json
@@ -5882,7 +5882,7 @@
           "name": "shouldRenderSource",
           "type": "TMermaidRenderEligibility",
           "required": false,
-          "defaultValue": "isSimpleMermaidFlowchartSource"
+          "defaultValue": "undefined"
         },
         {
           "name": "loadingText",
@@ -6101,7 +6101,7 @@
           "name": "shouldRenderSource",
           "type": "TMermaidRenderEligibility",
           "required": false,
-          "defaultValue": "isSimpleMermaidFlowchartSource"
+          "defaultValue": "undefined"
         },
         {
           "name": "loadingText",

--- a/docs/generated/api-manifest.json
+++ b/docs/generated/api-manifest.json
@@ -151,6 +151,7 @@
         "detectTerminalGraphicsCapabilities",
         "dispatchTLogPluginLinkAction",
         "getTLogPluginMetadata",
+        "isSimpleMermaidFlowchartSource",
         "markMermaidRenderErrorFatal",
         "parseTLogAnnotatedText",
         "resolveTLogLinksPanelTheme",

--- a/docs/generated/api-manifest.json
+++ b/docs/generated/api-manifest.json
@@ -243,6 +243,8 @@
         "TMermaidAsciiOptions",
         "TMermaidAsciiTheme",
         "TMermaidCopyPayload",
+        "TMermaidRenderEligibility",
+        "TMermaidRenderEligibilityContext",
         "TMermaidRenderer",
         "TMermaidResolvedAsciiOptions",
         "TMermaidTextProps",
@@ -299,12 +301,15 @@
         "TMermaidText",
         "beautifulMermaidRenderer",
         "createBeautifulMermaidRenderer",
+        "isSimpleMermaidFlowchartSource",
         "markMermaidRenderErrorFatal"
       ],
       "typeExports": [
         "TMermaidAsciiOptions",
         "TMermaidAsciiTheme",
         "TMermaidCopyPayload",
+        "TMermaidRenderEligibility",
+        "TMermaidRenderEligibilityContext",
         "TMermaidRenderer",
         "TMermaidResolvedAsciiOptions",
         "TMermaidTextProps",
@@ -647,12 +652,15 @@
         "TMermaidText",
         "beautifulMermaidRenderer",
         "createBeautifulMermaidRenderer",
+        "isSimpleMermaidFlowchartSource",
         "markMermaidRenderErrorFatal"
       ],
       "typeExports": [
         "TMermaidAsciiOptions",
         "TMermaidAsciiTheme",
         "TMermaidCopyPayload",
+        "TMermaidRenderEligibility",
+        "TMermaidRenderEligibilityContext",
         "TMermaidRenderer",
         "TMermaidResolvedAsciiOptions",
         "TMermaidTextProps",
@@ -815,6 +823,7 @@
         "createTerminalRouter",
         "createTextRestrictionPlugin",
         "createTheme",
+        "isSimpleMermaidFlowchartSource",
         "linkifyTextSegments",
         "lintJsonText",
         "markMermaidRenderErrorFatal",
@@ -887,6 +896,8 @@
         "TMermaidAsciiOptions",
         "TMermaidAsciiTheme",
         "TMermaidCopyPayload",
+        "TMermaidRenderEligibility",
+        "TMermaidRenderEligibilityContext",
         "TMermaidRenderer",
         "TMermaidResolvedAsciiOptions",
         "TMermaidTextProps",
@@ -5868,6 +5879,12 @@
           "defaultValue": "undefined"
         },
         {
+          "name": "shouldRenderSource",
+          "type": "TMermaidRenderEligibility",
+          "required": false,
+          "defaultValue": "undefined"
+        },
+        {
           "name": "loadingText",
           "type": "string",
           "required": false,
@@ -6077,6 +6094,12 @@
         {
           "name": "isTransientError",
           "type": "TMermaidTransientErrorClassifier",
+          "required": false,
+          "defaultValue": "undefined"
+        },
+        {
+          "name": "shouldRenderSource",
+          "type": "TMermaidRenderEligibility",
           "required": false,
           "defaultValue": "undefined"
         },

--- a/docs/generated/components-api.md
+++ b/docs/generated/components-api.md
@@ -1466,10 +1466,17 @@ Import: `@simon_he/vue-tui/vue`
 | <code>missingDependencyText</code> | <code>string</code>                           | <code>&quot;Install the Mermaid renderer package and use TMermaidText from @simon_he/vue...</code> | 否   | —    |
 | <code>errorText</code>             | <code>string</code>                           | <code>&quot;Mermaid render failed&quot;</code>                                                     | 否   | —    |
 | <code>showErrorDetails</code>      | <code>boolean</code>                          | <code>true</code>                                                                                  | 否   | —    |
+| <code>box</code>                   | <code>boolean</code>                          | <code>true</code>                                                                                  | 否   | —    |
+| <code>title</code>                 | <code>string</code>                           | <code>&quot;mermaid&quot;</code>                                                                   | 否   | —    |
+| <code>copyButton</code>            | <code>boolean</code>                          | <code>true</code>                                                                                  | 否   | —    |
+| <code>copyText</code>              | <code>string</code>                           | <code>&quot;copy&quot;</code>                                                                      | 否   | —    |
+| <code>copiedText</code>            | <code>string</code>                           | <code>&quot;copied&quot;</code>                                                                    | 否   | —    |
 
 ### Events
 
-—
+| 名称              | Payload                          | 说明 |
+| ----------------- | -------------------------------- | ---- |
+| <code>copy</code> | <code>TMermaidCopyPayload</code> | —    |
 
 ## TMermaidText
 
@@ -1508,10 +1515,17 @@ Import: `@simon_he/vue-tui/vue`
 | <code>missingDependencyText</code> | <code>string</code>                           | <code>&quot;Install the Mermaid renderer package and use TMermaidText from @simon_he/vue...</code> | 否   | —    |
 | <code>errorText</code>             | <code>string</code>                           | <code>&quot;Mermaid render failed&quot;</code>                                                     | 否   | —    |
 | <code>showErrorDetails</code>      | <code>boolean</code>                          | <code>true</code>                                                                                  | 否   | —    |
+| <code>box</code>                   | <code>boolean</code>                          | <code>true</code>                                                                                  | 否   | —    |
+| <code>title</code>                 | <code>string</code>                           | <code>&quot;mermaid&quot;</code>                                                                   | 否   | —    |
+| <code>copyButton</code>            | <code>boolean</code>                          | <code>true</code>                                                                                  | 否   | —    |
+| <code>copyText</code>              | <code>string</code>                           | <code>&quot;copy&quot;</code>                                                                      | 否   | —    |
+| <code>copiedText</code>            | <code>string</code>                           | <code>&quot;copied&quot;</code>                                                                    | 否   | —    |
 
 ### Events
 
-—
+| 名称              | Payload                          | 说明 |
+| ----------------- | -------------------------------- | ---- |
+| <code>copy</code> | <code>TMermaidCopyPayload</code> | —    |
 
 ## TMultilineModal
 

--- a/docs/generated/components-api.md
+++ b/docs/generated/components-api.md
@@ -1461,7 +1461,7 @@ Import: `@simon_he/vue-tui/vue`
 | <code>options</code>               | <code>TMermaidAsciiOptions</code>             | <code>undefined</code>                                                                             | 否   | —    |
 | <code>renderer</code>              | <code>TMermaidRenderer</code>                 | <code>undefined</code>                                                                             | 否   | —    |
 | <code>isTransientError</code>      | <code>TMermaidTransientErrorClassifier</code> | <code>undefined</code>                                                                             | 否   | —    |
-| <code>shouldRenderSource</code>    | <code>TMermaidRenderEligibility</code>        | <code>isSimpleMermaidFlowchartSource</code>                                                        | 否   | —    |
+| <code>shouldRenderSource</code>    | <code>TMermaidRenderEligibility</code>        | <code>undefined</code>                                                                             | 否   | —    |
 | <code>loadingText</code>           | <code>string</code>                           | <code>&quot;Rendering Mermaid diagram...&quot;</code>                                              | 否   | —    |
 | <code>incompleteText</code>        | <code>string</code>                           | <code>&quot;Waiting for complete Mermaid diagram...&quot;</code>                                   | 否   | —    |
 | <code>missingDependencyText</code> | <code>string</code>                           | <code>&quot;Install the Mermaid renderer package and use TMermaidText from @simon_he/vue...</code> | 否   | —    |
@@ -1515,7 +1515,7 @@ Import: `@simon_he/vue-tui/vue`
 | <code>options</code>               | <code>TMermaidAsciiOptions</code>             | <code>undefined</code>                                                                             | 否   | —    |
 | <code>renderer</code>              | <code>TMermaidRenderer</code>                 | <code>undefined</code>                                                                             | 否   | —    |
 | <code>isTransientError</code>      | <code>TMermaidTransientErrorClassifier</code> | <code>undefined</code>                                                                             | 否   | —    |
-| <code>shouldRenderSource</code>    | <code>TMermaidRenderEligibility</code>        | <code>isSimpleMermaidFlowchartSource</code>                                                        | 否   | —    |
+| <code>shouldRenderSource</code>    | <code>TMermaidRenderEligibility</code>        | <code>undefined</code>                                                                             | 否   | —    |
 | <code>loadingText</code>           | <code>string</code>                           | <code>&quot;Rendering Mermaid diagram...&quot;</code>                                              | 否   | —    |
 | <code>incompleteText</code>        | <code>string</code>                           | <code>&quot;Waiting for complete Mermaid diagram...&quot;</code>                                   | 否   | —    |
 | <code>missingDependencyText</code> | <code>string</code>                           | <code>&quot;Install the Mermaid renderer package and use TMermaidText from @simon_he/vue...</code> | 否   | —    |

--- a/docs/generated/components-api.md
+++ b/docs/generated/components-api.md
@@ -1461,7 +1461,7 @@ Import: `@simon_he/vue-tui/vue`
 | <code>options</code>               | <code>TMermaidAsciiOptions</code>             | <code>undefined</code>                                                                             | 否   | —    |
 | <code>renderer</code>              | <code>TMermaidRenderer</code>                 | <code>undefined</code>                                                                             | 否   | —    |
 | <code>isTransientError</code>      | <code>TMermaidTransientErrorClassifier</code> | <code>undefined</code>                                                                             | 否   | —    |
-| <code>shouldRenderSource</code>    | <code>TMermaidRenderEligibility</code>        | <code>undefined</code>                                                                             | 否   | —    |
+| <code>shouldRenderSource</code>    | <code>TMermaidRenderEligibility</code>        | <code>isSimpleMermaidFlowchartSource</code>                                                        | 否   | —    |
 | <code>loadingText</code>           | <code>string</code>                           | <code>&quot;Rendering Mermaid diagram...&quot;</code>                                              | 否   | —    |
 | <code>incompleteText</code>        | <code>string</code>                           | <code>&quot;Waiting for complete Mermaid diagram...&quot;</code>                                   | 否   | —    |
 | <code>missingDependencyText</code> | <code>string</code>                           | <code>&quot;Install the Mermaid renderer package and use TMermaidText from @simon_he/vue...</code> | 否   | —    |
@@ -1515,7 +1515,7 @@ Import: `@simon_he/vue-tui/vue`
 | <code>options</code>               | <code>TMermaidAsciiOptions</code>             | <code>undefined</code>                                                                             | 否   | —    |
 | <code>renderer</code>              | <code>TMermaidRenderer</code>                 | <code>undefined</code>                                                                             | 否   | —    |
 | <code>isTransientError</code>      | <code>TMermaidTransientErrorClassifier</code> | <code>undefined</code>                                                                             | 否   | —    |
-| <code>shouldRenderSource</code>    | <code>TMermaidRenderEligibility</code>        | <code>undefined</code>                                                                             | 否   | —    |
+| <code>shouldRenderSource</code>    | <code>TMermaidRenderEligibility</code>        | <code>isSimpleMermaidFlowchartSource</code>                                                        | 否   | —    |
 | <code>loadingText</code>           | <code>string</code>                           | <code>&quot;Rendering Mermaid diagram...&quot;</code>                                              | 否   | —    |
 | <code>incompleteText</code>        | <code>string</code>                           | <code>&quot;Waiting for complete Mermaid diagram...&quot;</code>                                   | 否   | —    |
 | <code>missingDependencyText</code> | <code>string</code>                           | <code>&quot;Install the Mermaid renderer package and use TMermaidText from @simon_he/vue...</code> | 否   | —    |

--- a/docs/generated/components-api.md
+++ b/docs/generated/components-api.md
@@ -1471,6 +1471,10 @@ Import: `@simon_he/vue-tui/vue`
 | <code>copyButton</code>            | <code>boolean</code>                          | <code>true</code>                                                                                  | 否   | —    |
 | <code>copyText</code>              | <code>string</code>                           | <code>&quot;copy&quot;</code>                                                                      | 否   | —    |
 | <code>copiedText</code>            | <code>string</code>                           | <code>&quot;copied&quot;</code>                                                                    | 否   | —    |
+| <code>renderTimeoutMs</code>       | <code>number</code>                           | <code>DEFAULT_MERMAID_RENDER_TIMEOUT_MS</code>                                                     | 否   | —    |
+| <code>maxRenderSourceChars</code>  | <code>number</code>                           | <code>DEFAULT_MERMAID_MAX_RENDER_SOURCE_CHARS</code>                                               | 否   | —    |
+| <code>maxRenderSourceLines</code>  | <code>number</code>                           | <code>DEFAULT_MERMAID_MAX_RENDER_SOURCE_LINES</code>                                               | 否   | —    |
+| <code>copiedDurationMs</code>      | <code>number</code>                           | <code>DEFAULT_MERMAID_COPIED_DURATION_MS</code>                                                    | 否   | —    |
 
 ### Events
 
@@ -1520,6 +1524,10 @@ Import: `@simon_he/vue-tui/vue`
 | <code>copyButton</code>            | <code>boolean</code>                          | <code>true</code>                                                                                  | 否   | —    |
 | <code>copyText</code>              | <code>string</code>                           | <code>&quot;copy&quot;</code>                                                                      | 否   | —    |
 | <code>copiedText</code>            | <code>string</code>                           | <code>&quot;copied&quot;</code>                                                                    | 否   | —    |
+| <code>renderTimeoutMs</code>       | <code>number</code>                           | <code>DEFAULT_MERMAID_RENDER_TIMEOUT_MS</code>                                                     | 否   | —    |
+| <code>maxRenderSourceChars</code>  | <code>number</code>                           | <code>DEFAULT_MERMAID_MAX_RENDER_SOURCE_CHARS</code>                                               | 否   | —    |
+| <code>maxRenderSourceLines</code>  | <code>number</code>                           | <code>DEFAULT_MERMAID_MAX_RENDER_SOURCE_LINES</code>                                               | 否   | —    |
+| <code>copiedDurationMs</code>      | <code>number</code>                           | <code>DEFAULT_MERMAID_COPIED_DURATION_MS</code>                                                    | 否   | —    |
 
 ### Events
 

--- a/docs/generated/components-api.md
+++ b/docs/generated/components-api.md
@@ -1461,6 +1461,7 @@ Import: `@simon_he/vue-tui/vue`
 | <code>options</code>               | <code>TMermaidAsciiOptions</code>             | <code>undefined</code>                                                                             | 否   | —    |
 | <code>renderer</code>              | <code>TMermaidRenderer</code>                 | <code>undefined</code>                                                                             | 否   | —    |
 | <code>isTransientError</code>      | <code>TMermaidTransientErrorClassifier</code> | <code>undefined</code>                                                                             | 否   | —    |
+| <code>shouldRenderSource</code>    | <code>TMermaidRenderEligibility</code>        | <code>undefined</code>                                                                             | 否   | —    |
 | <code>loadingText</code>           | <code>string</code>                           | <code>&quot;Rendering Mermaid diagram...&quot;</code>                                              | 否   | —    |
 | <code>incompleteText</code>        | <code>string</code>                           | <code>&quot;Waiting for complete Mermaid diagram...&quot;</code>                                   | 否   | —    |
 | <code>missingDependencyText</code> | <code>string</code>                           | <code>&quot;Install the Mermaid renderer package and use TMermaidText from @simon_he/vue...</code> | 否   | —    |
@@ -1514,6 +1515,7 @@ Import: `@simon_he/vue-tui/vue`
 | <code>options</code>               | <code>TMermaidAsciiOptions</code>             | <code>undefined</code>                                                                             | 否   | —    |
 | <code>renderer</code>              | <code>TMermaidRenderer</code>                 | <code>undefined</code>                                                                             | 否   | —    |
 | <code>isTransientError</code>      | <code>TMermaidTransientErrorClassifier</code> | <code>undefined</code>                                                                             | 否   | —    |
+| <code>shouldRenderSource</code>    | <code>TMermaidRenderEligibility</code>        | <code>undefined</code>                                                                             | 否   | —    |
 | <code>loadingText</code>           | <code>string</code>                           | <code>&quot;Rendering Mermaid diagram...&quot;</code>                                              | 否   | —    |
 | <code>incompleteText</code>        | <code>string</code>                           | <code>&quot;Waiting for complete Mermaid diagram...&quot;</code>                                   | 否   | —    |
 | <code>missingDependencyText</code> | <code>string</code>                           | <code>&quot;Install the Mermaid renderer package and use TMermaidText from @simon_he/vue...</code> | 否   | —    |

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -71,6 +71,7 @@ export {
 export type {
   TMermaidAsciiOptions,
   TMermaidAsciiTheme,
+  TMermaidCopyPayload,
   TMermaidRenderer,
   TMermaidResolvedAsciiOptions,
   TMermaidTextProps,

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -37,6 +37,7 @@ export { TLogVirtualSearchResults } from "./vue/components/TLogVirtualSearchResu
 export { TLogVirtualLinksPanel } from "./vue/components/TLogVirtualLinksPanel.js";
 export { TVirtualMarkdown } from "./vue/components/TVirtualMarkdown.js";
 export {
+  isSimpleMermaidFlowchartSource,
   markMermaidRenderErrorFatal,
   TMermaid,
   TMermaidText,

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -73,6 +73,8 @@ export type {
   TMermaidAsciiTheme,
   TMermaidCopyPayload,
   TMermaidRenderer,
+  TMermaidRenderEligibility,
+  TMermaidRenderEligibilityContext,
   TMermaidResolvedAsciiOptions,
   TMermaidTextProps,
   TMermaidTransientErrorClassifier,

--- a/src/agent/mermaid.ts
+++ b/src/agent/mermaid.ts
@@ -3,6 +3,8 @@ export type {
   TMermaidAsciiTheme,
   TMermaidCopyPayload,
   TMermaidRenderer,
+  TMermaidRenderEligibility,
+  TMermaidRenderEligibilityContext,
   TMermaidResolvedAsciiOptions,
   TMermaidTextProps,
   TMermaidTransientErrorClassifier,
@@ -12,6 +14,7 @@ export type {
 export {
   beautifulMermaidRenderer,
   createBeautifulMermaidRenderer,
+  isSimpleMermaidFlowchartSource,
   markMermaidRenderErrorFatal,
   TBeautifulMermaid,
   TBeautifulMermaidText,

--- a/src/agent/mermaid.ts
+++ b/src/agent/mermaid.ts
@@ -1,6 +1,7 @@
 export type {
   TMermaidAsciiOptions,
   TMermaidAsciiTheme,
+  TMermaidCopyPayload,
   TMermaidRenderer,
   TMermaidResolvedAsciiOptions,
   TMermaidTextProps,

--- a/src/create-terminal-app.ts
+++ b/src/create-terminal-app.ts
@@ -117,6 +117,8 @@ function resolveSelectionConfig(
 
 const unsupportedClipboard: ClipboardApi = {
   supported: false,
+  canRead: false,
+  canWrite: false,
   async readText() {
     return "";
   },
@@ -124,6 +126,14 @@ const unsupportedClipboard: ClipboardApi = {
     throw new Error("Clipboard unavailable");
   },
 };
+
+function clipboardCanRead(api: ClipboardApi): boolean {
+  return api.canRead ?? api.supported;
+}
+
+function clipboardCanWrite(api: ClipboardApi): boolean {
+  return api.canWrite ?? api.supported;
+}
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   if (!v || typeof v !== "object") return false;
@@ -820,7 +830,7 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
             ...createDefaultTInputHostAdapter(),
             isTerminalLike: true,
             async readClipboardText() {
-              if (!clipboard.supported) return "";
+              if (!clipboardCanRead(clipboard)) return "";
               try {
                 return await clipboard.readText();
               } catch {
@@ -828,7 +838,7 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
               }
             },
             async writeClipboardText(text: string) {
-              if (!text || !clipboard.supported) return false;
+              if (!text || !clipboardCanWrite(clipboard)) return false;
               try {
                 await clipboard.writeText(text);
                 return true;

--- a/src/create-terminal-app.ts
+++ b/src/create-terminal-app.ts
@@ -583,6 +583,7 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
       return handle;
     },
   };
+  const clipboard = options.clipboard ?? unsupportedClipboard;
 
   const rootLayout = shallowReactive<LayoutContext>({
     originX: 0,
@@ -617,7 +618,7 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
   const selection = createTerminalSelectionController({
     terminal,
     overlayTerminal: selectionOverlay,
-    clipboard: options.clipboard ?? unsupportedClipboard,
+    clipboard,
     getRow: (y) => readTerminalRowForPlanes(terminal, y, selectionReadPlanes),
     getTextProviders: () => Array.from(selectionTextProviders.values()),
     getOptions: () => {
@@ -819,17 +820,17 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
             ...createDefaultTInputHostAdapter(),
             isTerminalLike: true,
             async readClipboardText() {
-              if (!options.clipboard?.supported) return "";
+              if (!clipboard.supported) return "";
               try {
-                return await options.clipboard.readText();
+                return await clipboard.readText();
               } catch {
                 return "";
               }
             },
             async writeClipboardText(text: string) {
-              if (!text || !options.clipboard?.supported) return false;
+              if (!text || !clipboard.supported) return false;
               try {
-                await options.clipboard.writeText(text);
+                await clipboard.writeText(text);
                 return true;
               } catch {
                 return false;
@@ -870,6 +871,7 @@ export function createTerminalApp(options: CreateTerminalAppOptions): TerminalAp
     events: shallowRef(events as any),
     scheduler: schedulerApi,
     runtime,
+    clipboard,
     observability: { trace, framePerf },
     selection: selectionContext,
     defaultStyle: ref(options.defaultStyle ?? {}),

--- a/src/mermaid.ts
+++ b/src/mermaid.ts
@@ -3,13 +3,18 @@ export type {
   TMermaidAsciiTheme,
   TMermaidCopyPayload,
   TMermaidRenderer,
+  TMermaidRenderEligibility,
+  TMermaidRenderEligibilityContext,
   TMermaidResolvedAsciiOptions,
   TMermaidTextProps,
   TMermaidTransientErrorClassifier,
   TMermaidTransientErrorContext,
 } from "./vue/components/TMermaidText.js";
 
-export { markMermaidRenderErrorFatal } from "./vue/components/TMermaidText.js";
+export {
+  isSimpleMermaidFlowchartSource,
+  markMermaidRenderErrorFatal,
+} from "./vue/components/TMermaidText.js";
 
 export {
   beautifulMermaidRenderer,

--- a/src/mermaid.ts
+++ b/src/mermaid.ts
@@ -1,6 +1,7 @@
 export type {
   TMermaidAsciiOptions,
   TMermaidAsciiTheme,
+  TMermaidCopyPayload,
   TMermaidRenderer,
   TMermaidResolvedAsciiOptions,
   TMermaidTextProps,

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -61,28 +61,41 @@ function createUnsupportedClipboard(): ClipboardApi {
   };
 }
 
+function browserClipboard(): any {
+  return typeof navigator !== "undefined" ? (navigator as any).clipboard : undefined;
+}
+
 function createClipboard(kind: RuntimeEnv): ClipboardApi {
-  if (kind === "browser") {
-    const clipboard = typeof navigator !== "undefined" ? (navigator as any).clipboard : undefined;
-    const canRead = typeof clipboard?.readText === "function";
-    const canWrite = typeof clipboard?.writeText === "function";
+  if (kind !== "browser") return createUnsupportedClipboard();
 
-    return {
-      supported: canRead && canWrite,
-      canRead,
-      canWrite,
-      async readText() {
-        if (!canRead) throw new Error("Clipboard read not available in this runtime");
-        return clipboard.readText();
-      },
-      async writeText(text: string) {
-        if (!canWrite) throw new Error("Clipboard write not available in this runtime");
-        await clipboard.writeText(text);
-      },
-    };
-  }
-
-  return createUnsupportedClipboard();
+  return {
+    get supported() {
+      const clipboard = browserClipboard();
+      return (
+        typeof clipboard?.readText === "function" && typeof clipboard?.writeText === "function"
+      );
+    },
+    get canRead() {
+      return typeof browserClipboard()?.readText === "function";
+    },
+    get canWrite() {
+      return typeof browserClipboard()?.writeText === "function";
+    },
+    async readText() {
+      const clipboard = browserClipboard();
+      if (typeof clipboard?.readText !== "function") {
+        throw new Error("Clipboard read not available in this runtime");
+      }
+      return clipboard.readText();
+    },
+    async writeText(text: string) {
+      const clipboard = browserClipboard();
+      if (typeof clipboard?.writeText !== "function") {
+        throw new Error("Clipboard write not available in this runtime");
+      }
+      await clipboard.writeText(text);
+    },
+  };
 }
 
 function nowMs(): number {

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -59,19 +59,19 @@ function createUnsupportedClipboard(): ClipboardApi {
 
 function createClipboard(kind: RuntimeEnv): ClipboardApi {
   if (kind === "browser") {
-    const supported =
-      typeof navigator !== "undefined" &&
-      !!(navigator as any).clipboard?.writeText &&
-      !!(navigator as any).clipboard?.readText;
+    const clipboard = typeof navigator !== "undefined" ? (navigator as any).clipboard : undefined;
+    const canRead = typeof clipboard?.readText === "function";
+    const canWrite = typeof clipboard?.writeText === "function";
+
     return {
-      supported,
+      supported: canRead || canWrite,
       async readText() {
-        if (!supported) throw new Error("Clipboard not available in this runtime");
-        return (navigator as any).clipboard.readText();
+        if (!canRead) throw new Error("Clipboard read not available in this runtime");
+        return clipboard.readText();
       },
       async writeText(text: string) {
-        if (!supported) throw new Error("Clipboard not available in this runtime");
-        await (navigator as any).clipboard.writeText(text);
+        if (!canWrite) throw new Error("Clipboard write not available in this runtime");
+        await clipboard.writeText(text);
       },
     };
   }

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -14,6 +14,8 @@ export type RafApi = Readonly<{
 
 export type ClipboardApi = Readonly<{
   supported: boolean;
+  canRead?: boolean;
+  canWrite?: boolean;
   readText: () => Promise<string>;
   writeText: (text: string) => Promise<void>;
 }>;
@@ -48,6 +50,8 @@ function detectEnv(): RuntimeEnv {
 function createUnsupportedClipboard(): ClipboardApi {
   return {
     supported: false,
+    canRead: false,
+    canWrite: false,
     async readText() {
       throw new Error("Clipboard not available in this runtime");
     },
@@ -64,7 +68,9 @@ function createClipboard(kind: RuntimeEnv): ClipboardApi {
     const canWrite = typeof clipboard?.writeText === "function";
 
     return {
-      supported: canRead || canWrite,
+      supported: canRead && canWrite,
+      canRead,
+      canWrite,
       async readText() {
         if (!canRead) throw new Error("Clipboard read not available in this runtime");
         return clipboard.readText();

--- a/src/runtime/osc52.ts
+++ b/src/runtime/osc52.ts
@@ -51,17 +51,20 @@ export function createOsc52ClipboardProvider(options: Osc52ClipboardOptions = {}
     ((sequence: string) => {
       stdout?.write?.(sequence);
     });
-  const supported = options.supported ?? Boolean(options.write || (stdout?.write && stdout.isTTY));
+  const canWrite = options.supported ?? Boolean(options.write || (stdout?.write && stdout.isTTY));
+  const canRead = typeof options.readText === "function";
   const target = normalizeOsc52Target(options.target);
 
   return {
-    supported,
+    supported: canWrite,
+    canRead,
+    canWrite,
     async readText() {
-      if (!options.readText) throw new Error("Clipboard read not available in this runtime");
+      if (!canRead) throw new Error("Clipboard read not available in this runtime");
       return options.readText();
     },
     async writeText(text: string) {
-      if (!supported) throw new Error("Clipboard not available in this runtime");
+      if (!canWrite) throw new Error("Clipboard not available in this runtime");
       const bytes = encodeTextBytes(text);
       const maxBytes = resolveMaxBytes(options.maxBytes, 100 * 1024);
       if (bytes.byteLength > maxBytes)

--- a/src/selection/terminal-selection.ts
+++ b/src/selection/terminal-selection.ts
@@ -258,6 +258,10 @@ function clampPointToRect(point: TerminalSelectionPoint, rect: Rect): TerminalSe
   };
 }
 
+function clipboardCanWrite(api: ClipboardApi): boolean {
+  return api.canWrite ?? api.supported;
+}
+
 export function createTerminalSelectionController(
   options: CreateTerminalSelectionControllerOptions,
 ): TerminalSelectionController {
@@ -535,7 +539,7 @@ export function createTerminalSelectionController(
       const text = state.value.text || selectedText();
       if (!text) return false;
       setResolvedText(text);
-      if (!options.clipboard.supported) {
+      if (!clipboardCanWrite(options.clipboard)) {
         options.onCopy?.(copyPayload(text, false, new Error("Clipboard unavailable")));
         return false;
       }

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -1,6 +1,10 @@
 import type { ExtractPublicPropTypes, PropType } from "vue";
 import type { Style } from "../../core/types.js";
-import type { Rect, TerminalPointerEvent } from "../../events/manager/types.js";
+import type {
+  Rect,
+  TerminalKeyboardEvent,
+  TerminalPointerEvent,
+} from "../../events/manager/types.js";
 import {
   computed,
   defineComponent,
@@ -263,7 +267,8 @@ export const TMermaidText = defineComponent({
   },
   setup(props, { emit }) {
     const instance = getCurrentInstance();
-    const { terminal, defaultStyle, scheduler, widthProvider } = useTerminal();
+    const terminalContext = useTerminal();
+    const { terminal, defaultStyle, scheduler, widthProvider } = terminalContext;
     const layout = useLayout();
     const { visible, rootProps } = useVisibility();
 
@@ -474,14 +479,15 @@ export const TMermaidText = defineComponent({
       return props.style ?? defaultStyle.value;
     });
 
-    const contentHeight = computed(() => {
-      return Math.max(1, props.h ?? displayLines.value.length);
+    const fullHeight = computed(() => {
+      const autoContentHeight = Math.max(1, displayLines.value.length);
+      const autoHeight = hasBox.value ? autoContentHeight + 2 : autoContentHeight;
+      return Math.max(1, Math.floor(props.h ?? autoHeight));
     });
 
     const fullRect = computed<Rect>(() => {
-      const height = hasBox.value ? contentHeight.value + 2 : contentHeight.value;
       return translateRect(
-        { x: props.x, y: props.y, w: props.w, h: height },
+        { x: props.x, y: props.y, w: props.w, h: fullHeight.value },
         layout.originX,
         layout.originY,
       );
@@ -495,21 +501,50 @@ export const TMermaidText = defineComponent({
 
     const copyLabel = computed(() => (copied.value ? props.copiedText : props.copyText));
 
+    function cellWidth(value: string): number {
+      return withTextWidthProvider(widthProvider, () => textCellWidth(value));
+    }
+
     const copyHitRect = computed<Rect>(() => {
       if (!visible.value || !hasBox.value || !props.copyButton) return { x: 0, y: 0, w: 0, h: 0 };
       const full = fullRect.value;
       const fullW = Math.max(0, Math.floor(full.w));
       if (fullW < 4) return { x: 0, y: 0, w: 0, h: 0 };
-      const labelWidth = textCellWidth(sanitizeInlineText(copyLabel.value));
+      const label = sanitizeInlineText(copyLabel.value);
+      if (!label) return { x: 0, y: 0, w: 0, h: 0 };
+      const labelWidth = cellWidth(label);
       const hitWidth = Math.min(Math.max(0, fullW - 2), labelWidth + 2);
       if (hitWidth <= 0) return { x: 0, y: 0, w: 0, h: 0 };
-      return {
+      const raw = {
         x: Math.floor(full.x) + Math.max(1, fullW - hitWidth - 1),
         y: Math.floor(full.y),
         w: hitWidth,
         h: 1,
       };
+      if (!layout.clipRect) return raw;
+      return intersectRect(raw, layout.clipRect) ?? { x: 0, y: 0, w: 0, h: 0 };
     });
+
+    async function writeClipboardText(text: string): Promise<void> {
+      const contextClipboard = terminalContext.clipboard;
+      if (contextClipboard?.supported) {
+        await contextClipboard.writeText(text);
+        return;
+      }
+
+      const navClipboard = (globalThis as any).navigator?.clipboard;
+      if (navClipboard && typeof navClipboard.writeText === "function") {
+        await navClipboard.writeText(text);
+        return;
+      }
+
+      if (contextClipboard) {
+        await contextClipboard.writeText(text);
+        return;
+      }
+
+      throw new Error("Clipboard not available");
+    }
 
     async function copySource(): Promise<void> {
       const text = source.value;
@@ -517,16 +552,13 @@ export const TMermaidText = defineComponent({
       let copyError: unknown;
 
       try {
-        const clipboard = (globalThis as any).navigator?.clipboard;
-        if (!clipboard || typeof clipboard.writeText !== "function") {
-          throw new Error("Clipboard not available");
-        }
-        await clipboard.writeText(text);
+        await writeClipboardText(text);
         ok = true;
       } catch (err) {
         copyError = err;
       }
 
+      if (!alive) return;
       copied.value = ok;
       bump();
       emit("copy", ok ? { text, ok } : { text, ok, error: copyError });
@@ -538,31 +570,47 @@ export const TMermaidText = defineComponent({
       void copySource();
     }
 
+    function onCopyKeydown(event: TerminalKeyboardEvent): void {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      event.stopPropagation();
+      void copySource();
+    }
+
     useTerminalNode(() => ({
       rect: copyHitRect.value,
       zIndex: props.zIndex + 1,
       visible: visible.value && hasBox.value && props.copyButton && copyHitRect.value.w > 0,
-      focusable: false,
+      focusable: true,
       handlers: {
         click: onCopyClick,
+        keydown: onCopyKeydown,
       },
     }));
 
     function overlayCells(row: string, text: string, start: number, width: number): string {
-      if (width <= 0 || start >= width) return row;
-      const clipped = sliceByCells(text, Math.max(0, width - start));
+      const rowWidth = Math.max(0, Math.floor(width));
+      const end = Math.max(0, rowWidth - 1);
+      const clampedStart = Math.max(0, Math.floor(start));
+      if (rowWidth <= 1 || clampedStart >= end) return row;
+      const clipped = sliceByCells(text, Math.max(0, end - clampedStart));
       if (!clipped) return row;
-      return `${sliceByCells(row, start)}${clipped}${sliceByCellsRange(row, start + textCellWidth(clipped), width)}`;
+      return `${sliceByCells(row, clampedStart)}${clipped}${sliceByCellsRange(
+        row,
+        clampedStart + cellWidth(clipped),
+        rowWidth,
+      )}`;
     }
 
-    function contentLine(rowIndex: number, width: number): string {
+    function contentLine(rowIndex: number, width: number, pad: boolean): string {
       const src = displayLines.value[rowIndex] ?? "";
-      return padEndByCells(sliceByCells(src, width), width);
+      const clipped = sliceByCells(src, width);
+      return pad ? padEndByCells(clipped, width) : clipped;
     }
 
     function boxRow(rowIndex: number, width: number, height: number): string {
       if (!hasBox.value || width < 2 || height < 2) {
-        return contentLine(rowIndex, width);
+        return contentLine(rowIndex, width, props.clear);
       }
 
       const innerW = Math.max(0, width - 2);
@@ -573,8 +621,8 @@ export const TMermaidText = defineComponent({
         if (props.copyButton) {
           const label = sanitizeInlineText(copyLabel.value);
           if (label) {
-            const copy = ` ${label} `;
-            const start = Math.max(1, width - textCellWidth(copy) - 1);
+            const copy = sliceByCells(` ${label} `, Math.max(0, width - 2));
+            const start = Math.max(1, width - cellWidth(copy) - 1);
             row = overlayCells(row, copy, start, width);
           }
         }
@@ -583,7 +631,7 @@ export const TMermaidText = defineComponent({
 
       if (rowIndex === height - 1) return `└${repeatChar("─", innerW)}┘`;
 
-      return `│${contentLine(rowIndex - 1, innerW)}│`;
+      return `│${contentLine(rowIndex - 1, innerW, true)}│`;
     }
 
     useRenderNode(() => ({

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -897,7 +897,10 @@ export const TMermaidText = defineComponent({
     }>;
 
     function canDrawBox(width: number, height: number): boolean {
-      return hasBox.value && Math.floor(width) >= 2 && Math.floor(height) >= 3;
+      // `h` is the outer box height. A 2-row box is still valid chrome:
+      // row 0 = header, row 1 = bottom border. It just has no content row.
+      // Only h < 2 should degrade to raw content.
+      return hasBox.value && Math.floor(width) >= 2 && Math.floor(height) >= 2;
     }
 
     function segmentCells(text: string): number {

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -185,10 +185,7 @@ function createMermaidScannerState(): MermaidScannerState {
 
 function scannerAtTopLevel(state: MermaidScannerState): boolean {
   return (
-    !state.quote &&
-    state.squareDepth === 0 &&
-    state.parenDepth === 0 &&
-    state.braceDepth === 0
+    !state.quote && state.squareDepth === 0 && state.parenDepth === 0 && state.braceDepth === 0
   );
 }
 

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -479,7 +479,7 @@ export const tMermaidTextProps = {
   },
   shouldRenderSource: {
     type: Function as PropType<TMermaidRenderEligibility>,
-    default: isSimpleMermaidFlowchartSource,
+    default: undefined,
   },
   loadingText: {
     type: String,

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -10,11 +10,13 @@ import {
   defineComponent,
   getCurrentInstance,
   h,
+  inject,
   markRaw,
   onBeforeUnmount,
   shallowRef,
   watch,
 } from "vue";
+import { EventZIndexContextKey } from "../context.js";
 import { useLayout } from "../composables/use-layout.js";
 import { useRenderNode } from "../composables/use-render-node.js";
 import { useTerminal } from "../composables/use-terminal.js";
@@ -303,6 +305,7 @@ export const TMermaidText = defineComponent({
     const { terminal, defaultStyle, scheduler, widthProvider } = terminalContext;
     const layout = useLayout();
     const { visible, rootProps } = useVisibility();
+    const parentEventZ = inject(EventZIndexContextKey, computed(() => 0) as any);
 
     const status = shallowRef<TMermaidStatus>("idle");
     const error = shallowRef("");
@@ -626,11 +629,29 @@ export const TMermaidText = defineComponent({
       return withTextWidthProvider(widthProvider, () => textCellWidth(value));
     }
 
+    function sliceCells(text: string, maxCells: number): string {
+      return withTextWidthProvider(widthProvider, () => sliceByCells(text, maxCells));
+    }
+
+    function sliceCellsRange(text: string, startCells: number, endCells: number): string {
+      return withTextWidthProvider(widthProvider, () =>
+        sliceByCellsRange(text, startCells, endCells),
+      );
+    }
+
+    function padCells(text: string, width: number): string {
+      return withTextWidthProvider(widthProvider, () => padEndByCells(text, width));
+    }
+
     type HeaderSegment = Readonly<{
       text: string;
       start: number;
       cells: number;
     }>;
+
+    function canDrawBox(width: number, height: number): boolean {
+      return hasBox.value && Math.floor(width) >= 2 && Math.floor(height) >= 2;
+    }
 
     function segmentCells(text: string): number {
       return cellWidth(text);
@@ -646,7 +667,7 @@ export const TMermaidText = defineComponent({
       if (!label) return null;
 
       const maxCells = Math.max(0, rowWidth - 2);
-      const text = sliceByCells(` ${label} `, maxCells);
+      const text = sliceCells(` ${label} `, maxCells);
       const cells = segmentCells(text);
       if (!text || cells <= 0) return null;
 
@@ -671,7 +692,7 @@ export const TMermaidText = defineComponent({
       const maxCells = Math.max(0, titleEnd - titleStart);
       if (maxCells <= 0) return null;
 
-      const text = sliceByCells(` ${title} `, maxCells);
+      const text = sliceCells(` ${title} `, maxCells);
       const cells = segmentCells(text);
       if (!text || cells <= 0) return null;
 
@@ -683,9 +704,11 @@ export const TMermaidText = defineComponent({
     }
 
     const copyHitRect = computed<Rect>(() => {
-      if (!visible.value || !hasBox.value || !props.copyButton) return { x: 0, y: 0, w: 0, h: 0 };
-
       const full = fullRect.value;
+      if (!visible.value || !props.copyButton || !canDrawBox(full.w, full.h)) {
+        return { x: 0, y: 0, w: 0, h: 0 };
+      }
+
       const copy = headerCopySegment(Math.max(0, Math.floor(full.w)));
       if (!copy) return { x: 0, y: 0, w: 0, h: 0 };
 
@@ -753,14 +776,19 @@ export const TMermaidText = defineComponent({
     }
 
     const copyNodeActive = computed(
-      () => visible.value && hasBox.value && props.copyButton && copyHitRect.value.w > 0,
+      () =>
+        visible.value &&
+        props.copyButton &&
+        copyHitRect.value.w > 0 &&
+        copyHitRect.value.h > 0,
     );
 
     useTerminalNode(() => ({
       rect: copyHitRect.value,
-      zIndex: props.zIndex + 1,
+      zIndex: (parentEventZ.value ?? 0) + props.zIndex + 1,
       visible: copyNodeActive.value,
       focusable: copyNodeActive.value,
+      selectable: false,
       handlers: copyNodeActive.value
         ? {
             click: onCopyClick,
@@ -775,24 +803,24 @@ export const TMermaidText = defineComponent({
       if (rowWidth <= 1 || start >= rowWidth - 1 || segment.cells <= 0) return row;
 
       const maxCells = Math.max(0, rowWidth - 1 - start);
-      const text = sliceByCells(segment.text, maxCells);
+      const text = sliceCells(segment.text, maxCells);
       const cells = segmentCells(text);
       if (!text || cells <= 0) return row;
 
-      return `${sliceByCells(row, start)}${text}${sliceByCellsRange(row, start + cells, rowWidth)}`;
+      return `${sliceCells(row, start)}${text}${sliceCellsRange(row, start + cells, rowWidth)}`;
     }
 
     function contentLine(rowIndex: number, width: number, pad: boolean): string {
       const src = displayLines.value[rowIndex] ?? "";
-      const clipped = sliceByCells(src, width);
-      return pad ? padEndByCells(clipped, width) : clipped;
+      const clipped = sliceCells(src, width);
+      return pad ? padCells(clipped, width) : clipped;
     }
 
     function boxRow(rowIndex: number, width: number, height: number): string {
       const rowWidth = Math.max(0, Math.floor(width));
       const rowHeight = Math.max(0, Math.floor(height));
 
-      if (!hasBox.value || rowWidth < 2 || rowHeight < 2) {
+      if (!canDrawBox(rowWidth, rowHeight)) {
         return contentLine(rowIndex, rowWidth, props.clear);
       }
 
@@ -858,8 +886,8 @@ export const TMermaidText = defineComponent({
             }
 
             const src = boxRow(rowIndex, fullW, fullH);
-            const clipped = dx > 0 ? sliceByCellsRange(src, dx, dx + r.w) : sliceByCells(src, r.w);
-            const value = props.clear ? padEndByCells(clipped, r.w) : clipped;
+            const clipped = dx > 0 ? sliceCellsRange(src, dx, dx + r.w) : sliceCells(src, r.w);
+            const value = props.clear ? padCells(clipped, r.w) : clipped;
             if (value || props.clear) {
               terminal.write(value, { x: r.x, y, style });
             }

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -636,7 +636,8 @@ export const TMermaidText = defineComponent({
     function shouldSkipRender(code: string): boolean {
       if (shouldSkipRenderForSize(code)) return true;
 
-      const shouldRenderSource = props.shouldRenderSource ?? isSimpleMermaidFlowchartSource;
+      const shouldRenderSource = props.shouldRenderSource;
+      if (!shouldRenderSource) return false;
 
       try {
         return !shouldRenderSource(code, {

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -636,8 +636,7 @@ export const TMermaidText = defineComponent({
     function shouldSkipRender(code: string): boolean {
       if (shouldSkipRenderForSize(code)) return true;
 
-      const shouldRenderSource = props.shouldRenderSource;
-      if (!shouldRenderSource) return false;
+      const shouldRenderSource = props.shouldRenderSource ?? isSimpleMermaidFlowchartSource;
 
       try {
         return !shouldRenderSource(code, {

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -663,7 +663,8 @@ export const TMermaidText = defineComponent({
     function shouldSkipRender(code: string): boolean {
       if (shouldSkipRenderForSize(code)) return true;
 
-      const shouldRenderSource = props.shouldRenderSource ?? isSimpleMermaidFlowchartSource;
+      const shouldRenderSource = props.shouldRenderSource;
+      if (!shouldRenderSource) return false;
 
       try {
         return !shouldRenderSource(code, {

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -1,6 +1,6 @@
 import type { ExtractPublicPropTypes, PropType } from "vue";
 import type { Style } from "../../core/types.js";
-import type { Rect } from "../../events/manager/types.js";
+import type { Rect, TerminalPointerEvent } from "../../events/manager/types.js";
 import {
   computed,
   defineComponent,
@@ -14,14 +14,18 @@ import {
 import { useLayout } from "../composables/use-layout.js";
 import { useRenderNode } from "../composables/use-render-node.js";
 import { useTerminal } from "../composables/use-terminal.js";
+import { useTerminalNode } from "../composables/use-terminal-node.js";
 import { useVisibility } from "../composables/use-visibility.js";
 import { intersectRect, translateRect } from "../utils/rect.js";
 import {
   padEndByCells,
+  repeatChar,
+  sanitizeInlineText,
   sanitizeTextBlock,
   sliceByCells,
   sliceByCellsRange,
   spaces,
+  textCellWidth,
   withTextWidthProvider,
 } from "../utils/text.js";
 
@@ -68,6 +72,17 @@ export type TMermaidTransientErrorClassifier = (
 ) => boolean;
 
 type TMermaidStatus = "idle" | "loading" | "ready" | "incomplete" | "error";
+
+type TMermaidRenderSnapshot = Readonly<{
+  source: string;
+  lines: readonly string[];
+}>;
+
+export type TMermaidCopyPayload = Readonly<{
+  text: string;
+  ok: boolean;
+  error?: unknown;
+}>;
 
 const TUI_MERMAID_FATAL_RENDER_ERROR = "__vueTuiMermaidFatalRenderError" as const;
 const fatalMermaidRenderErrors = new WeakSet<object>();
@@ -231,6 +246,11 @@ export const tMermaidTextProps = {
     type: Boolean,
     default: true,
   },
+  box: { type: Boolean, default: true },
+  title: { type: String, default: "mermaid" },
+  copyButton: { type: Boolean, default: true },
+  copyText: { type: String, default: "copy" },
+  copiedText: { type: String, default: "copied" },
 } as const;
 
 export type TMermaidTextProps = ExtractPublicPropTypes<typeof tMermaidTextProps>;
@@ -238,7 +258,10 @@ export type TMermaidTextProps = ExtractPublicPropTypes<typeof tMermaidTextProps>
 export const TMermaidText = defineComponent({
   name: "TMermaidText",
   props: tMermaidTextProps,
-  setup(props) {
+  emits: {
+    copy: (_payload: TMermaidCopyPayload) => true,
+  },
+  setup(props, { emit }) {
     const instance = getCurrentInstance();
     const { terminal, defaultStyle, scheduler, widthProvider } = useTerminal();
     const layout = useLayout();
@@ -247,8 +270,9 @@ export const TMermaidText = defineComponent({
     const status = shallowRef<TMermaidStatus>("idle");
     const error = shallowRef("");
     const missingRenderer = shallowRef(false);
-    const lines = shallowRef<readonly string[]>(markRaw([""]));
+    const renderedSnapshot = shallowRef<TMermaidRenderSnapshot | null>(null);
     const documentVersion = shallowRef(0);
+    const copied = shallowRef(false);
 
     let builtOnce = false;
     let renderVersion = 0;
@@ -295,14 +319,25 @@ export const TMermaidText = defineComponent({
       const code = source.value;
       if (!code.trim()) {
         if (!alive || version !== renderVersion) return;
-        lines.value = markRaw([""]);
-        status.value = "ready";
+        renderedSnapshot.value = null;
+        status.value = "idle";
         error.value = "";
         missingRenderer.value = false;
         bump();
         return;
       }
 
+      if (props.streaming && !props.final) {
+        if (!alive || version !== renderVersion) return;
+        renderedSnapshot.value = null;
+        status.value = "idle";
+        error.value = "";
+        missingRenderer.value = false;
+        bump();
+        return;
+      }
+
+      renderedSnapshot.value = null;
       status.value = "loading";
       error.value = "";
       missingRenderer.value = false;
@@ -312,7 +347,7 @@ export const TMermaidText = defineComponent({
         const renderer = props.renderer;
         if (!renderer) {
           if (!alive || version !== renderVersion) return;
-          lines.value = markRaw([""]);
+          renderedSnapshot.value = null;
           missingRenderer.value = true;
           status.value = "error";
           bump();
@@ -322,18 +357,32 @@ export const TMermaidText = defineComponent({
         const rendered = await renderer(code, resolveAsciiOptions());
         if (!alive || version !== renderVersion) return;
 
-        lines.value = markRaw(splitRenderedOutput(rendered));
-        status.value = "ready";
+        const renderedLines = splitRenderedOutput(rendered);
+        if (hasVisibleRenderedOutput(renderedLines)) {
+          renderedSnapshot.value = markRaw({
+            source: code,
+            lines: markRaw(renderedLines),
+          });
+          status.value = "ready";
+          error.value = "";
+          missingRenderer.value = false;
+          bump();
+          return;
+        }
+
+        renderedSnapshot.value = null;
+        status.value = "error";
         error.value = "";
         missingRenderer.value = false;
         bump();
       } catch (err) {
         if (!alive || version !== renderVersion) return;
+        renderedSnapshot.value = null;
         missingRenderer.value = false;
         error.value = errorMessage(err);
 
         if (shouldTreatRenderErrorAsTransient(err, code)) {
-          status.value = hasVisibleRenderedOutput(lines.value) ? "ready" : "incomplete";
+          status.value = "incomplete";
           bump();
           return;
         }
@@ -345,6 +394,18 @@ export const TMermaidText = defineComponent({
 
     function scheduleRender(): void {
       const version = ++renderVersion;
+      copied.value = false;
+
+      if (props.streaming && !props.final) {
+        builtOnce = true;
+        scheduler.cancelFrameTask?.(frameTaskId);
+        renderedSnapshot.value = null;
+        status.value = "idle";
+        error.value = "";
+        missingRenderer.value = false;
+        bump();
+        return;
+      }
 
       if (!builtOnce || !props.streaming) {
         builtOnce = true;
@@ -393,40 +454,29 @@ export const TMermaidText = defineComponent({
       scheduler.cancelFrameTask?.(frameTaskId);
     });
 
-    const showingInitialLoadingText = computed(
-      () => status.value === "loading" && !hasVisibleRenderedOutput(lines.value),
-    );
+    const hasBox = computed(() => props.box !== false);
+
+    const sourceLines = computed<readonly string[]>(() => splitRenderedOutput(source.value));
 
     const displayLines = computed<readonly string[]>(() => {
-      if (status.value === "error") {
-        const detailText = missingRenderer.value ? props.missingDependencyText : error.value;
-        const detail = props.showErrorDetails && detailText ? `: ${detailText}` : "";
-        return splitRenderedOutput(`${props.errorText}${detail}`);
+      const snapshot = renderedSnapshot.value;
+      if (
+        snapshot &&
+        snapshot.source === source.value &&
+        hasVisibleRenderedOutput(snapshot.lines)
+      ) {
+        return snapshot.lines;
       }
-      if (status.value === "incomplete") {
-        return splitRenderedOutput(props.incompleteText);
-      }
-      if (showingInitialLoadingText.value) {
-        return splitRenderedOutput(props.loadingText);
-      }
-      return lines.value.length ? lines.value : [""];
+      return sourceLines.value;
     });
 
     const currentStyle = computed<Style>(() => {
-      if (status.value === "error") {
-        return props.errorStyle ?? props.style ?? defaultStyle.value;
-      }
-      if (status.value === "incomplete") {
-        return props.loadingStyle ?? props.style ?? defaultStyle.value;
-      }
-      if (showingInitialLoadingText.value) {
-        return props.loadingStyle ?? props.style ?? defaultStyle.value;
-      }
       return props.style ?? defaultStyle.value;
     });
 
     const fullRect = computed<Rect>(() => {
-      const height = props.h ?? Math.max(1, displayLines.value.length);
+      const contentHeight = Math.max(1, displayLines.value.length);
+      const height = props.h ?? (hasBox.value ? contentHeight + 2 : contentHeight);
       return translateRect(
         { x: props.x, y: props.y, w: props.w, h: height },
         layout.originX,
@@ -440,6 +490,99 @@ export const TMermaidText = defineComponent({
       return intersectRect(translated, layout.clipRect) ?? { x: 0, y: 0, w: 0, h: 0 };
     });
 
+    const copyLabel = computed(() => (copied.value ? props.copiedText : props.copyText));
+
+    const copyHitRect = computed<Rect>(() => {
+      if (!visible.value || !hasBox.value || !props.copyButton) return { x: 0, y: 0, w: 0, h: 0 };
+      const full = fullRect.value;
+      const fullW = Math.max(0, Math.floor(full.w));
+      if (fullW < 4) return { x: 0, y: 0, w: 0, h: 0 };
+      const labelWidth = textCellWidth(sanitizeInlineText(copyLabel.value));
+      const hitWidth = Math.min(Math.max(0, fullW - 2), labelWidth + 2);
+      if (hitWidth <= 0) return { x: 0, y: 0, w: 0, h: 0 };
+      return {
+        x: Math.floor(full.x) + Math.max(1, fullW - hitWidth - 1),
+        y: Math.floor(full.y),
+        w: hitWidth,
+        h: 1,
+      };
+    });
+
+    async function copySource(): Promise<void> {
+      const text = source.value;
+      let ok = false;
+      let copyError: unknown;
+
+      try {
+        const clipboard = (globalThis as any).navigator?.clipboard;
+        if (!clipboard || typeof clipboard.writeText !== "function") {
+          throw new Error("Clipboard not available");
+        }
+        await clipboard.writeText(text);
+        ok = true;
+      } catch (err) {
+        copyError = err;
+      }
+
+      copied.value = ok;
+      bump();
+      emit("copy", ok ? { text, ok } : { text, ok, error: copyError });
+    }
+
+    function onCopyClick(event: TerminalPointerEvent): void {
+      event.preventDefault();
+      event.stopPropagation();
+      void copySource();
+    }
+
+    useTerminalNode(() => ({
+      rect: copyHitRect.value,
+      zIndex: props.zIndex + 1,
+      visible: visible.value && hasBox.value && props.copyButton && copyHitRect.value.w > 0,
+      focusable: false,
+      handlers: {
+        click: onCopyClick,
+      },
+    }));
+
+    function overlayCells(row: string, text: string, start: number, width: number): string {
+      if (width <= 0 || start >= width) return row;
+      const clipped = sliceByCells(text, Math.max(0, width - start));
+      if (!clipped) return row;
+      return `${sliceByCells(row, start)}${clipped}${sliceByCellsRange(row, start + textCellWidth(clipped), width)}`;
+    }
+
+    function contentLine(rowIndex: number, width: number): string {
+      const src = displayLines.value[rowIndex] ?? "";
+      return padEndByCells(sliceByCells(src, width), width);
+    }
+
+    function boxRow(rowIndex: number, width: number, height: number): string {
+      if (!hasBox.value || width < 2 || height < 2) {
+        return contentLine(rowIndex, width);
+      }
+
+      const innerW = Math.max(0, width - 2);
+      if (rowIndex === 0) {
+        let row = `┌${repeatChar("─", innerW)}┐`;
+        const title = sanitizeInlineText(props.title);
+        if (title) row = overlayCells(row, ` ${title} `, 1, width);
+        if (props.copyButton) {
+          const label = sanitizeInlineText(copyLabel.value);
+          if (label) {
+            const copy = ` ${label} `;
+            const start = Math.max(1, width - textCellWidth(copy) - 1);
+            row = overlayCells(row, copy, start, width);
+          }
+        }
+        return row;
+      }
+
+      if (rowIndex === height - 1) return `└${repeatChar("─", innerW)}┘`;
+
+      return `│${contentLine(rowIndex - 1, innerW)}│`;
+    }
+
     useRenderNode(() => ({
       zIndex: props.zIndex,
       rect: visible.value ? absRect.value : { x: 0, y: 0, w: 0, h: 0 },
@@ -452,6 +595,12 @@ export const TMermaidText = defineComponent({
         props.clear,
         status.value,
         error.value,
+        missingRenderer.value,
+        renderedSnapshot.value,
+        hasBox.value,
+        props.title,
+        props.copyButton,
+        copyLabel.value,
         documentVersion.value,
       ],
       paint: (dirtyRows) => {
@@ -463,21 +612,22 @@ export const TMermaidText = defineComponent({
           if (r.w <= 0 || r.h <= 0) return;
 
           const style = currentStyle.value;
-          const out = displayLines.value;
           const dx = Math.max(0, Math.floor(r.x - full.x));
           const fullY = Math.floor(full.y);
+          const fullW = Math.max(0, Math.floor(full.w));
+          const fullH = Math.max(0, Math.floor(full.h));
           const blank = props.clear ? spaces(r.w) : "";
 
           const paintRow = (y: number) => {
             if (y < r.y || y >= r.y + r.h) return;
 
             const rowIndex = y - fullY;
-            if (rowIndex < 0 || rowIndex >= out.length) {
+            if (rowIndex < 0 || rowIndex >= fullH) {
               if (props.clear) terminal.write(blank, { x: r.x, y, style });
               return;
             }
 
-            const src = out[rowIndex] ?? "";
+            const src = boxRow(rowIndex, fullW, fullH);
             const clipped = dx > 0 ? sliceByCellsRange(src, dx, dx + r.w) : sliceByCells(src, r.w);
             const value = props.clear ? padEndByCells(clipped, r.w) : clipped;
             if (value || props.clear) {

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -442,7 +442,7 @@ export const TMermaidText = defineComponent({
         return;
       }
 
-      if (!props.final) {
+      if (props.streaming && !props.final) {
         if (!alive || version !== renderVersion) return;
         renderedSnapshot.value = null;
         status.value = "idle";
@@ -521,7 +521,7 @@ export const TMermaidText = defineComponent({
       const version = ++renderVersion;
       setCopied(false, false);
 
-      if (!props.final) {
+      if (props.streaming && !props.final) {
         builtOnce = true;
         scheduler.cancelFrameTask?.(frameTaskId);
         renderedSnapshot.value = null;
@@ -776,11 +776,7 @@ export const TMermaidText = defineComponent({
     }
 
     const copyNodeActive = computed(
-      () =>
-        visible.value &&
-        props.copyButton &&
-        copyHitRect.value.w > 0 &&
-        copyHitRect.value.h > 0,
+      () => visible.value && props.copyButton && copyHitRect.value.w > 0 && copyHitRect.value.h > 0,
     );
 
     useTerminalNode(() => ({

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -319,6 +319,7 @@ export const TMermaidText = defineComponent({
     let alive = true;
     const frameTaskId = `TMermaidText:${instance?.uid ?? "unknown"}:mermaid`;
     let copiedTimer: ReturnType<typeof setTimeout> | null = null;
+    let copyRequestVersion = 0;
 
     const source = computed(() => props.code ?? props.content ?? "");
 
@@ -367,6 +368,11 @@ export const TMermaidText = defineComponent({
       if (copied.value === next) return;
       copied.value = next;
       if (repaint) bump();
+    }
+
+    function resetCopyFeedback(repaint = true): void {
+      copyRequestVersion++;
+      setCopied(false, repaint);
     }
 
     function showCopiedFeedback(): void {
@@ -519,7 +525,7 @@ export const TMermaidText = defineComponent({
 
     function scheduleRender(): void {
       const version = ++renderVersion;
-      setCopied(false, false);
+      resetCopyFeedback(false);
 
       if (props.streaming && !props.final) {
         builtOnce = true;
@@ -725,7 +731,11 @@ export const TMermaidText = defineComponent({
 
     async function writeClipboardText(text: string): Promise<void> {
       const contextClipboard = terminalContext.clipboard;
-      if (contextClipboard?.supported) {
+
+      if (contextClipboard) {
+        if (!contextClipboard.supported) {
+          throw new Error("Clipboard not available in this runtime");
+        }
         await contextClipboard.writeText(text);
         return;
       }
@@ -736,16 +746,12 @@ export const TMermaidText = defineComponent({
         return;
       }
 
-      if (contextClipboard) {
-        await contextClipboard.writeText(text);
-        return;
-      }
-
       throw new Error("Clipboard not available");
     }
 
     async function copySource(): Promise<void> {
       const text = source.value;
+      const requestVersion = ++copyRequestVersion;
       let ok = false;
       let copyError: unknown;
 
@@ -757,8 +763,12 @@ export const TMermaidText = defineComponent({
       }
 
       if (!alive) return;
-      if (ok) showCopiedFeedback();
-      else setCopied(false);
+      const isLatestForCurrentSource =
+        requestVersion === copyRequestVersion && source.value === text;
+      if (isLatestForCurrentSource) {
+        if (ok) showCopiedFeedback();
+        else setCopied(false);
+      }
       emit("copy", ok ? { text, ok } : { text, ok, error: copyError });
     }
 

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -669,7 +669,8 @@ export const TMermaidText = defineComponent({
     function shouldSkipRender(code: string): boolean {
       if (shouldSkipRenderForSize(code)) return true;
 
-      const shouldRenderSource = props.shouldRenderSource ?? isSimpleMermaidFlowchartSource;
+      const shouldRenderSource = props.shouldRenderSource;
+      if (!shouldRenderSource) return false;
 
       try {
         return !shouldRenderSource(code, {

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -663,8 +663,7 @@ export const TMermaidText = defineComponent({
     function shouldSkipRender(code: string): boolean {
       if (shouldSkipRenderForSize(code)) return true;
 
-      const shouldRenderSource = props.shouldRenderSource;
-      if (!shouldRenderSource) return false;
+      const shouldRenderSource = props.shouldRenderSource ?? isSimpleMermaidFlowchartSource;
 
       try {
         return !shouldRenderSource(code, {

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -376,6 +376,9 @@ export function isSimpleMermaidFlowchartSource(code: string): boolean {
   return sawDirective && renderableStatements > 0;
 }
 
+const defaultShouldRenderMermaidSource: TMermaidRenderEligibility = (code) =>
+  isSimpleMermaidFlowchartSource(code);
+
 function clipboardCanWrite(api: { supported: boolean; canWrite?: boolean }): boolean {
   return api.canWrite ?? api.supported;
 }
@@ -669,8 +672,7 @@ export const TMermaidText = defineComponent({
     function shouldSkipRender(code: string): boolean {
       if (shouldSkipRenderForSize(code)) return true;
 
-      const shouldRenderSource = props.shouldRenderSource;
-      if (!shouldRenderSource) return false;
+      const shouldRenderSource = props.shouldRenderSource ?? defaultShouldRenderMermaidSource;
 
       try {
         return !shouldRenderSource(code, {

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -378,7 +378,10 @@ function hasTopLevelMermaidComplexToken(statement: string): boolean {
     const ch = statement[index] ?? "";
 
     if (scannerAtTopLevel(state)) {
-      if (statement.startsWith("@{", index)) return true;
+      // Top-level `@` is used by newer / richer flowchart syntax such as
+      // shape metadata and edge ids. Labels like `|user@example.com|` remain
+      // allowed because the scanner is not at top level inside pipe labels.
+      if (ch === "@") return true;
       if (statement.startsWith(":::", index) && /[A-Za-z_]/.test(statement[index + 3] ?? "")) {
         return true;
       }

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -635,7 +635,8 @@ export const TMermaidText = defineComponent({
     function shouldSkipRender(code: string): boolean {
       if (shouldSkipRenderForSize(code)) return true;
 
-      const shouldRenderSource = props.shouldRenderSource ?? isSimpleMermaidFlowchartSource;
+      const shouldRenderSource = props.shouldRenderSource;
+      if (!shouldRenderSource) return false;
 
       try {
         return !shouldRenderSource(code, {

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -97,6 +97,17 @@ const DEFAULT_MERMAID_MAX_RENDER_SOURCE_CHARS = 20_000;
 const DEFAULT_MERMAID_MAX_RENDER_SOURCE_LINES = 400;
 const DEFAULT_MERMAID_COPIED_DURATION_MS = 1200;
 
+// Keep Mermaid rendering intentionally conservative. The renderer runs on the
+// main thread, so timeout guards cannot protect us from synchronous CPU-heavy
+// Mermaid layouts. Unsupported or complex sources should stay as source text.
+const DEFAULT_MERMAID_MAX_RENDER_FLOW_STATEMENTS = 120;
+const SIMPLE_MERMAID_DIRECTIVE_RE = /^(?:graph|flowchart)\s+(?:TB|TD|BT|LR|RL)\b/i;
+const MERMAID_INIT_DIRECTIVE_RE = /^%%\{/;
+const MERMAID_COMMENT_RE = /^%%/;
+const MERMAID_FRONTMATTER_DELIMITER_RE = /^---\s*$/;
+const COMPLEX_MERMAID_FLOW_FEATURE_RE =
+  /^(?:subgraph|classDef|class|click|style|linkStyle|accTitle|accDescr)\b/i;
+
 const ESC = String.fromCharCode(27);
 const BEL = String.fromCharCode(7);
 const TERMINAL_ESCAPE_RE = new RegExp(
@@ -133,6 +144,75 @@ function countLinesUpTo(value: string, max: number): number {
     if (lines > max) return lines;
   }
   return lines;
+}
+
+function mermaidSourceLines(code: string): readonly string[] {
+  return String(code ?? "")
+    .replace(/\r\n?/g, "\n")
+    .split("\n");
+}
+
+function firstMermaidStatement(code: string): string {
+  for (const rawLine of mermaidSourceLines(code)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    if (MERMAID_INIT_DIRECTIVE_RE.test(line)) return "";
+    if (MERMAID_FRONTMATTER_DELIMITER_RE.test(line)) return "";
+
+    if (MERMAID_COMMENT_RE.test(line)) continue;
+    return line;
+  }
+
+  return "";
+}
+
+function hasComplexMermaidFlowFeature(code: string): boolean {
+  for (const rawLine of mermaidSourceLines(code)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    if (MERMAID_INIT_DIRECTIVE_RE.test(line)) return true;
+    if (MERMAID_FRONTMATTER_DELIMITER_RE.test(line)) return true;
+    if (MERMAID_COMMENT_RE.test(line)) continue;
+
+    if (COMPLEX_MERMAID_FLOW_FEATURE_RE.test(line)) return true;
+  }
+
+  return false;
+}
+
+function countMermaidFlowStatementsUpTo(code: string, max: number): number {
+  if (max <= 0) return 0;
+
+  let statements = 0;
+  let sawDirective = false;
+
+  for (const rawLine of mermaidSourceLines(code)) {
+    const line = rawLine.trim();
+    if (!line || MERMAID_COMMENT_RE.test(line)) continue;
+
+    if (!sawDirective && SIMPLE_MERMAID_DIRECTIVE_RE.test(line)) {
+      sawDirective = true;
+      continue;
+    }
+
+    statements++;
+    if (statements > max) return statements;
+  }
+
+  return statements;
+}
+
+function shouldSkipRenderForComplexity(code: string): boolean {
+  const first = firstMermaidStatement(code);
+  if (!SIMPLE_MERMAID_DIRECTIVE_RE.test(first)) return true;
+  if (hasComplexMermaidFlowFeature(code)) return true;
+
+  return (
+    countMermaidFlowStatementsUpTo(code, DEFAULT_MERMAID_MAX_RENDER_FLOW_STATEMENTS) >
+    DEFAULT_MERMAID_MAX_RENDER_FLOW_STATEMENTS
+  );
 }
 
 function timeoutError(ms: number): Error & { code: string } {
@@ -411,6 +491,10 @@ export const TMermaidText = defineComponent({
       return false;
     }
 
+    function shouldSkipRender(code: string): boolean {
+      return shouldSkipRenderForSize(code) || shouldSkipRenderForComplexity(code);
+    }
+
     async function renderWithTimeout(
       renderer: TMermaidRenderer,
       code: string,
@@ -458,7 +542,7 @@ export const TMermaidText = defineComponent({
         return;
       }
 
-      if (shouldSkipRenderForSize(code)) {
+      if (shouldSkipRender(code)) {
         if (!alive || version !== renderVersion) return;
         renderedSnapshot.value = null;
         status.value = "idle";

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -624,6 +624,12 @@ export const TMermaidText = defineComponent({
       setCopied(false, repaint);
     }
 
+    function clearRenderedSnapshot(): boolean {
+      if (renderedSnapshot.value == null) return false;
+      renderedSnapshot.value = null;
+      return true;
+    }
+
     function showCopiedFeedback(): void {
       clearCopiedTimer();
 
@@ -790,12 +796,20 @@ export const TMermaidText = defineComponent({
 
     function scheduleRender(): void {
       const version = ++renderVersion;
+      const copiedWasVisible = copied.value;
+
       resetCopyFeedback(false);
+
+      // Source-first invariant:
+      // any new render attempt, even for the exact same source, must immediately
+      // invalidate the previously rendered diagram. Otherwise same-source changes
+      // such as renderer/options/ascii/eligibility can keep showing a stale diagram
+      // until the queued low-priority frame task runs.
+      const snapshotCleared = clearRenderedSnapshot();
 
       if (!props.final) {
         builtOnce = true;
         scheduler.cancelFrameTask?.(frameTaskId);
-        renderedSnapshot.value = null;
         status.value = "idle";
         error.value = "";
         missingRenderer.value = false;
@@ -807,6 +821,12 @@ export const TMermaidText = defineComponent({
         builtOnce = true;
         void renderNow(version);
         return;
+      }
+
+      // When the render work is queued, paint the source/copy-label reset now
+      // instead of waiting for the low-priority frame task.
+      if (copiedWasVisible || snapshotCleared) {
+        bump();
       }
 
       const accepted = scheduler.queueFrameTask({

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -139,10 +139,18 @@ function countLinesUpTo(value: string, max: number): number {
 
   let lines = 1;
   for (let index = 0; index < value.length; index++) {
-    if (value.charCodeAt(index) !== 10) continue;
+    const code = value.charCodeAt(index);
+    if (code !== 10 && code !== 13) continue;
+
     lines++;
+
+    if (code === 13 && value.charCodeAt(index + 1) === 10) {
+      index++;
+    }
+
     if (lines > max) return lines;
   }
+
   return lines;
 }
 
@@ -152,31 +160,47 @@ function mermaidSourceLines(code: string): readonly string[] {
     .split("\n");
 }
 
-function firstMermaidStatement(code: string): string {
+function mermaidSourceStatements(code: string): readonly string[] {
+  const statements: string[] = [];
+
   for (const rawLine of mermaidSourceLines(code)) {
     const line = rawLine.trim();
     if (!line) continue;
 
-    if (MERMAID_INIT_DIRECTIVE_RE.test(line)) return "";
-    if (MERMAID_FRONTMATTER_DELIMITER_RE.test(line)) return "";
+    if (MERMAID_INIT_DIRECTIVE_RE.test(line) || MERMAID_FRONTMATTER_DELIMITER_RE.test(line)) {
+      statements.push(line);
+      continue;
+    }
 
     if (MERMAID_COMMENT_RE.test(line)) continue;
-    return line;
+
+    for (const rawStatement of line.split(";")) {
+      const statement = rawStatement.trim();
+      if (!statement || MERMAID_COMMENT_RE.test(statement)) continue;
+      statements.push(statement);
+    }
+  }
+
+  return statements;
+}
+
+function firstMermaidStatement(code: string): string {
+  for (const statement of mermaidSourceStatements(code)) {
+    if (MERMAID_INIT_DIRECTIVE_RE.test(statement)) return "";
+    if (MERMAID_FRONTMATTER_DELIMITER_RE.test(statement)) return "";
+    return statement;
   }
 
   return "";
 }
 
 function hasComplexMermaidFlowFeature(code: string): boolean {
-  for (const rawLine of mermaidSourceLines(code)) {
-    const line = rawLine.trim();
-    if (!line) continue;
+  for (const statement of mermaidSourceStatements(code)) {
+    if (MERMAID_INIT_DIRECTIVE_RE.test(statement)) return true;
+    if (MERMAID_FRONTMATTER_DELIMITER_RE.test(statement)) return true;
+    if (SIMPLE_MERMAID_DIRECTIVE_RE.test(statement)) continue;
 
-    if (MERMAID_INIT_DIRECTIVE_RE.test(line)) return true;
-    if (MERMAID_FRONTMATTER_DELIMITER_RE.test(line)) return true;
-    if (MERMAID_COMMENT_RE.test(line)) continue;
-
-    if (COMPLEX_MERMAID_FLOW_FEATURE_RE.test(line)) return true;
+    if (COMPLEX_MERMAID_FLOW_FEATURE_RE.test(statement)) return true;
   }
 
   return false;
@@ -188,11 +212,8 @@ function countMermaidFlowStatementsUpTo(code: string, max: number): number {
   let statements = 0;
   let sawDirective = false;
 
-  for (const rawLine of mermaidSourceLines(code)) {
-    const line = rawLine.trim();
-    if (!line || MERMAID_COMMENT_RE.test(line)) continue;
-
-    if (!sawDirective && SIMPLE_MERMAID_DIRECTIVE_RE.test(line)) {
+  for (const statement of mermaidSourceStatements(code)) {
+    if (!sawDirective && SIMPLE_MERMAID_DIRECTIVE_RE.test(statement)) {
       sawDirective = true;
       continue;
     }

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -356,7 +356,7 @@ export const tMermaidTextProps = {
   },
   shouldRenderSource: {
     type: Function as PropType<TMermaidRenderEligibility>,
-    default: undefined,
+    default: isSimpleMermaidFlowchartSource,
   },
   loadingText: {
     type: String,

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -557,6 +557,10 @@ export const TMermaidText = defineComponent({
 
     const source = computed(() => props.code ?? props.content ?? "");
 
+    const waitingForStreamingSourceToFinish = computed(
+      () => props.streaming && !props.final,
+    );
+
     function bump(): void {
       documentVersion.value++;
     }
@@ -700,7 +704,7 @@ export const TMermaidText = defineComponent({
         return;
       }
 
-      if (!props.final) {
+      if (waitingForStreamingSourceToFinish.value) {
         if (!alive || version !== renderVersion) return;
         clearRenderState();
         bump();
@@ -752,7 +756,7 @@ export const TMermaidText = defineComponent({
       // until the queued low-priority frame task runs.
       const snapshotCleared = clearRenderedSnapshot();
 
-      if (!props.final) {
+      if (waitingForStreamingSourceToFinish.value) {
         builtOnce = true;
         scheduler.cancelFrameTask?.(frameTaskId);
         if (copiedWasVisible || snapshotCleared) bump();

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -513,7 +513,8 @@ export const TMermaidText = defineComponent({
     function shouldSkipRender(code: string): boolean {
       if (shouldSkipRenderForSize(code)) return true;
 
-      const shouldRenderSource = props.shouldRenderSource ?? isSimpleMermaidFlowchartSource;
+      const shouldRenderSource = props.shouldRenderSource;
+      if (!shouldRenderSource) return false;
 
       try {
         return !shouldRenderSource(code, {

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -98,7 +98,6 @@ export type TMermaidCopyPayload = Readonly<{
 }>;
 
 export type TMermaidRenderEligibilityContext = Readonly<{
-  code: string;
   final: boolean;
   streaming: boolean;
 }>;
@@ -134,7 +133,7 @@ const ASCII_MERMAID_BOX_CHARS: TMermaidBoxChars = Object.freeze({
 });
 
 const DEFAULT_MERMAID_MAX_RENDER_FLOW_STATEMENTS = 120;
-const SIMPLE_MERMAID_DIRECTIVE_RE = /^(?:graph|flowchart)\s+(?:TB|TD|BT|LR|RL)\b/i;
+const SIMPLE_MERMAID_DIRECTIVE_RE = /^(?:graph|flowchart)\s+(?:TB|TD|BT|LR|RL)\s*$/i;
 const MERMAID_INIT_DIRECTIVE_RE = /^%%\{/;
 const MERMAID_COMMENT_RE = /^%%/;
 const MERMAID_FRONTMATTER_DELIMITER_RE = /^---\s*$/;
@@ -425,9 +424,7 @@ function clipboardCanWrite(api: { supported: boolean; canWrite?: boolean }): boo
   return api.canWrite ?? api.supported;
 }
 
-function timeoutError(ms: number): Error {
-  return new Error(`Mermaid render timed out after ${ms}ms`);
-}
+const MERMAID_RENDER_TIMEOUT = Symbol("MERMAID_RENDER_TIMEOUT");
 
 type TMermaidFatalRenderError = Error & {
   [TUI_MERMAID_FATAL_RENDER_ERROR]?: true;
@@ -488,6 +485,9 @@ export const tMermaidTextProps = {
     type: Function as PropType<TMermaidRenderer>,
     default: undefined,
   },
+  // Deprecated source-first compatibility props.
+  // Source-first Mermaid never paints loading/incomplete/error placeholders;
+  // renderer failure keeps source visible. These props remain for source compatibility.
   isTransientError: {
     type: Function as PropType<TMermaidTransientErrorClassifier>,
     default: undefined,
@@ -496,6 +496,8 @@ export const tMermaidTextProps = {
     type: Function as PropType<TMermaidRenderEligibility>,
     default: undefined,
   },
+  // Deprecated source-first compatibility text props.
+  // Kept so existing callers do not break, but not used by the source-first renderer.
   loadingText: {
     type: String,
     default: "Rendering Mermaid diagram...",
@@ -643,7 +645,6 @@ export const TMermaidText = defineComponent({
 
       try {
         return !shouldRenderSource(code, {
-          code,
           final: props.final,
           streaming: props.streaming,
         });
@@ -669,7 +670,7 @@ export const TMermaidText = defineComponent({
         return await Promise.race([
           Promise.resolve().then(() => renderer(code, options)),
           new Promise<string>((_resolve, reject) => {
-            timer = setTimeout(() => reject(timeoutError(timeoutMs)), timeoutMs);
+            timer = setTimeout(() => reject(MERMAID_RENDER_TIMEOUT), timeoutMs);
           }),
         ]);
       } finally {

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -77,8 +77,6 @@ export type TMermaidTransientErrorClassifier = (
   context: TMermaidTransientErrorContext,
 ) => boolean;
 
-type TMermaidStatus = "idle" | "loading" | "ready" | "incomplete" | "error";
-
 type TMermaidBoxChars = Readonly<{
   tl: string;
   tr: string;
@@ -160,10 +158,6 @@ const TERMINAL_ESCAPE_RE = new RegExp(
 
 function stripTerminalEscapes(value: string): string {
   return value.replace(TERMINAL_ESCAPE_RE, "");
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 
 function normalizeNonNegativeInt(value: unknown, fallback: number): number {
@@ -383,10 +377,8 @@ function clipboardCanWrite(api: { supported: boolean; canWrite?: boolean }): boo
   return api.canWrite ?? api.supported;
 }
 
-function timeoutError(ms: number): Error & { code: string } {
-  const error = new Error(`Mermaid render timed out after ${ms}ms`) as Error & { code: string };
-  error.code = "VUE_TUI_MERMAID_RENDER_TIMEOUT";
-  return error;
+function timeoutError(ms: number): Error {
+  return new Error(`Mermaid render timed out after ${ms}ms`);
 }
 
 type TMermaidFatalRenderError = Error & {
@@ -408,61 +400,6 @@ export function markMermaidRenderErrorFatal(error: unknown): Error {
     } catch {}
   }
   return normalized;
-}
-
-function errorCode(error: unknown): string {
-  if (!error || typeof error !== "object") return "";
-  const value = (error as { code?: unknown }).code;
-  return typeof value === "string" ? value : "";
-}
-
-function errorCause(error: unknown): unknown {
-  if (!error || typeof error !== "object") return undefined;
-  return (error as { cause?: unknown }).cause;
-}
-
-const PERMANENT_MERMAID_RENDER_ERROR_CODES = new Set([
-  "VUE_TUI_MISSING_BEAUTIFUL_MERMAID",
-  "VUE_TUI_INVALID_BEAUTIFUL_MERMAID_EXPORT",
-  "VUE_TUI_MERMAID_RENDERER_SETUP",
-  "VUE_TUI_MISSING_MERMAID_RENDERER",
-]);
-
-function hasErrorCode(
-  error: unknown,
-  codes: ReadonlySet<string>,
-  seen = new WeakSet<object>(),
-): boolean {
-  if (!error || typeof error !== "object") return false;
-  if (seen.has(error)) return false;
-  seen.add(error);
-
-  if (codes.has(errorCode(error))) return true;
-
-  const cause = errorCause(error);
-  return cause !== undefined && hasErrorCode(cause, codes, seen);
-}
-
-function isMermaidRenderErrorFatal(error: unknown, seen = new WeakSet<object>()): boolean {
-  if (!error || typeof error !== "object") return false;
-  if (seen.has(error)) return false;
-  seen.add(error);
-
-  if (
-    fatalMermaidRenderErrors.has(error) ||
-    (error as TMermaidFatalRenderError)[TUI_MERMAID_FATAL_RENDER_ERROR] === true
-  ) {
-    return true;
-  }
-
-  const cause = errorCause(error);
-  return cause !== undefined && isMermaidRenderErrorFatal(cause, seen);
-}
-
-function isPermanentMermaidRenderError(error: unknown): boolean {
-  return (
-    isMermaidRenderErrorFatal(error) || hasErrorCode(error, PERMANENT_MERMAID_RENDER_ERROR_CODES)
-  );
 }
 
 function splitRenderedOutput(value: string): readonly string[] {
@@ -559,9 +496,6 @@ export const TMermaidText = defineComponent({
     const { visible, rootProps } = useVisibility();
     const parentEventZ = inject(EventZIndexContextKey, computed(() => 0) as any);
 
-    const status = shallowRef<TMermaidStatus>("idle");
-    const error = shallowRef("");
-    const missingRenderer = shallowRef(false);
     const renderedSnapshot = shallowRef<TMermaidRenderSnapshot | null>(null);
     const documentVersion = shallowRef(0);
     const copied = shallowRef(false);
@@ -589,24 +523,6 @@ export const TMermaidText = defineComponent({
         boxBorderPadding: props.boxBorderPadding ?? base.boxBorderPadding,
         colorMode: "none",
       };
-    }
-
-    function shouldTreatRenderErrorAsTransient(err: unknown, code: string): boolean {
-      if (!props.streaming || props.final || isPermanentMermaidRenderError(err)) return false;
-
-      const context: TMermaidTransientErrorContext = {
-        code,
-        final: props.final,
-        streaming: props.streaming,
-      };
-
-      if (!props.isTransientError) return true;
-
-      try {
-        return props.isTransientError(err, context);
-      } catch {
-        return false;
-      }
     }
 
     function clearCopiedTimer(): void {
@@ -710,51 +626,55 @@ export const TMermaidText = defineComponent({
       }
     }
 
+    function clearRenderState(): void {
+      renderedSnapshot.value = null;
+    }
+
+    function acceptRenderedSnapshot(code: string, rendered: string): void {
+      const renderedLines = splitRenderedOutput(rendered);
+      if (!hasVisibleRenderedOutput(renderedLines)) {
+        renderedSnapshot.value = null;
+        return;
+      }
+
+      renderedSnapshot.value = markRaw({
+        source: code,
+        lines: markRaw(renderedLines),
+      });
+    }
+
     async function renderNow(version: number): Promise<void> {
       const code = source.value;
       if (!code.trim()) {
         if (!alive || version !== renderVersion) return;
-        renderedSnapshot.value = null;
-        status.value = "idle";
-        error.value = "";
-        missingRenderer.value = false;
+        clearRenderState();
         bump();
         return;
       }
 
       if (!props.final) {
         if (!alive || version !== renderVersion) return;
-        renderedSnapshot.value = null;
-        status.value = "idle";
-        error.value = "";
-        missingRenderer.value = false;
+        clearRenderState();
         bump();
         return;
       }
 
       if (shouldSkipRender(code)) {
         if (!alive || version !== renderVersion) return;
-        renderedSnapshot.value = null;
-        status.value = "idle";
-        error.value = "";
-        missingRenderer.value = false;
+        clearRenderState();
         bump();
         return;
       }
 
+      // Source-first invariant: while renderer is pending, screen must keep showing source.
       renderedSnapshot.value = null;
-      status.value = "loading";
-      error.value = "";
-      missingRenderer.value = false;
       bump();
 
       try {
         const renderer = props.renderer;
         if (!renderer) {
           if (!alive || version !== renderVersion) return;
-          renderedSnapshot.value = null;
-          missingRenderer.value = true;
-          status.value = "error";
+          clearRenderState();
           bump();
           return;
         }
@@ -762,37 +682,11 @@ export const TMermaidText = defineComponent({
         const rendered = await renderWithTimeout(renderer, code, resolveAsciiOptions());
         if (!alive || version !== renderVersion) return;
 
-        const renderedLines = splitRenderedOutput(rendered);
-        if (hasVisibleRenderedOutput(renderedLines)) {
-          renderedSnapshot.value = markRaw({
-            source: code,
-            lines: markRaw(renderedLines),
-          });
-          status.value = "ready";
-          error.value = "";
-          missingRenderer.value = false;
-          bump();
-          return;
-        }
-
-        renderedSnapshot.value = null;
-        status.value = "error";
-        error.value = "";
-        missingRenderer.value = false;
+        acceptRenderedSnapshot(code, rendered);
         bump();
-      } catch (err) {
+      } catch {
         if (!alive || version !== renderVersion) return;
-        renderedSnapshot.value = null;
-        missingRenderer.value = false;
-        error.value = errorMessage(err);
-
-        if (shouldTreatRenderErrorAsTransient(err, code)) {
-          status.value = "incomplete";
-          bump();
-          return;
-        }
-
-        status.value = "error";
+        clearRenderState();
         bump();
       }
     }
@@ -813,10 +707,7 @@ export const TMermaidText = defineComponent({
       if (!props.final) {
         builtOnce = true;
         scheduler.cancelFrameTask?.(frameTaskId);
-        status.value = "idle";
-        error.value = "";
-        missingRenderer.value = false;
-        bump();
+        if (copiedWasVisible || snapshotCleared) bump();
         return;
       }
 
@@ -859,7 +750,6 @@ export const TMermaidText = defineComponent({
         () => props.options,
         () => props.streaming,
         () => props.final,
-        () => props.isTransientError,
         () => props.renderTimeoutMs,
         () => props.maxRenderSourceChars,
         () => props.maxRenderSourceLines,
@@ -1165,9 +1055,6 @@ export const TMermaidText = defineComponent({
         displayLines.value,
         currentStyle.value,
         props.clear,
-        status.value,
-        error.value,
-        missingRenderer.value,
         renderedSnapshot.value,
         hasBox.value,
         boxChars.value,

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -474,9 +474,12 @@ export const TMermaidText = defineComponent({
       return props.style ?? defaultStyle.value;
     });
 
+    const contentHeight = computed(() => {
+      return Math.max(1, props.h ?? displayLines.value.length);
+    });
+
     const fullRect = computed<Rect>(() => {
-      const contentHeight = Math.max(1, displayLines.value.length);
-      const height = props.h ?? (hasBox.value ? contentHeight + 2 : contentHeight);
+      const height = hasBox.value ? contentHeight.value + 2 : contentHeight.value;
       return translateRect(
         { x: props.x, y: props.y, w: props.w, h: height },
         layout.originX,

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -367,15 +367,18 @@ export const TMermaidText = defineComponent({
     }
 
     function showCopiedFeedback(): void {
-      setCopied(true);
       clearCopiedTimer();
 
       const duration = normalizeNonNegativeInt(
         props.copiedDurationMs,
         DEFAULT_MERMAID_COPIED_DURATION_MS,
       );
-      if (duration <= 0) return;
+      if (duration <= 0) {
+        setCopied(false);
+        return;
+      }
 
+      setCopied(true);
       copiedTimer = setTimeout(() => {
         copiedTimer = null;
         if (!alive) return;
@@ -436,7 +439,7 @@ export const TMermaidText = defineComponent({
         return;
       }
 
-      if (props.streaming && !props.final) {
+      if (!props.final) {
         if (!alive || version !== renderVersion) return;
         renderedSnapshot.value = null;
         status.value = "idle";
@@ -515,7 +518,7 @@ export const TMermaidText = defineComponent({
       const version = ++renderVersion;
       setCopied(false, false);
 
-      if (props.streaming && !props.final) {
+      if (!props.final) {
         builtOnce = true;
         scheduler.cancelFrameTask?.(frameTaskId);
         renderedSnapshot.value = null;
@@ -749,15 +752,21 @@ export const TMermaidText = defineComponent({
       void copySource();
     }
 
+    const copyNodeActive = computed(
+      () => visible.value && hasBox.value && props.copyButton && copyHitRect.value.w > 0,
+    );
+
     useTerminalNode(() => ({
       rect: copyHitRect.value,
       zIndex: props.zIndex + 1,
-      visible: visible.value && hasBox.value && props.copyButton && copyHitRect.value.w > 0,
-      focusable: true,
-      handlers: {
-        click: onCopyClick,
-        keydown: onCopyKeydown,
-      },
+      visible: copyNodeActive.value,
+      focusable: copyNodeActive.value,
+      handlers: copyNodeActive.value
+        ? {
+            click: onCopyClick,
+            keydown: onCopyKeydown,
+          }
+        : {},
     }));
 
     function overlayCells(row: string, segment: HeaderSegment, width: number): string {

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -514,8 +514,7 @@ export const TMermaidText = defineComponent({
     function shouldSkipRender(code: string): boolean {
       if (shouldSkipRenderForSize(code)) return true;
 
-      const shouldRenderSource = props.shouldRenderSource;
-      if (!shouldRenderSource) return false;
+      const shouldRenderSource = props.shouldRenderSource ?? isSimpleMermaidFlowchartSource;
 
       try {
         return !shouldRenderSource(code, {

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -90,6 +90,17 @@ export type TMermaidCopyPayload = Readonly<{
   error?: unknown;
 }>;
 
+export type TMermaidRenderEligibilityContext = Readonly<{
+  code: string;
+  final: boolean;
+  streaming: boolean;
+}>;
+
+export type TMermaidRenderEligibility = (
+  code: string,
+  context: TMermaidRenderEligibilityContext,
+) => boolean;
+
 const TUI_MERMAID_FATAL_RENDER_ERROR = "__vueTuiMermaidFatalRenderError" as const;
 const fatalMermaidRenderErrors = new WeakSet<object>();
 const DEFAULT_MERMAID_RENDER_TIMEOUT_MS = 2500;
@@ -97,11 +108,6 @@ const DEFAULT_MERMAID_MAX_RENDER_SOURCE_CHARS = 20_000;
 const DEFAULT_MERMAID_MAX_RENDER_SOURCE_LINES = 400;
 const DEFAULT_MERMAID_COPIED_DURATION_MS = 1200;
 
-// Keep Mermaid rendering intentionally conservative. The renderer runs on the
-// main thread, so timeout guards cannot protect us from synchronous CPU-heavy
-// Mermaid layouts. Only simple graph/flowchart sources are eligible for
-// replacement rendering; unsupported, non-flowchart, or complex sources stay as
-// source text.
 const DEFAULT_MERMAID_MAX_RENDER_FLOW_STATEMENTS = 120;
 const SIMPLE_MERMAID_DIRECTIVE_RE = /^(?:graph|flowchart)\s+(?:TB|TD|BT|LR|RL)\b/i;
 const MERMAID_INIT_DIRECTIVE_RE = /^%%\{/;
@@ -227,14 +233,14 @@ function countMermaidFlowStatementsUpTo(code: string, max: number): number {
   return statements;
 }
 
-function shouldSkipRenderForComplexity(code: string): boolean {
+export function isSimpleMermaidFlowchartSource(code: string): boolean {
   const first = firstMermaidStatement(code);
-  if (!first) return true;
-  if (!SIMPLE_MERMAID_DIRECTIVE_RE.test(first)) return true;
-  if (hasComplexMermaidFlowFeature(code)) return true;
+  if (!first) return false;
+  if (!SIMPLE_MERMAID_DIRECTIVE_RE.test(first)) return false;
+  if (hasComplexMermaidFlowFeature(code)) return false;
 
   return (
-    countMermaidFlowStatementsUpTo(code, DEFAULT_MERMAID_MAX_RENDER_FLOW_STATEMENTS) >
+    countMermaidFlowStatementsUpTo(code, DEFAULT_MERMAID_MAX_RENDER_FLOW_STATEMENTS) <=
     DEFAULT_MERMAID_MAX_RENDER_FLOW_STATEMENTS
   );
 }
@@ -361,6 +367,10 @@ export const tMermaidTextProps = {
   },
   isTransientError: {
     type: Function as PropType<TMermaidTransientErrorClassifier>,
+    default: undefined,
+  },
+  shouldRenderSource: {
+    type: Function as PropType<TMermaidRenderEligibility>,
     default: undefined,
   },
   loadingText: {
@@ -516,7 +526,20 @@ export const TMermaidText = defineComponent({
     }
 
     function shouldSkipRender(code: string): boolean {
-      return shouldSkipRenderForSize(code) || shouldSkipRenderForComplexity(code);
+      if (shouldSkipRenderForSize(code)) return true;
+
+      const shouldRenderSource = props.shouldRenderSource;
+      if (!shouldRenderSource) return false;
+
+      try {
+        return !shouldRenderSource(code, {
+          code,
+          final: props.final,
+          streaming: props.streaming,
+        });
+      } catch {
+        return true;
+      }
     }
 
     async function renderWithTimeout(
@@ -683,6 +706,7 @@ export const TMermaidText = defineComponent({
         () => props.renderTimeoutMs,
         () => props.maxRenderSourceChars,
         () => props.maxRenderSourceLines,
+        () => props.shouldRenderSource,
       ],
       () => {
         scheduleRender();

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -227,7 +227,8 @@ function countMermaidFlowStatementsUpTo(code: string, max: number): number {
 
 function shouldSkipRenderForComplexity(code: string): boolean {
   const first = firstMermaidStatement(code);
-  if (!SIMPLE_MERMAID_DIRECTIVE_RE.test(first)) return true;
+  if (!first) return true;
+  if (!SIMPLE_MERMAID_DIRECTIVE_RE.test(first)) return false;
   if (hasComplexMermaidFlowFeature(code)) return true;
 
   return (

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -113,12 +113,10 @@ const SIMPLE_MERMAID_DIRECTIVE_RE = /^(?:graph|flowchart)\s+(?:TB|TD|BT|LR|RL)\b
 const MERMAID_INIT_DIRECTIVE_RE = /^%%\{/;
 const MERMAID_COMMENT_RE = /^%%/;
 const MERMAID_FRONTMATTER_DELIMITER_RE = /^---\s*$/;
-const SIMPLE_MERMAID_NODE_ID_RE_SOURCE = "[A-Za-z_][A-Za-z0-9_]*";
-const SIMPLE_MERMAID_FLOW_EDGE_RE = new RegExp(
-  `^${SIMPLE_MERMAID_NODE_ID_RE_SOURCE}\\s*(?:-->|---)\\s*${SIMPLE_MERMAID_NODE_ID_RE_SOURCE}$`,
-);
+const SIMPLE_MERMAID_FLOW_STATEMENT_START_RE = /^[A-Za-z_][A-Za-z0-9_-]*/;
+const SIMPLE_MERMAID_COMPLEX_TOKEN_RE = /:::[A-Za-z_][A-Za-z0-9_-]*|@\{/;
 const COMPLEX_MERMAID_FLOW_FEATURE_RE =
-  /^(?:subgraph|classDef|class|click|style|linkStyle|accTitle|accDescr|direction)\b/i;
+  /^(?:subgraph|end|classDef|class|click|style|linkStyle|accTitle|accDescr|direction)\b/i;
 
 const ESC = String.fromCharCode(27);
 const BEL = String.fromCharCode(7);
@@ -204,14 +202,17 @@ function isForbiddenMermaidFlowStatement(statement: string): boolean {
   );
 }
 
-function isSimpleMermaidFlowEdgeStatement(statement: string): boolean {
-  return SIMPLE_MERMAID_FLOW_EDGE_RE.test(statement);
+function isSimpleMermaidFlowStatement(statement: string): boolean {
+  if (SIMPLE_MERMAID_DIRECTIVE_RE.test(statement)) return false;
+  if (isForbiddenMermaidFlowStatement(statement)) return false;
+  if (SIMPLE_MERMAID_COMPLEX_TOKEN_RE.test(statement)) return false;
+  return SIMPLE_MERMAID_FLOW_STATEMENT_START_RE.test(statement);
 }
 
 export function isSimpleMermaidFlowchartSource(code: string): boolean {
   const statements = mermaidSourceStatements(code);
   let sawDirective = false;
-  let flowStatements = 0;
+  let renderableStatements = 0;
 
   for (const statement of statements) {
     if (!sawDirective) {
@@ -220,15 +221,13 @@ export function isSimpleMermaidFlowchartSource(code: string): boolean {
       continue;
     }
 
-    if (SIMPLE_MERMAID_DIRECTIVE_RE.test(statement)) return false;
-    if (isForbiddenMermaidFlowStatement(statement)) return false;
-    if (!isSimpleMermaidFlowEdgeStatement(statement)) return false;
+    if (!isSimpleMermaidFlowStatement(statement)) return false;
 
-    flowStatements++;
-    if (flowStatements > DEFAULT_MERMAID_MAX_RENDER_FLOW_STATEMENTS) return false;
+    renderableStatements++;
+    if (renderableStatements > DEFAULT_MERMAID_MAX_RENDER_FLOW_STATEMENTS) return false;
   }
 
-  return sawDirective && flowStatements > 0;
+  return sawDirective && renderableStatements > 0;
 }
 
 function timeoutError(ms: number): Error & { code: string } {

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -113,8 +113,12 @@ const SIMPLE_MERMAID_DIRECTIVE_RE = /^(?:graph|flowchart)\s+(?:TB|TD|BT|LR|RL)\b
 const MERMAID_INIT_DIRECTIVE_RE = /^%%\{/;
 const MERMAID_COMMENT_RE = /^%%/;
 const MERMAID_FRONTMATTER_DELIMITER_RE = /^---\s*$/;
+const SIMPLE_MERMAID_NODE_ID_RE_SOURCE = "[A-Za-z_][A-Za-z0-9_]*";
+const SIMPLE_MERMAID_FLOW_EDGE_RE = new RegExp(
+  `^${SIMPLE_MERMAID_NODE_ID_RE_SOURCE}\\s*(?:-->|---)\\s*${SIMPLE_MERMAID_NODE_ID_RE_SOURCE}$`,
+);
 const COMPLEX_MERMAID_FLOW_FEATURE_RE =
-  /^(?:subgraph|classDef|class|click|style|linkStyle|accTitle|accDescr)\b/i;
+  /^(?:subgraph|classDef|class|click|style|linkStyle|accTitle|accDescr|direction)\b/i;
 
 const ESC = String.fromCharCode(27);
 const BEL = String.fromCharCode(7);
@@ -192,57 +196,39 @@ function mermaidSourceStatements(code: string): readonly string[] {
   return statements;
 }
 
-function firstMermaidStatement(code: string): string {
-  for (const statement of mermaidSourceStatements(code)) {
-    if (MERMAID_INIT_DIRECTIVE_RE.test(statement)) return "";
-    if (MERMAID_FRONTMATTER_DELIMITER_RE.test(statement)) return "";
-    return statement;
-  }
-
-  return "";
+function isForbiddenMermaidFlowStatement(statement: string): boolean {
+  return (
+    MERMAID_INIT_DIRECTIVE_RE.test(statement) ||
+    MERMAID_FRONTMATTER_DELIMITER_RE.test(statement) ||
+    COMPLEX_MERMAID_FLOW_FEATURE_RE.test(statement)
+  );
 }
 
-function hasComplexMermaidFlowFeature(code: string): boolean {
-  for (const statement of mermaidSourceStatements(code)) {
-    if (MERMAID_INIT_DIRECTIVE_RE.test(statement)) return true;
-    if (MERMAID_FRONTMATTER_DELIMITER_RE.test(statement)) return true;
-    if (SIMPLE_MERMAID_DIRECTIVE_RE.test(statement)) continue;
-
-    if (COMPLEX_MERMAID_FLOW_FEATURE_RE.test(statement)) return true;
-  }
-
-  return false;
+function isSimpleMermaidFlowEdgeStatement(statement: string): boolean {
+  return SIMPLE_MERMAID_FLOW_EDGE_RE.test(statement);
 }
 
-function countMermaidFlowStatementsUpTo(code: string, max: number): number {
-  if (max <= 0) return 0;
-
-  let statements = 0;
+export function isSimpleMermaidFlowchartSource(code: string): boolean {
+  const statements = mermaidSourceStatements(code);
   let sawDirective = false;
+  let flowStatements = 0;
 
-  for (const statement of mermaidSourceStatements(code)) {
-    if (!sawDirective && SIMPLE_MERMAID_DIRECTIVE_RE.test(statement)) {
+  for (const statement of statements) {
+    if (!sawDirective) {
+      if (!SIMPLE_MERMAID_DIRECTIVE_RE.test(statement)) return false;
       sawDirective = true;
       continue;
     }
 
-    statements++;
-    if (statements > max) return statements;
+    if (SIMPLE_MERMAID_DIRECTIVE_RE.test(statement)) return false;
+    if (isForbiddenMermaidFlowStatement(statement)) return false;
+    if (!isSimpleMermaidFlowEdgeStatement(statement)) return false;
+
+    flowStatements++;
+    if (flowStatements > DEFAULT_MERMAID_MAX_RENDER_FLOW_STATEMENTS) return false;
   }
 
-  return statements;
-}
-
-export function isSimpleMermaidFlowchartSource(code: string): boolean {
-  const first = firstMermaidStatement(code);
-  if (!first) return false;
-  if (!SIMPLE_MERMAID_DIRECTIVE_RE.test(first)) return false;
-  if (hasComplexMermaidFlowFeature(code)) return false;
-
-  return (
-    countMermaidFlowStatementsUpTo(code, DEFAULT_MERMAID_MAX_RENDER_FLOW_STATEMENTS) <=
-    DEFAULT_MERMAID_MAX_RENDER_FLOW_STATEMENTS
-  );
+  return sawDirective && flowStatements > 0;
 }
 
 function timeoutError(ms: number): Error & { code: string } {

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -79,6 +79,15 @@ export type TMermaidTransientErrorClassifier = (
 
 type TMermaidStatus = "idle" | "loading" | "ready" | "incomplete" | "error";
 
+type TMermaidBoxChars = Readonly<{
+  tl: string;
+  tr: string;
+  bl: string;
+  br: string;
+  h: string;
+  v: string;
+}>;
+
 type TMermaidRenderSnapshot = Readonly<{
   source: string;
   lines: readonly string[];
@@ -107,6 +116,24 @@ const DEFAULT_MERMAID_RENDER_TIMEOUT_MS = 2500;
 const DEFAULT_MERMAID_MAX_RENDER_SOURCE_CHARS = 20_000;
 const DEFAULT_MERMAID_MAX_RENDER_SOURCE_LINES = 400;
 const DEFAULT_MERMAID_COPIED_DURATION_MS = 1200;
+
+const UNICODE_MERMAID_BOX_CHARS: TMermaidBoxChars = Object.freeze({
+  tl: "┌",
+  tr: "┐",
+  bl: "└",
+  br: "┘",
+  h: "─",
+  v: "│",
+});
+
+const ASCII_MERMAID_BOX_CHARS: TMermaidBoxChars = Object.freeze({
+  tl: "+",
+  tr: "+",
+  bl: "+",
+  br: "+",
+  h: "-",
+  v: "|",
+});
 
 const DEFAULT_MERMAID_MAX_RENDER_FLOW_STATEMENTS = 120;
 const SIMPLE_MERMAID_DIRECTIVE_RE = /^(?:graph|flowchart)\s+(?:TB|TD|BT|LR|RL)\b/i;
@@ -830,6 +857,10 @@ export const TMermaidText = defineComponent({
 
     const hasBox = computed(() => props.box !== false);
 
+    const boxChars = computed<TMermaidBoxChars>(() =>
+      props.ascii ? ASCII_MERMAID_BOX_CHARS : UNICODE_MERMAID_BOX_CHARS,
+    );
+
     const sourceLines = computed<readonly string[]>(() => splitRenderedOutput(source.value));
 
     const displayLines = computed<readonly string[]>(() => {
@@ -849,9 +880,13 @@ export const TMermaidText = defineComponent({
     });
 
     const fullHeight = computed(() => {
+      if (props.h != null) {
+        const h = Math.floor(Number(props.h));
+        return Number.isFinite(h) ? Math.max(0, h) : 0;
+      }
+
       const autoContentHeight = Math.max(1, displayLines.value.length);
-      const autoHeight = hasBox.value ? autoContentHeight + 2 : autoContentHeight;
-      return Math.max(1, Math.floor(props.h ?? autoHeight));
+      return hasBox.value ? autoContentHeight + 2 : autoContentHeight;
     });
 
     const fullRect = computed<Rect>(() => {
@@ -1069,9 +1104,11 @@ export const TMermaidText = defineComponent({
         return contentLine(rowIndex, rowWidth, props.clear);
       }
 
+      const chars = boxChars.value;
       const innerW = Math.max(0, rowWidth - 2);
+
       if (rowIndex === 0) {
-        let row = `┌${repeatChar("─", innerW)}┐`;
+        let row = `${chars.tl}${repeatChar(chars.h, innerW)}${chars.tr}`;
         const copy = headerCopySegment(rowWidth);
         const title = headerTitleSegment(rowWidth, copy);
 
@@ -1081,9 +1118,11 @@ export const TMermaidText = defineComponent({
         return row;
       }
 
-      if (rowIndex === rowHeight - 1) return `└${repeatChar("─", innerW)}┘`;
+      if (rowIndex === rowHeight - 1) {
+        return `${chars.bl}${repeatChar(chars.h, innerW)}${chars.br}`;
+      }
 
-      return `│${contentLine(rowIndex - 1, innerW, true)}│`;
+      return `${chars.v}${contentLine(rowIndex - 1, innerW, true)}${chars.v}`;
     }
 
     useRenderNode(() => ({
@@ -1101,6 +1140,7 @@ export const TMermaidText = defineComponent({
         missingRenderer.value,
         renderedSnapshot.value,
         hasBox.value,
+        boxChars.value,
         props.title,
         props.copyButton,
         copyLabel.value,

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -90,6 +90,10 @@ export type TMermaidCopyPayload = Readonly<{
 
 const TUI_MERMAID_FATAL_RENDER_ERROR = "__vueTuiMermaidFatalRenderError" as const;
 const fatalMermaidRenderErrors = new WeakSet<object>();
+const DEFAULT_MERMAID_RENDER_TIMEOUT_MS = 2500;
+const DEFAULT_MERMAID_MAX_RENDER_SOURCE_CHARS = 20_000;
+const DEFAULT_MERMAID_MAX_RENDER_SOURCE_LINES = 400;
+const DEFAULT_MERMAID_COPIED_DURATION_MS = 1200;
 
 const ESC = String.fromCharCode(27);
 const BEL = String.fromCharCode(7);
@@ -109,6 +113,30 @@ function stripTerminalEscapes(value: string): string {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function normalizeNonNegativeInt(value: unknown, fallback: number): number {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(0, Math.floor(n));
+}
+
+function countLinesUpTo(value: string, max: number): number {
+  if (max <= 0) return 0;
+
+  let lines = 1;
+  for (let index = 0; index < value.length; index++) {
+    if (value.charCodeAt(index) !== 10) continue;
+    lines++;
+    if (lines > max) return lines;
+  }
+  return lines;
+}
+
+function timeoutError(ms: number): Error & { code: string } {
+  const error = new Error(`Mermaid render timed out after ${ms}ms`) as Error & { code: string };
+  error.code = "VUE_TUI_MERMAID_RENDER_TIMEOUT";
+  return error;
 }
 
 type TMermaidFatalRenderError = Error & {
@@ -255,6 +283,10 @@ export const tMermaidTextProps = {
   copyButton: { type: Boolean, default: true },
   copyText: { type: String, default: "copy" },
   copiedText: { type: String, default: "copied" },
+  renderTimeoutMs: { type: Number, default: DEFAULT_MERMAID_RENDER_TIMEOUT_MS },
+  maxRenderSourceChars: { type: Number, default: DEFAULT_MERMAID_MAX_RENDER_SOURCE_CHARS },
+  maxRenderSourceLines: { type: Number, default: DEFAULT_MERMAID_MAX_RENDER_SOURCE_LINES },
+  copiedDurationMs: { type: Number, default: DEFAULT_MERMAID_COPIED_DURATION_MS },
 } as const;
 
 export type TMermaidTextProps = ExtractPublicPropTypes<typeof tMermaidTextProps>;
@@ -283,6 +315,7 @@ export const TMermaidText = defineComponent({
     let renderVersion = 0;
     let alive = true;
     const frameTaskId = `TMermaidText:${instance?.uid ?? "unknown"}:mermaid`;
+    let copiedTimer: ReturnType<typeof setTimeout> | null = null;
 
     const source = computed(() => props.code ?? props.content ?? "");
 
@@ -320,6 +353,77 @@ export const TMermaidText = defineComponent({
       }
     }
 
+    function clearCopiedTimer(): void {
+      if (copiedTimer == null) return;
+      clearTimeout(copiedTimer);
+      copiedTimer = null;
+    }
+
+    function setCopied(next: boolean, repaint = true): void {
+      if (!next) clearCopiedTimer();
+      if (copied.value === next) return;
+      copied.value = next;
+      if (repaint) bump();
+    }
+
+    function showCopiedFeedback(): void {
+      setCopied(true);
+      clearCopiedTimer();
+
+      const duration = normalizeNonNegativeInt(
+        props.copiedDurationMs,
+        DEFAULT_MERMAID_COPIED_DURATION_MS,
+      );
+      if (duration <= 0) return;
+
+      copiedTimer = setTimeout(() => {
+        copiedTimer = null;
+        if (!alive) return;
+        setCopied(false);
+      }, duration);
+    }
+
+    function shouldSkipRenderForSize(code: string): boolean {
+      const maxChars = normalizeNonNegativeInt(
+        props.maxRenderSourceChars,
+        DEFAULT_MERMAID_MAX_RENDER_SOURCE_CHARS,
+      );
+      if (maxChars > 0 && code.length > maxChars) return true;
+
+      const maxLines = normalizeNonNegativeInt(
+        props.maxRenderSourceLines,
+        DEFAULT_MERMAID_MAX_RENDER_SOURCE_LINES,
+      );
+      if (maxLines > 0 && countLinesUpTo(code, maxLines) > maxLines) return true;
+
+      return false;
+    }
+
+    async function renderWithTimeout(
+      renderer: TMermaidRenderer,
+      code: string,
+      options: TMermaidResolvedAsciiOptions,
+    ): Promise<string> {
+      const timeoutMs = normalizeNonNegativeInt(
+        props.renderTimeoutMs,
+        DEFAULT_MERMAID_RENDER_TIMEOUT_MS,
+      );
+      if (timeoutMs <= 0) return await renderer(code, options);
+
+      let timer: ReturnType<typeof setTimeout> | null = null;
+
+      try {
+        return await Promise.race([
+          Promise.resolve().then(() => renderer(code, options)),
+          new Promise<string>((_resolve, reject) => {
+            timer = setTimeout(() => reject(timeoutError(timeoutMs)), timeoutMs);
+          }),
+        ]);
+      } finally {
+        if (timer != null) clearTimeout(timer);
+      }
+    }
+
     async function renderNow(version: number): Promise<void> {
       const code = source.value;
       if (!code.trim()) {
@@ -333,6 +437,16 @@ export const TMermaidText = defineComponent({
       }
 
       if (props.streaming && !props.final) {
+        if (!alive || version !== renderVersion) return;
+        renderedSnapshot.value = null;
+        status.value = "idle";
+        error.value = "";
+        missingRenderer.value = false;
+        bump();
+        return;
+      }
+
+      if (shouldSkipRenderForSize(code)) {
         if (!alive || version !== renderVersion) return;
         renderedSnapshot.value = null;
         status.value = "idle";
@@ -359,7 +473,7 @@ export const TMermaidText = defineComponent({
           return;
         }
 
-        const rendered = await renderer(code, resolveAsciiOptions());
+        const rendered = await renderWithTimeout(renderer, code, resolveAsciiOptions());
         if (!alive || version !== renderVersion) return;
 
         const renderedLines = splitRenderedOutput(rendered);
@@ -399,7 +513,7 @@ export const TMermaidText = defineComponent({
 
     function scheduleRender(): void {
       const version = ++renderVersion;
-      copied.value = false;
+      setCopied(false, false);
 
       if (props.streaming && !props.final) {
         builtOnce = true;
@@ -446,6 +560,9 @@ export const TMermaidText = defineComponent({
         () => props.streaming,
         () => props.final,
         () => props.isTransientError,
+        () => props.renderTimeoutMs,
+        () => props.maxRenderSourceChars,
+        () => props.maxRenderSourceLines,
       ],
       () => {
         scheduleRender();
@@ -456,6 +573,7 @@ export const TMermaidText = defineComponent({
     onBeforeUnmount(() => {
       alive = false;
       renderVersion++;
+      clearCopiedTimer();
       scheduler.cancelFrameTask?.(frameTaskId);
     });
 
@@ -505,22 +623,76 @@ export const TMermaidText = defineComponent({
       return withTextWidthProvider(widthProvider, () => textCellWidth(value));
     }
 
+    type HeaderSegment = Readonly<{
+      text: string;
+      start: number;
+      cells: number;
+    }>;
+
+    function segmentCells(text: string): number {
+      return cellWidth(text);
+    }
+
+    function headerCopySegment(width: number): HeaderSegment | null {
+      if (!hasBox.value || !props.copyButton) return null;
+
+      const rowWidth = Math.max(0, Math.floor(width));
+      if (rowWidth < 4) return null;
+
+      const label = sanitizeInlineText(copyLabel.value);
+      if (!label) return null;
+
+      const maxCells = Math.max(0, rowWidth - 2);
+      const text = sliceByCells(` ${label} `, maxCells);
+      const cells = segmentCells(text);
+      if (!text || cells <= 0) return null;
+
+      return {
+        text,
+        start: Math.max(1, rowWidth - cells - 1),
+        cells,
+      };
+    }
+
+    function headerTitleSegment(width: number, copy: HeaderSegment | null): HeaderSegment | null {
+      if (!hasBox.value) return null;
+
+      const rowWidth = Math.max(0, Math.floor(width));
+      if (rowWidth < 4) return null;
+
+      const title = sanitizeInlineText(props.title);
+      if (!title) return null;
+
+      const titleStart = 1;
+      const titleEnd = copy ? Math.max(titleStart, copy.start - 1) : rowWidth - 1;
+      const maxCells = Math.max(0, titleEnd - titleStart);
+      if (maxCells <= 0) return null;
+
+      const text = sliceByCells(` ${title} `, maxCells);
+      const cells = segmentCells(text);
+      if (!text || cells <= 0) return null;
+
+      return {
+        text,
+        start: titleStart,
+        cells,
+      };
+    }
+
     const copyHitRect = computed<Rect>(() => {
       if (!visible.value || !hasBox.value || !props.copyButton) return { x: 0, y: 0, w: 0, h: 0 };
+
       const full = fullRect.value;
-      const fullW = Math.max(0, Math.floor(full.w));
-      if (fullW < 4) return { x: 0, y: 0, w: 0, h: 0 };
-      const label = sanitizeInlineText(copyLabel.value);
-      if (!label) return { x: 0, y: 0, w: 0, h: 0 };
-      const labelWidth = cellWidth(label);
-      const hitWidth = Math.min(Math.max(0, fullW - 2), labelWidth + 2);
-      if (hitWidth <= 0) return { x: 0, y: 0, w: 0, h: 0 };
+      const copy = headerCopySegment(Math.max(0, Math.floor(full.w)));
+      if (!copy) return { x: 0, y: 0, w: 0, h: 0 };
+
       const raw = {
-        x: Math.floor(full.x) + Math.max(1, fullW - hitWidth - 1),
+        x: Math.floor(full.x) + copy.start,
         y: Math.floor(full.y),
-        w: hitWidth,
+        w: copy.cells,
         h: 1,
       };
+
       if (!layout.clipRect) return raw;
       return intersectRect(raw, layout.clipRect) ?? { x: 0, y: 0, w: 0, h: 0 };
     });
@@ -559,8 +731,8 @@ export const TMermaidText = defineComponent({
       }
 
       if (!alive) return;
-      copied.value = ok;
-      bump();
+      if (ok) showCopiedFeedback();
+      else setCopied(false);
       emit("copy", ok ? { text, ok } : { text, ok, error: copyError });
     }
 
@@ -588,18 +760,17 @@ export const TMermaidText = defineComponent({
       },
     }));
 
-    function overlayCells(row: string, text: string, start: number, width: number): string {
+    function overlayCells(row: string, segment: HeaderSegment, width: number): string {
       const rowWidth = Math.max(0, Math.floor(width));
-      const end = Math.max(0, rowWidth - 1);
-      const clampedStart = Math.max(0, Math.floor(start));
-      if (rowWidth <= 1 || clampedStart >= end) return row;
-      const clipped = sliceByCells(text, Math.max(0, end - clampedStart));
-      if (!clipped) return row;
-      return `${sliceByCells(row, clampedStart)}${clipped}${sliceByCellsRange(
-        row,
-        clampedStart + cellWidth(clipped),
-        rowWidth,
-      )}`;
+      const start = Math.max(0, Math.floor(segment.start));
+      if (rowWidth <= 1 || start >= rowWidth - 1 || segment.cells <= 0) return row;
+
+      const maxCells = Math.max(0, rowWidth - 1 - start);
+      const text = sliceByCells(segment.text, maxCells);
+      const cells = segmentCells(text);
+      if (!text || cells <= 0) return row;
+
+      return `${sliceByCells(row, start)}${text}${sliceByCellsRange(row, start + cells, rowWidth)}`;
     }
 
     function contentLine(rowIndex: number, width: number, pad: boolean): string {
@@ -609,27 +780,26 @@ export const TMermaidText = defineComponent({
     }
 
     function boxRow(rowIndex: number, width: number, height: number): string {
-      if (!hasBox.value || width < 2 || height < 2) {
-        return contentLine(rowIndex, width, props.clear);
+      const rowWidth = Math.max(0, Math.floor(width));
+      const rowHeight = Math.max(0, Math.floor(height));
+
+      if (!hasBox.value || rowWidth < 2 || rowHeight < 2) {
+        return contentLine(rowIndex, rowWidth, props.clear);
       }
 
-      const innerW = Math.max(0, width - 2);
+      const innerW = Math.max(0, rowWidth - 2);
       if (rowIndex === 0) {
         let row = `┌${repeatChar("─", innerW)}┐`;
-        const title = sanitizeInlineText(props.title);
-        if (title) row = overlayCells(row, ` ${title} `, 1, width);
-        if (props.copyButton) {
-          const label = sanitizeInlineText(copyLabel.value);
-          if (label) {
-            const copy = sliceByCells(` ${label} `, Math.max(0, width - 2));
-            const start = Math.max(1, width - cellWidth(copy) - 1);
-            row = overlayCells(row, copy, start, width);
-          }
-        }
+        const copy = headerCopySegment(rowWidth);
+        const title = headerTitleSegment(rowWidth, copy);
+
+        if (title) row = overlayCells(row, title, rowWidth);
+        if (copy) row = overlayCells(row, copy, rowWidth);
+
         return row;
       }
 
-      if (rowIndex === height - 1) return `└${repeatChar("─", innerW)}┘`;
+      if (rowIndex === rowHeight - 1) return `└${repeatChar("─", innerW)}┘`;
 
       return `│${contentLine(rowIndex - 1, innerW, true)}│`;
     }

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -663,7 +663,8 @@ export const TMermaidText = defineComponent({
     function shouldSkipRender(code: string): boolean {
       if (shouldSkipRenderForSize(code)) return true;
 
-      const shouldRenderSource = props.shouldRenderSource ?? isSimpleMermaidFlowchartSource;
+      const shouldRenderSource = props.shouldRenderSource;
+      if (!shouldRenderSource) return false;
 
       try {
         return !shouldRenderSource(code, {
@@ -857,6 +858,13 @@ export const TMermaidText = defineComponent({
 
     const hasBox = computed(() => props.box !== false);
 
+    const normalizedWidth = computed(() => {
+      const width = Math.floor(Number(props.w));
+      return Number.isFinite(width) ? Math.max(0, width) : 0;
+    });
+
+    const reservesBoxRows = computed(() => hasBox.value && normalizedWidth.value >= 2);
+
     const boxChars = computed<TMermaidBoxChars>(() =>
       props.ascii ? ASCII_MERMAID_BOX_CHARS : UNICODE_MERMAID_BOX_CHARS,
     );
@@ -886,7 +894,7 @@ export const TMermaidText = defineComponent({
       }
 
       const autoContentHeight = Math.max(1, displayLines.value.length);
-      return hasBox.value ? autoContentHeight + 2 : autoContentHeight;
+      return reservesBoxRows.value ? autoContentHeight + 2 : autoContentHeight;
     });
 
     const fullRect = computed<Rect>(() => {

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -140,7 +140,6 @@ const MERMAID_COMMENT_RE = /^%%/;
 const MERMAID_FRONTMATTER_DELIMITER_RE = /^---\s*$/;
 const SIMPLE_MERMAID_FLOW_STATEMENT_START_RE =
   /^(?:"[^"]+"|'[^']+'|`[^`]+`|[A-Za-z0-9_][A-Za-z0-9_-]*)/;
-const SIMPLE_MERMAID_COMPLEX_TOKEN_RE = /:::[A-Za-z_][A-Za-z0-9_-]*|@\{/;
 const COMPLEX_MERMAID_FLOW_FEATURE_RE =
   /^(?:subgraph|end|classDef|class|click|style|linkStyle|accTitle|accDescr|direction)\b/i;
 
@@ -192,6 +191,7 @@ type MermaidScannerState = {
   squareDepth: number;
   parenDepth: number;
   braceDepth: number;
+  pipeLabel: boolean;
 };
 
 function createMermaidScannerState(): MermaidScannerState {
@@ -201,16 +201,39 @@ function createMermaidScannerState(): MermaidScannerState {
     squareDepth: 0,
     parenDepth: 0,
     braceDepth: 0,
+    pipeLabel: false,
   };
 }
 
 function scannerAtTopLevel(state: MermaidScannerState): boolean {
   return (
-    !state.quote && state.squareDepth === 0 && state.parenDepth === 0 && state.braceDepth === 0
+    !state.quote &&
+    !state.pipeLabel &&
+    state.squareDepth === 0 &&
+    state.parenDepth === 0 &&
+    state.braceDepth === 0
   );
 }
 
 function advanceMermaidScannerState(state: MermaidScannerState, ch: string): void {
+  if (state.pipeLabel) {
+    if (state.escaped) {
+      state.escaped = false;
+      return;
+    }
+
+    if (ch === "\\") {
+      state.escaped = true;
+      return;
+    }
+
+    if (ch === "|") {
+      state.pipeLabel = false;
+    }
+
+    return;
+  }
+
   if (state.quote) {
     if (state.escaped) {
       state.escaped = false;
@@ -231,6 +254,12 @@ function advanceMermaidScannerState(state: MermaidScannerState, ch: string): voi
 
   if (ch === '"' || ch === "'" || ch === "`") {
     state.quote = ch;
+    state.escaped = false;
+    return;
+  }
+
+  if (ch === "|" && scannerAtTopLevel(state)) {
+    state.pipeLabel = true;
     state.escaped = false;
     return;
   }
@@ -342,10 +371,29 @@ function isForbiddenMermaidFlowStatement(statement: string): boolean {
   );
 }
 
+function hasTopLevelMermaidComplexToken(statement: string): boolean {
+  const state = createMermaidScannerState();
+
+  for (let index = 0; index < statement.length; index++) {
+    const ch = statement[index] ?? "";
+
+    if (scannerAtTopLevel(state)) {
+      if (statement.startsWith("@{", index)) return true;
+      if (statement.startsWith(":::", index) && /[A-Za-z_]/.test(statement[index + 3] ?? "")) {
+        return true;
+      }
+    }
+
+    advanceMermaidScannerState(state, ch);
+  }
+
+  return false;
+}
+
 function isSimpleMermaidFlowStatement(statement: string): boolean {
   if (SIMPLE_MERMAID_DIRECTIVE_RE.test(statement)) return false;
   if (isForbiddenMermaidFlowStatement(statement)) return false;
-  if (SIMPLE_MERMAID_COMPLEX_TOKEN_RE.test(statement)) return false;
+  if (hasTopLevelMermaidComplexToken(statement)) return false;
   return SIMPLE_MERMAID_FLOW_STATEMENT_START_RE.test(statement);
 }
 

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -113,7 +113,8 @@ const SIMPLE_MERMAID_DIRECTIVE_RE = /^(?:graph|flowchart)\s+(?:TB|TD|BT|LR|RL)\b
 const MERMAID_INIT_DIRECTIVE_RE = /^%%\{/;
 const MERMAID_COMMENT_RE = /^%%/;
 const MERMAID_FRONTMATTER_DELIMITER_RE = /^---\s*$/;
-const SIMPLE_MERMAID_FLOW_STATEMENT_START_RE = /^[A-Za-z_][A-Za-z0-9_-]*/;
+const SIMPLE_MERMAID_FLOW_STATEMENT_START_RE =
+  /^(?:"[^"]+"|'[^']+'|`[^`]+`|[A-Za-z0-9_][A-Za-z0-9_-]*)/;
 const SIMPLE_MERMAID_COMPLEX_TOKEN_RE = /:::[A-Za-z_][A-Za-z0-9_-]*|@\{/;
 const COMPLEX_MERMAID_FLOW_FEATURE_RE =
   /^(?:subgraph|end|classDef|class|click|style|linkStyle|accTitle|accDescr|direction)\b/i;
@@ -164,6 +165,127 @@ function countLinesUpTo(value: string, max: number): number {
   return lines;
 }
 
+type MermaidScannerState = {
+  quote: '"' | "'" | "`" | "";
+  escaped: boolean;
+  squareDepth: number;
+  parenDepth: number;
+  braceDepth: number;
+};
+
+function createMermaidScannerState(): MermaidScannerState {
+  return {
+    quote: "",
+    escaped: false,
+    squareDepth: 0,
+    parenDepth: 0,
+    braceDepth: 0,
+  };
+}
+
+function scannerAtTopLevel(state: MermaidScannerState): boolean {
+  return (
+    !state.quote &&
+    state.squareDepth === 0 &&
+    state.parenDepth === 0 &&
+    state.braceDepth === 0
+  );
+}
+
+function advanceMermaidScannerState(state: MermaidScannerState, ch: string): void {
+  if (state.quote) {
+    if (state.escaped) {
+      state.escaped = false;
+      return;
+    }
+
+    if (ch === "\\") {
+      state.escaped = true;
+      return;
+    }
+
+    if (ch === state.quote) {
+      state.quote = "";
+    }
+
+    return;
+  }
+
+  if (ch === '"' || ch === "'" || ch === "`") {
+    state.quote = ch;
+    state.escaped = false;
+    return;
+  }
+
+  if (ch === "[") {
+    state.squareDepth++;
+    return;
+  }
+
+  if (ch === "]") {
+    state.squareDepth = Math.max(0, state.squareDepth - 1);
+    return;
+  }
+
+  if (ch === "(") {
+    state.parenDepth++;
+    return;
+  }
+
+  if (ch === ")") {
+    state.parenDepth = Math.max(0, state.parenDepth - 1);
+    return;
+  }
+
+  if (ch === "{") {
+    state.braceDepth++;
+    return;
+  }
+
+  if (ch === "}") {
+    state.braceDepth = Math.max(0, state.braceDepth - 1);
+  }
+}
+
+function splitMermaidLineStatements(line: string): readonly string[] {
+  const out: string[] = [];
+  const state = createMermaidScannerState();
+  let start = 0;
+
+  for (let index = 0; index < line.length; index++) {
+    const ch = line[index] ?? "";
+
+    if (ch === ";" && scannerAtTopLevel(state)) {
+      const statement = line.slice(start, index).trim();
+      if (statement) out.push(statement);
+      start = index + 1;
+      continue;
+    }
+
+    advanceMermaidScannerState(state, ch);
+  }
+
+  const tail = line.slice(start).trim();
+  if (tail) out.push(tail);
+  return out;
+}
+
+function stripTopLevelMermaidComment(statement: string): string {
+  const state = createMermaidScannerState();
+
+  for (let index = 0; index < statement.length; index++) {
+    const ch = statement[index] ?? "";
+
+    if (ch === "%" && statement[index + 1] === "%" && scannerAtTopLevel(state)) {
+      return statement.slice(0, index).trim();
+    }
+
+    advanceMermaidScannerState(state, ch);
+  }
+
+  return statement.trim();
+}
+
 function mermaidSourceLines(code: string): readonly string[] {
   return String(code ?? "")
     .replace(/\r\n?/g, "\n")
@@ -184,8 +306,8 @@ function mermaidSourceStatements(code: string): readonly string[] {
 
     if (MERMAID_COMMENT_RE.test(line)) continue;
 
-    for (const rawStatement of line.split(";")) {
-      const statement = rawStatement.trim();
+    for (const rawStatement of splitMermaidLineStatements(line)) {
+      const statement = stripTopLevelMermaidComment(rawStatement);
       if (!statement || MERMAID_COMMENT_RE.test(statement)) continue;
       statements.push(statement);
     }
@@ -228,6 +350,10 @@ export function isSimpleMermaidFlowchartSource(code: string): boolean {
   }
 
   return sawDirective && renderableStatements > 0;
+}
+
+function clipboardCanWrite(api: { supported: boolean; canWrite?: boolean }): boolean {
+  return api.canWrite ?? api.supported;
 }
 
 function timeoutError(ms: number): Error & { code: string } {
@@ -850,8 +976,8 @@ export const TMermaidText = defineComponent({
       const contextClipboard = terminalContext.clipboard;
 
       if (contextClipboard) {
-        if (!contextClipboard.supported) {
-          throw new Error("Clipboard not available in this runtime");
+        if (!clipboardCanWrite(contextClipboard)) {
+          throw new Error("Clipboard write not available in this runtime");
         }
         await contextClipboard.writeText(text);
         return;
@@ -863,7 +989,7 @@ export const TMermaidText = defineComponent({
         return;
       }
 
-      throw new Error("Clipboard not available");
+      throw new Error("Clipboard write not available in this runtime");
     }
 
     async function copySource(): Promise<void> {

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -99,7 +99,9 @@ const DEFAULT_MERMAID_COPIED_DURATION_MS = 1200;
 
 // Keep Mermaid rendering intentionally conservative. The renderer runs on the
 // main thread, so timeout guards cannot protect us from synchronous CPU-heavy
-// Mermaid layouts. Unsupported or complex sources should stay as source text.
+// Mermaid layouts. Only simple graph/flowchart sources are eligible for
+// replacement rendering; unsupported, non-flowchart, or complex sources stay as
+// source text.
 const DEFAULT_MERMAID_MAX_RENDER_FLOW_STATEMENTS = 120;
 const SIMPLE_MERMAID_DIRECTIVE_RE = /^(?:graph|flowchart)\s+(?:TB|TD|BT|LR|RL)\b/i;
 const MERMAID_INIT_DIRECTIVE_RE = /^%%\{/;
@@ -228,7 +230,7 @@ function countMermaidFlowStatementsUpTo(code: string, max: number): number {
 function shouldSkipRenderForComplexity(code: string): boolean {
   const first = firstMermaidStatement(code);
   if (!first) return true;
-  if (!SIMPLE_MERMAID_DIRECTIVE_RE.test(first)) return false;
+  if (!SIMPLE_MERMAID_DIRECTIVE_RE.test(first)) return true;
   if (hasComplexMermaidFlowFeature(code)) return true;
 
   return (
@@ -554,7 +556,7 @@ export const TMermaidText = defineComponent({
         return;
       }
 
-      if (props.streaming && !props.final) {
+      if (!props.final) {
         if (!alive || version !== renderVersion) return;
         renderedSnapshot.value = null;
         status.value = "idle";
@@ -633,7 +635,7 @@ export const TMermaidText = defineComponent({
       const version = ++renderVersion;
       resetCopyFeedback(false);
 
-      if (props.streaming && !props.final) {
+      if (!props.final) {
         builtOnce = true;
         scheduler.cancelFrameTask?.(frameTaskId);
         renderedSnapshot.value = null;

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -635,8 +635,7 @@ export const TMermaidText = defineComponent({
     function shouldSkipRender(code: string): boolean {
       if (shouldSkipRenderForSize(code)) return true;
 
-      const shouldRenderSource = props.shouldRenderSource;
-      if (!shouldRenderSource) return false;
+      const shouldRenderSource = props.shouldRenderSource ?? isSimpleMermaidFlowchartSource;
 
       try {
         return !shouldRenderSource(code, {
@@ -898,7 +897,7 @@ export const TMermaidText = defineComponent({
     }>;
 
     function canDrawBox(width: number, height: number): boolean {
-      return hasBox.value && Math.floor(width) >= 2 && Math.floor(height) >= 2;
+      return hasBox.value && Math.floor(width) >= 2 && Math.floor(height) >= 3;
     }
 
     function segmentCells(text: string): number {

--- a/src/vue/components/TMermaidText.ts
+++ b/src/vue/components/TMermaidText.ts
@@ -418,9 +418,6 @@ export function isSimpleMermaidFlowchartSource(code: string): boolean {
   return sawDirective && renderableStatements > 0;
 }
 
-const defaultShouldRenderMermaidSource: TMermaidRenderEligibility = (code) =>
-  isSimpleMermaidFlowchartSource(code);
-
 function clipboardCanWrite(api: { supported: boolean; canWrite?: boolean }): boolean {
   return api.canWrite ?? api.supported;
 }
@@ -557,9 +554,7 @@ export const TMermaidText = defineComponent({
 
     const source = computed(() => props.code ?? props.content ?? "");
 
-    const waitingForStreamingSourceToFinish = computed(
-      () => props.streaming && !props.final,
-    );
+    const waitingForStreamingSourceToFinish = computed(() => props.streaming && !props.final);
 
     function bump(): void {
       documentVersion.value++;
@@ -640,7 +635,8 @@ export const TMermaidText = defineComponent({
     function shouldSkipRender(code: string): boolean {
       if (shouldSkipRenderForSize(code)) return true;
 
-      const shouldRenderSource = props.shouldRenderSource ?? defaultShouldRenderMermaidSource;
+      const shouldRenderSource = props.shouldRenderSource;
+      if (!shouldRenderSource) return false;
 
       try {
         return !shouldRenderSource(code, {

--- a/src/vue/components/TerminalProvider.ts
+++ b/src/vue/components/TerminalProvider.ts
@@ -304,6 +304,7 @@ export const TerminalProvider = defineComponent({
       events,
       scheduler: schedulerApi,
       runtime,
+      clipboard: selectionClipboard,
       observability: { trace, framePerf },
       selection: selectionContext,
       defaultStyle: toRef(props, "defaultStyle"),

--- a/src/vue/components/TerminalProvider.ts
+++ b/src/vue/components/TerminalProvider.ts
@@ -81,6 +81,14 @@ export type {
   TerminalProviderSelectionOptions,
 } from "./terminal-provider/selection-config.js";
 
+function clipboardCanRead(api: ClipboardApi): boolean {
+  return api.canRead ?? api.supported;
+}
+
+function clipboardCanWrite(api: ClipboardApi): boolean {
+  return api.canWrite ?? api.supported;
+}
+
 export const TerminalProvider = defineComponent({
   name: "TerminalProvider",
   props: {
@@ -206,15 +214,22 @@ export const TerminalProvider = defineComponent({
     const invalidate = schedulerApi.invalidate;
 
     const platformRuntime = createRuntime();
+    const activeClipboard = computed(() => props.clipboard ?? platformRuntime.clipboard);
     const selectionClipboard: ClipboardApi = {
       get supported() {
-        return props.clipboard?.supported ?? platformRuntime.clipboard.supported;
+        return activeClipboard.value.supported;
+      },
+      get canRead() {
+        return clipboardCanRead(activeClipboard.value);
+      },
+      get canWrite() {
+        return clipboardCanWrite(activeClipboard.value);
       },
       readText() {
-        return (props.clipboard ?? platformRuntime.clipboard).readText();
+        return activeClipboard.value.readText();
       },
       writeText(text: string) {
-        return (props.clipboard ?? platformRuntime.clipboard).writeText(text);
+        return activeClipboard.value.writeText(text);
       },
     };
     const selectionTextProviders = new Map<string, SelectionTextProvider>();

--- a/src/vue/context.ts
+++ b/src/vue/context.ts
@@ -11,6 +11,7 @@ import type {
   TerminalSelectionRefreshOptions,
 } from "../selection/terminal-selection.js";
 import type { RendererCapabilities, TerminalRendererLike } from "../renderer/capabilities.js";
+import type { ClipboardApi } from "../runtime/index.js";
 import type { TraceStore } from "../observability/trace.js";
 import type { FramePerfReason } from "../observability/frame-perf.js";
 import type { FramePerfStore } from "../observability/frame-perf-store.js";
@@ -147,6 +148,7 @@ export type TerminalContext = Readonly<{
   events: Ref<EventManager | null>;
   scheduler: TerminalScheduler;
   runtime: TerminalRuntime;
+  clipboard?: ClipboardApi;
   observability: Readonly<{
     trace: TraceStore;
     framePerf: FramePerfStore;

--- a/src/vue/index.ts
+++ b/src/vue/index.ts
@@ -100,12 +100,19 @@ export type {
 } from "./components/link/host.js";
 export { linkifyTextSegments } from "./linkify.js";
 export type { TLinkifyOptions, TLinkifyProtocol, TLinkifySegment } from "./linkify.js";
-export { markMermaidRenderErrorFatal, TMermaid, TMermaidText } from "./components/TMermaidText.js";
+export {
+  isSimpleMermaidFlowchartSource,
+  markMermaidRenderErrorFatal,
+  TMermaid,
+  TMermaidText,
+} from "./components/TMermaidText.js";
 export type {
   TMermaidAsciiOptions,
   TMermaidAsciiTheme,
   TMermaidCopyPayload,
   TMermaidRenderer,
+  TMermaidRenderEligibility,
+  TMermaidRenderEligibilityContext,
   TMermaidResolvedAsciiOptions,
   TMermaidTextProps,
   TMermaidTransientErrorClassifier,

--- a/src/vue/index.ts
+++ b/src/vue/index.ts
@@ -104,6 +104,7 @@ export { markMermaidRenderErrorFatal, TMermaid, TMermaidText } from "./component
 export type {
   TMermaidAsciiOptions,
   TMermaidAsciiTheme,
+  TMermaidCopyPayload,
   TMermaidRenderer,
   TMermaidResolvedAsciiOptions,
   TMermaidTextProps,

--- a/src/vue/markdown/ast.ts
+++ b/src/vue/markdown/ast.ts
@@ -84,6 +84,16 @@ function sanitizeCodeBlockText(text: string, tabSize = 4): string {
   return sanitizeTextBlock(normalized);
 }
 
+function codeBlockLanguage(node: TuiMarkdownNode): string | undefined {
+  const raw =
+    stringProp(node, "lang") ||
+    stringProp(node, "language") ||
+    stringProp(node, "info") ||
+    stringProp(node, "meta");
+  const language = raw.trim().split(/\s+/)[0]?.toLowerCase() ?? "";
+  return language || undefined;
+}
+
 function inlineNodeSegments(
   nodes: readonly TuiMarkdownNode[],
   theme: TuiMarkdownTheme,
@@ -250,6 +260,7 @@ function blockFromCodeBlock(
   return {
     type: "code_block",
     key,
+    language: codeBlockLanguage(node),
     lines: sanitizeCodeBlockText(stringProp(node, "code")).split("\n"),
     style: theme.codeBlock,
     prefixSegments: context.prefixSegments,

--- a/src/vue/markdown/layout.ts
+++ b/src/vue/markdown/layout.ts
@@ -520,6 +520,7 @@ function blockLayoutSignature(block: TuiMarkdownBlock): string {
     case "code_block":
       return [
         block.type,
+        block.language ?? "",
         block.lines.join("\u0002"),
         styleSignature(block.style),
         inlineSegmentsSignature(block.prefixSegments),

--- a/src/vue/markdown/types.ts
+++ b/src/vue/markdown/types.ts
@@ -32,6 +32,7 @@ export type TuiMarkdownBlock =
       type: "code_block";
       key: string;
       lines: readonly string[];
+      language?: string;
       style?: Style;
       prefixSegments?: readonly TuiMarkdownInlineSegment[];
       continuationPrefixSegments?: readonly TuiMarkdownInlineSegment[];

--- a/src/vue/mermaid/beautiful-mermaid.ts
+++ b/src/vue/mermaid/beautiful-mermaid.ts
@@ -1,7 +1,6 @@
 import { defineComponent, h } from "vue";
 import {
   TMermaidText as TBaseMermaidText,
-  isSimpleMermaidFlowchartSource,
   markMermaidRenderErrorFatal,
   tMermaidTextProps,
   type TMermaidCopyPayload,
@@ -196,9 +195,6 @@ export const TMermaidText = defineComponent({
   setup(props, { attrs, emit, slots }) {
     return () => {
       const renderer = props.renderer ?? beautifulMermaidRenderer;
-      const shouldRenderSource =
-        props.shouldRenderSource ??
-        (renderer === beautifulMermaidRenderer ? isSimpleMermaidFlowchartSource : undefined);
 
       return h(
         TBaseMermaidText,
@@ -206,7 +202,6 @@ export const TMermaidText = defineComponent({
           ...attrs,
           ...props,
           renderer,
-          shouldRenderSource,
           isTransientError: props.isTransientError ?? isTransientBeautifulMermaidRenderError,
           onCopy: (payload: TMermaidCopyPayload) => emit("copy", payload),
         },

--- a/src/vue/mermaid/beautiful-mermaid.ts
+++ b/src/vue/mermaid/beautiful-mermaid.ts
@@ -3,6 +3,7 @@ import {
   TMermaidText as TBaseMermaidText,
   markMermaidRenderErrorFatal,
   tMermaidTextProps,
+  type TMermaidCopyPayload,
   type TMermaidRenderer,
   type TMermaidTransientErrorClassifier,
 } from "../components/TMermaidText.js";
@@ -186,15 +187,21 @@ export function createBeautifulMermaidRenderer(): TMermaidRenderer {
 
 export const TMermaidText = defineComponent({
   name: "TMermaidText",
+  inheritAttrs: false,
   props: tMermaidTextProps,
-  setup(props, { slots }) {
+  emits: {
+    copy: (_payload: TMermaidCopyPayload) => true,
+  },
+  setup(props, { attrs, emit, slots }) {
     return () =>
       h(
         TBaseMermaidText,
         {
+          ...attrs,
           ...props,
           renderer: props.renderer ?? beautifulMermaidRenderer,
           isTransientError: props.isTransientError ?? isTransientBeautifulMermaidRenderError,
+          onCopy: (payload: TMermaidCopyPayload) => emit("copy", payload),
         },
         slots,
       );

--- a/src/vue/mermaid/beautiful-mermaid.ts
+++ b/src/vue/mermaid/beautiful-mermaid.ts
@@ -1,6 +1,7 @@
 import { defineComponent, h } from "vue";
 import {
   TMermaidText as TBaseMermaidText,
+  isSimpleMermaidFlowchartSource,
   markMermaidRenderErrorFatal,
   tMermaidTextProps,
   type TMermaidCopyPayload,
@@ -201,6 +202,7 @@ export const TMermaidText = defineComponent({
           ...props,
           renderer: props.renderer ?? beautifulMermaidRenderer,
           isTransientError: props.isTransientError ?? isTransientBeautifulMermaidRenderError,
+          shouldRenderSource: props.shouldRenderSource ?? isSimpleMermaidFlowchartSource,
           onCopy: (payload: TMermaidCopyPayload) => emit("copy", payload),
         },
         slots,

--- a/src/vue/mermaid/beautiful-mermaid.ts
+++ b/src/vue/mermaid/beautiful-mermaid.ts
@@ -1,7 +1,6 @@
 import { defineComponent, h } from "vue";
 import {
   TMermaidText as TBaseMermaidText,
-  isSimpleMermaidFlowchartSource,
   markMermaidRenderErrorFatal,
   tMermaidTextProps,
   type TMermaidCopyPayload,
@@ -194,24 +193,19 @@ export const TMermaidText = defineComponent({
     copy: (_payload: TMermaidCopyPayload) => true,
   },
   setup(props, { attrs, emit, slots }) {
-    return () => {
-      const usesBuiltinRenderer = props.renderer == null;
-
-      return h(
+    return () =>
+      h(
         TBaseMermaidText,
         {
           ...attrs,
           ...props,
           renderer: props.renderer ?? beautifulMermaidRenderer,
           isTransientError: props.isTransientError ?? isTransientBeautifulMermaidRenderError,
-          shouldRenderSource:
-            props.shouldRenderSource ??
-            (usesBuiltinRenderer ? isSimpleMermaidFlowchartSource : undefined),
+          shouldRenderSource: props.shouldRenderSource,
           onCopy: (payload: TMermaidCopyPayload) => emit("copy", payload),
         },
         slots,
       );
-    };
   },
 });
 

--- a/src/vue/mermaid/beautiful-mermaid.ts
+++ b/src/vue/mermaid/beautiful-mermaid.ts
@@ -194,19 +194,25 @@ export const TMermaidText = defineComponent({
     copy: (_payload: TMermaidCopyPayload) => true,
   },
   setup(props, { attrs, emit, slots }) {
-    return () =>
-      h(
+    return () => {
+      const renderer = props.renderer ?? beautifulMermaidRenderer;
+      const shouldRenderSource =
+        props.shouldRenderSource ??
+        (props.renderer ? undefined : isSimpleMermaidFlowchartSource);
+
+      return h(
         TBaseMermaidText,
         {
           ...attrs,
           ...props,
-          renderer: props.renderer ?? beautifulMermaidRenderer,
+          renderer,
           isTransientError: props.isTransientError ?? isTransientBeautifulMermaidRenderError,
-          shouldRenderSource: props.shouldRenderSource ?? isSimpleMermaidFlowchartSource,
+          shouldRenderSource,
           onCopy: (payload: TMermaidCopyPayload) => emit("copy", payload),
         },
         slots,
       );
+    };
   },
 });
 

--- a/src/vue/mermaid/beautiful-mermaid.ts
+++ b/src/vue/mermaid/beautiful-mermaid.ts
@@ -1,6 +1,7 @@
 import { defineComponent, h } from "vue";
 import {
   TMermaidText as TBaseMermaidText,
+  isSimpleMermaidFlowchartSource,
   markMermaidRenderErrorFatal,
   tMermaidTextProps,
   type TMermaidCopyPayload,
@@ -194,7 +195,11 @@ export const TMermaidText = defineComponent({
   },
   setup(props, { attrs, emit, slots }) {
     return () => {
+      const usesDefaultBeautifulRenderer = props.renderer == null;
       const renderer = props.renderer ?? beautifulMermaidRenderer;
+      const shouldRenderSource =
+        props.shouldRenderSource ??
+        (usesDefaultBeautifulRenderer ? isSimpleMermaidFlowchartSource : undefined);
 
       return h(
         TBaseMermaidText,
@@ -202,6 +207,7 @@ export const TMermaidText = defineComponent({
           ...attrs,
           ...props,
           renderer,
+          shouldRenderSource,
           isTransientError: props.isTransientError ?? isTransientBeautifulMermaidRenderError,
           onCopy: (payload: TMermaidCopyPayload) => emit("copy", payload),
         },

--- a/src/vue/mermaid/beautiful-mermaid.ts
+++ b/src/vue/mermaid/beautiful-mermaid.ts
@@ -1,6 +1,7 @@
 import { defineComponent, h } from "vue";
 import {
   TMermaidText as TBaseMermaidText,
+  isSimpleMermaidFlowchartSource,
   markMermaidRenderErrorFatal,
   tMermaidTextProps,
   type TMermaidCopyPayload,
@@ -193,19 +194,24 @@ export const TMermaidText = defineComponent({
     copy: (_payload: TMermaidCopyPayload) => true,
   },
   setup(props, { attrs, emit, slots }) {
-    return () =>
-      h(
+    return () => {
+      const usesBuiltInRenderer = props.renderer == null;
+
+      return h(
         TBaseMermaidText,
         {
           ...attrs,
           ...props,
           renderer: props.renderer ?? beautifulMermaidRenderer,
           isTransientError: props.isTransientError ?? isTransientBeautifulMermaidRenderError,
-          shouldRenderSource: props.shouldRenderSource,
+          shouldRenderSource:
+            props.shouldRenderSource ??
+            (usesBuiltInRenderer ? isSimpleMermaidFlowchartSource : undefined),
           onCopy: (payload: TMermaidCopyPayload) => emit("copy", payload),
         },
         slots,
       );
+    };
   },
 });
 

--- a/src/vue/mermaid/beautiful-mermaid.ts
+++ b/src/vue/mermaid/beautiful-mermaid.ts
@@ -1,6 +1,7 @@
 import { defineComponent, h } from "vue";
 import {
   TMermaidText as TBaseMermaidText,
+  isSimpleMermaidFlowchartSource,
   markMermaidRenderErrorFatal,
   tMermaidTextProps,
   type TMermaidCopyPayload,
@@ -193,18 +194,26 @@ export const TMermaidText = defineComponent({
     copy: (_payload: TMermaidCopyPayload) => true,
   },
   setup(props, { attrs, emit, slots }) {
-    return () =>
-      h(
+    return () => {
+      const usesDefaultBeautifulRenderer = props.renderer == null;
+      const renderer = props.renderer ?? beautifulMermaidRenderer;
+      const shouldRenderSource =
+        props.shouldRenderSource ??
+        (usesDefaultBeautifulRenderer ? isSimpleMermaidFlowchartSource : undefined);
+
+      return h(
         TBaseMermaidText,
         {
           ...attrs,
           ...props,
-          renderer: props.renderer ?? beautifulMermaidRenderer,
+          renderer,
+          shouldRenderSource,
           isTransientError: props.isTransientError ?? isTransientBeautifulMermaidRenderError,
           onCopy: (payload: TMermaidCopyPayload) => emit("copy", payload),
         },
         slots,
       );
+    };
   },
 });
 

--- a/src/vue/mermaid/beautiful-mermaid.ts
+++ b/src/vue/mermaid/beautiful-mermaid.ts
@@ -196,9 +196,7 @@ export const TMermaidText = defineComponent({
   setup(props, { attrs, emit, slots }) {
     return () => {
       const renderer = props.renderer ?? beautifulMermaidRenderer;
-      const shouldRenderSource =
-        props.shouldRenderSource ??
-        (props.renderer ? undefined : isSimpleMermaidFlowchartSource);
+      const shouldRenderSource = props.shouldRenderSource ?? isSimpleMermaidFlowchartSource;
 
       return h(
         TBaseMermaidText,

--- a/src/vue/mermaid/beautiful-mermaid.ts
+++ b/src/vue/mermaid/beautiful-mermaid.ts
@@ -1,7 +1,6 @@
 import { defineComponent, h } from "vue";
 import {
   TMermaidText as TBaseMermaidText,
-  isSimpleMermaidFlowchartSource,
   markMermaidRenderErrorFatal,
   tMermaidTextProps,
   type TMermaidCopyPayload,
@@ -194,26 +193,18 @@ export const TMermaidText = defineComponent({
     copy: (_payload: TMermaidCopyPayload) => true,
   },
   setup(props, { attrs, emit, slots }) {
-    return () => {
-      const usesDefaultBeautifulRenderer = props.renderer == null;
-      const renderer = props.renderer ?? beautifulMermaidRenderer;
-      const shouldRenderSource =
-        props.shouldRenderSource ??
-        (usesDefaultBeautifulRenderer ? isSimpleMermaidFlowchartSource : undefined);
-
-      return h(
+    return () =>
+      h(
         TBaseMermaidText,
         {
           ...attrs,
           ...props,
-          renderer,
-          shouldRenderSource,
+          renderer: props.renderer ?? beautifulMermaidRenderer,
           isTransientError: props.isTransientError ?? isTransientBeautifulMermaidRenderError,
           onCopy: (payload: TMermaidCopyPayload) => emit("copy", payload),
         },
         slots,
       );
-    };
   },
 });
 

--- a/src/vue/mermaid/beautiful-mermaid.ts
+++ b/src/vue/mermaid/beautiful-mermaid.ts
@@ -1,7 +1,6 @@
 import { defineComponent, h } from "vue";
 import {
   TMermaidText as TBaseMermaidText,
-  isSimpleMermaidFlowchartSource,
   markMermaidRenderErrorFatal,
   tMermaidTextProps,
   type TMermaidCopyPayload,
@@ -194,24 +193,18 @@ export const TMermaidText = defineComponent({
     copy: (_payload: TMermaidCopyPayload) => true,
   },
   setup(props, { attrs, emit, slots }) {
-    return () => {
-      const usesBuiltInRenderer = props.renderer == null;
-
-      return h(
+    return () =>
+      h(
         TBaseMermaidText,
         {
           ...attrs,
           ...props,
           renderer: props.renderer ?? beautifulMermaidRenderer,
           isTransientError: props.isTransientError ?? isTransientBeautifulMermaidRenderError,
-          shouldRenderSource:
-            props.shouldRenderSource ??
-            (usesBuiltInRenderer ? isSimpleMermaidFlowchartSource : undefined),
           onCopy: (payload: TMermaidCopyPayload) => emit("copy", payload),
         },
         slots,
       );
-    };
   },
 });
 

--- a/src/vue/mermaid/beautiful-mermaid.ts
+++ b/src/vue/mermaid/beautiful-mermaid.ts
@@ -1,6 +1,7 @@
 import { defineComponent, h } from "vue";
 import {
   TMermaidText as TBaseMermaidText,
+  isSimpleMermaidFlowchartSource,
   markMermaidRenderErrorFatal,
   tMermaidTextProps,
   type TMermaidCopyPayload,
@@ -195,6 +196,9 @@ export const TMermaidText = defineComponent({
   setup(props, { attrs, emit, slots }) {
     return () => {
       const renderer = props.renderer ?? beautifulMermaidRenderer;
+      const shouldRenderSource =
+        props.shouldRenderSource ??
+        (renderer === beautifulMermaidRenderer ? isSimpleMermaidFlowchartSource : undefined);
 
       return h(
         TBaseMermaidText,
@@ -202,6 +206,7 @@ export const TMermaidText = defineComponent({
           ...attrs,
           ...props,
           renderer,
+          shouldRenderSource,
           isTransientError: props.isTransientError ?? isTransientBeautifulMermaidRenderError,
           onCopy: (payload: TMermaidCopyPayload) => emit("copy", payload),
         },

--- a/src/vue/mermaid/beautiful-mermaid.ts
+++ b/src/vue/mermaid/beautiful-mermaid.ts
@@ -1,6 +1,7 @@
 import { defineComponent, h } from "vue";
 import {
   TMermaidText as TBaseMermaidText,
+  isSimpleMermaidFlowchartSource,
   markMermaidRenderErrorFatal,
   tMermaidTextProps,
   type TMermaidCopyPayload,
@@ -193,18 +194,24 @@ export const TMermaidText = defineComponent({
     copy: (_payload: TMermaidCopyPayload) => true,
   },
   setup(props, { attrs, emit, slots }) {
-    return () =>
-      h(
+    return () => {
+      const usesBuiltinRenderer = props.renderer == null;
+
+      return h(
         TBaseMermaidText,
         {
           ...attrs,
           ...props,
           renderer: props.renderer ?? beautifulMermaidRenderer,
           isTransientError: props.isTransientError ?? isTransientBeautifulMermaidRenderError,
+          shouldRenderSource:
+            props.shouldRenderSource ??
+            (usesBuiltinRenderer ? isSimpleMermaidFlowchartSource : undefined),
           onCopy: (payload: TMermaidCopyPayload) => emit("copy", payload),
         },
         slots,
       );
+    };
   },
 });
 

--- a/src/vue/mermaid/beautiful-mermaid.ts
+++ b/src/vue/mermaid/beautiful-mermaid.ts
@@ -195,11 +195,8 @@ export const TMermaidText = defineComponent({
   },
   setup(props, { attrs, emit, slots }) {
     return () => {
-      const usesDefaultBeautifulRenderer = props.renderer == null;
       const renderer = props.renderer ?? beautifulMermaidRenderer;
-      const shouldRenderSource =
-        props.shouldRenderSource ??
-        (usesDefaultBeautifulRenderer ? isSimpleMermaidFlowchartSource : undefined);
+      const shouldRenderSource = props.shouldRenderSource ?? isSimpleMermaidFlowchartSource;
 
       return h(
         TBaseMermaidText,

--- a/src/vue/mermaid/beautiful-mermaid.ts
+++ b/src/vue/mermaid/beautiful-mermaid.ts
@@ -1,7 +1,6 @@
 import { defineComponent, h } from "vue";
 import {
   TMermaidText as TBaseMermaidText,
-  isSimpleMermaidFlowchartSource,
   markMermaidRenderErrorFatal,
   tMermaidTextProps,
   type TMermaidCopyPayload,
@@ -196,7 +195,6 @@ export const TMermaidText = defineComponent({
   setup(props, { attrs, emit, slots }) {
     return () => {
       const renderer = props.renderer ?? beautifulMermaidRenderer;
-      const shouldRenderSource = props.shouldRenderSource ?? isSimpleMermaidFlowchartSource;
 
       return h(
         TBaseMermaidText,
@@ -205,7 +203,6 @@ export const TMermaidText = defineComponent({
           ...props,
           renderer,
           isTransientError: props.isTransientError ?? isTransientBeautifulMermaidRenderError,
-          shouldRenderSource,
           onCopy: (payload: TMermaidCopyPayload) => emit("copy", payload),
         },
         slots,

--- a/test/api-surface.test.ts
+++ b/test/api-surface.test.ts
@@ -106,6 +106,7 @@ describe("public API surface", () => {
         "createTerminalRouter",
         "createTextRestrictionPlugin",
         "createTheme",
+        "isSimpleMermaidFlowchartSource",
         "linkifyTextSegments",
         "lintJsonText",
         "markMermaidRenderErrorFatal",
@@ -189,6 +190,7 @@ describe("public API surface", () => {
         "TMermaidText",
         "beautifulMermaidRenderer",
         "createBeautifulMermaidRenderer",
+        "isSimpleMermaidFlowchartSource",
         "markMermaidRenderErrorFatal",
       ]
     `);
@@ -203,6 +205,7 @@ describe("public API surface", () => {
         "TMermaidText",
         "beautifulMermaidRenderer",
         "createBeautifulMermaidRenderer",
+        "isSimpleMermaidFlowchartSource",
         "markMermaidRenderErrorFatal",
       ]
     `);

--- a/test/api-surface.test.ts
+++ b/test/api-surface.test.ts
@@ -339,6 +339,7 @@ describe("public API surface", () => {
         "detectTerminalGraphicsCapabilities",
         "dispatchTLogPluginLinkAction",
         "getTLogPluginMetadata",
+        "isSimpleMermaidFlowchartSource",
         "markMermaidRenderErrorFatal",
         "parseTLogAnnotatedText",
         "resolveTLogLinksPanelTheme",

--- a/test/fixtures/package-types/index.ts
+++ b/test/fixtures/package-types/index.ts
@@ -37,6 +37,7 @@ import {
   TInputBox,
   TJsonEditor,
   markMermaidRenderErrorFatal,
+  isSimpleMermaidFlowchartSource,
   TMermaid,
   TMermaidText,
   TMultilineModal,
@@ -55,6 +56,8 @@ import {
   type TMermaidAsciiOptions,
   type TMermaidCopyPayload,
   type TMermaidRenderer,
+  type TMermaidRenderEligibility,
+  type TMermaidRenderEligibilityContext,
   type TMermaidTextProps as VueMermaidTextProps,
   type TMermaidTransientErrorClassifier,
   type TMermaidTransientErrorContext,
@@ -93,6 +96,8 @@ import {
   computeCommandPaletteMatchRanges,
   type TCommandPaletteItem as AgentTCommandPaletteItem,
   type TCommandPaletteMatchRange,
+  type TMermaidRenderEligibility as AgentMermaidRenderEligibility,
+  type TMermaidRenderEligibilityContext as AgentMermaidRenderEligibilityContext,
   type TMermaidTransientErrorClassifier as AgentMermaidTransientErrorClassifier,
   type TMermaidCopyPayload as AgentMermaidCopyPayload,
   type TMermaidTextProps as AgentMermaidTextProps,
@@ -108,8 +113,11 @@ import {
   TBeautifulMermaidText,
   beautifulMermaidRenderer,
   createBeautifulMermaidRenderer,
+  isSimpleMermaidFlowchartSource as isMermaidEntrySimpleMermaidFlowchartSource,
   markMermaidRenderErrorFatal as markMermaidEntryRenderErrorFatal,
   type TMermaidCopyPayload as MermaidEntryCopyPayload,
+  type TMermaidRenderEligibility as MermaidEntryRenderEligibility,
+  type TMermaidRenderEligibilityContext as MermaidEntryRenderEligibilityContext,
   type TMermaidTransientErrorContext as MermaidEntryTransientErrorContext,
   type TMermaidTextProps as MermaidEntryTextProps,
   type TMermaidTransientErrorClassifier as MermaidEntryTransientErrorClassifier,
@@ -118,8 +126,11 @@ import {
   TMermaid as AgentBeautifulMermaid,
   TMermaidText as AgentBeautifulMermaidText,
   beautifulMermaidRenderer as agentBeautifulMermaidRenderer,
+  isSimpleMermaidFlowchartSource as isAgentBeautifulMermaidSimpleMermaidFlowchartSource,
   markMermaidRenderErrorFatal as markAgentBeautifulMermaidRenderErrorFatal,
   type TMermaidCopyPayload as AgentBeautifulMermaidCopyPayload,
+  type TMermaidRenderEligibility as AgentBeautifulMermaidRenderEligibility,
+  type TMermaidRenderEligibilityContext as AgentBeautifulMermaidRenderEligibilityContext,
   type TMermaidTransientErrorClassifier as AgentBeautifulMermaidTransientErrorClassifier,
 } from "@simon_he/vue-tui/agent/mermaid";
 
@@ -176,23 +187,44 @@ const mermaidTransientErrorContext: TMermaidTransientErrorContext = {
   final: false,
   streaming: true,
 };
+const mermaidRenderEligibilityContext: TMermaidRenderEligibilityContext = {
+  code: "graph LR\n  A --> B",
+  final: true,
+  streaming: false,
+};
+const mermaidRenderEligibility: TMermaidRenderEligibility = (code, context) =>
+  code === context.code;
 const mermaidTransientErrorClassifier: TMermaidTransientErrorClassifier = (_error, context) =>
   context.streaming && !context.final;
 const mermaidCopyPayload: TMermaidCopyPayload = { text: "graph LR", ok: true };
 const mermaidTextProps: VueMermaidTextProps = { x: 0, y: 0, w: 12 };
 const agentMermaidTextProps: AgentMermaidTextProps = mermaidTextProps;
 const agentMermaidCopyPayload: AgentMermaidCopyPayload = mermaidCopyPayload;
+const agentMermaidRenderEligibilityContext: AgentMermaidRenderEligibilityContext =
+  mermaidRenderEligibilityContext;
+const agentMermaidRenderEligibility: AgentMermaidRenderEligibility = mermaidRenderEligibility;
 const agentMermaidTransientErrorClassifier: AgentMermaidTransientErrorClassifier =
   mermaidTransientErrorClassifier;
 const mermaidEntryTextProps: MermaidEntryTextProps = mermaidTextProps;
 const mermaidEntryCopyPayload: MermaidEntryCopyPayload = mermaidCopyPayload;
+const mermaidEntryRenderEligibilityContext: MermaidEntryRenderEligibilityContext =
+  mermaidRenderEligibilityContext;
+const mermaidEntryRenderEligibility: MermaidEntryRenderEligibility = mermaidRenderEligibility;
 const mermaidEntryTransientErrorContext: MermaidEntryTransientErrorContext =
   mermaidTransientErrorContext;
 const mermaidEntryTransientErrorClassifier: MermaidEntryTransientErrorClassifier =
   mermaidTransientErrorClassifier;
+const agentBeautifulMermaidRenderEligibilityContext: AgentBeautifulMermaidRenderEligibilityContext =
+  mermaidRenderEligibilityContext;
+const agentBeautifulMermaidRenderEligibility: AgentBeautifulMermaidRenderEligibility =
+  mermaidRenderEligibility;
 const agentBeautifulMermaidTransientErrorClassifier: AgentBeautifulMermaidTransientErrorClassifier =
   mermaidTransientErrorClassifier;
 const agentBeautifulMermaidCopyPayload: AgentBeautifulMermaidCopyPayload = mermaidCopyPayload;
+const simpleMermaidFromVue = isSimpleMermaidFlowchartSource("graph LR\n  A --> B");
+const simpleMermaidFromEntry = isMermaidEntrySimpleMermaidFlowchartSource("graph LR\n  A --> B");
+const simpleMermaidFromAgentEntry =
+  isAgentBeautifulMermaidSimpleMermaidFlowchartSource("graph LR\n  A --> B");
 const createdMermaidRenderer = createBeautifulMermaidRenderer();
 const fatalMermaidError = markMermaidRenderErrorFatal(new Error("fatal"));
 const fatalAgentMermaidError = markAgentMermaidRenderErrorFatal(new Error("fatal-agent"));
@@ -278,18 +310,29 @@ console.log(
   mermaidOptions,
   mermaidRenderer,
   mermaidTransientErrorContext,
+  mermaidRenderEligibilityContext,
+  mermaidRenderEligibility,
   mermaidTransientErrorClassifier,
   mermaidCopyPayload,
   mermaidTextProps,
   agentMermaidTextProps,
   agentMermaidCopyPayload,
+  agentMermaidRenderEligibilityContext,
+  agentMermaidRenderEligibility,
   agentMermaidTransientErrorClassifier,
   mermaidEntryTextProps,
   mermaidEntryCopyPayload,
+  mermaidEntryRenderEligibilityContext,
+  mermaidEntryRenderEligibility,
   mermaidEntryTransientErrorContext,
   mermaidEntryTransientErrorClassifier,
+  agentBeautifulMermaidRenderEligibilityContext,
+  agentBeautifulMermaidRenderEligibility,
   agentBeautifulMermaidTransientErrorClassifier,
   agentBeautifulMermaidCopyPayload,
+  simpleMermaidFromVue,
+  simpleMermaidFromEntry,
+  simpleMermaidFromAgentEntry,
   beautifulMermaidRenderer,
   agentBeautifulMermaidRenderer,
   createdMermaidRenderer,

--- a/test/fixtures/package-types/index.ts
+++ b/test/fixtures/package-types/index.ts
@@ -53,6 +53,7 @@ import {
   type TFormHandle,
   type TInputPlugin,
   type TMermaidAsciiOptions,
+  type TMermaidCopyPayload,
   type TMermaidRenderer,
   type TMermaidTextProps as VueMermaidTextProps,
   type TMermaidTransientErrorClassifier,
@@ -93,6 +94,7 @@ import {
   type TCommandPaletteItem as AgentTCommandPaletteItem,
   type TCommandPaletteMatchRange,
   type TMermaidTransientErrorClassifier as AgentMermaidTransientErrorClassifier,
+  type TMermaidCopyPayload as AgentMermaidCopyPayload,
   type TMermaidTextProps as AgentMermaidTextProps,
   TThinkingView,
   TToolCallView,
@@ -107,6 +109,7 @@ import {
   beautifulMermaidRenderer,
   createBeautifulMermaidRenderer,
   markMermaidRenderErrorFatal as markMermaidEntryRenderErrorFatal,
+  type TMermaidCopyPayload as MermaidEntryCopyPayload,
   type TMermaidTransientErrorContext as MermaidEntryTransientErrorContext,
   type TMermaidTextProps as MermaidEntryTextProps,
   type TMermaidTransientErrorClassifier as MermaidEntryTransientErrorClassifier,
@@ -116,6 +119,7 @@ import {
   TMermaidText as AgentBeautifulMermaidText,
   beautifulMermaidRenderer as agentBeautifulMermaidRenderer,
   markMermaidRenderErrorFatal as markAgentBeautifulMermaidRenderErrorFatal,
+  type TMermaidCopyPayload as AgentBeautifulMermaidCopyPayload,
   type TMermaidTransientErrorClassifier as AgentBeautifulMermaidTransientErrorClassifier,
 } from "@simon_he/vue-tui/agent/mermaid";
 
@@ -174,17 +178,21 @@ const mermaidTransientErrorContext: TMermaidTransientErrorContext = {
 };
 const mermaidTransientErrorClassifier: TMermaidTransientErrorClassifier = (_error, context) =>
   context.streaming && !context.final;
+const mermaidCopyPayload: TMermaidCopyPayload = { text: "graph LR", ok: true };
 const mermaidTextProps: VueMermaidTextProps = { x: 0, y: 0, w: 12 };
 const agentMermaidTextProps: AgentMermaidTextProps = mermaidTextProps;
+const agentMermaidCopyPayload: AgentMermaidCopyPayload = mermaidCopyPayload;
 const agentMermaidTransientErrorClassifier: AgentMermaidTransientErrorClassifier =
   mermaidTransientErrorClassifier;
 const mermaidEntryTextProps: MermaidEntryTextProps = mermaidTextProps;
+const mermaidEntryCopyPayload: MermaidEntryCopyPayload = mermaidCopyPayload;
 const mermaidEntryTransientErrorContext: MermaidEntryTransientErrorContext =
   mermaidTransientErrorContext;
 const mermaidEntryTransientErrorClassifier: MermaidEntryTransientErrorClassifier =
   mermaidTransientErrorClassifier;
 const agentBeautifulMermaidTransientErrorClassifier: AgentBeautifulMermaidTransientErrorClassifier =
   mermaidTransientErrorClassifier;
+const agentBeautifulMermaidCopyPayload: AgentBeautifulMermaidCopyPayload = mermaidCopyPayload;
 const createdMermaidRenderer = createBeautifulMermaidRenderer();
 const fatalMermaidError = markMermaidRenderErrorFatal(new Error("fatal"));
 const fatalAgentMermaidError = markAgentMermaidRenderErrorFatal(new Error("fatal-agent"));
@@ -271,13 +279,17 @@ console.log(
   mermaidRenderer,
   mermaidTransientErrorContext,
   mermaidTransientErrorClassifier,
+  mermaidCopyPayload,
   mermaidTextProps,
   agentMermaidTextProps,
+  agentMermaidCopyPayload,
   agentMermaidTransientErrorClassifier,
   mermaidEntryTextProps,
+  mermaidEntryCopyPayload,
   mermaidEntryTransientErrorContext,
   mermaidEntryTransientErrorClassifier,
   agentBeautifulMermaidTransientErrorClassifier,
+  agentBeautifulMermaidCopyPayload,
   beautifulMermaidRenderer,
   agentBeautifulMermaidRenderer,
   createdMermaidRenderer,

--- a/test/fixtures/package-types/index.ts
+++ b/test/fixtures/package-types/index.ts
@@ -189,12 +189,11 @@ const mermaidTransientErrorContext: TMermaidTransientErrorContext = {
   streaming: true,
 };
 const mermaidRenderEligibilityContext: TMermaidRenderEligibilityContext = {
-  code: "graph LR\n  A --> B",
   final: true,
   streaming: false,
 };
 const mermaidRenderEligibility: TMermaidRenderEligibility = (code, context) =>
-  code === context.code;
+  code === "graph LR\n  A --> B" && context.final && !context.streaming;
 const mermaidTransientErrorClassifier: TMermaidTransientErrorClassifier = (_error, context) =>
   context.streaming && !context.final;
 const mermaidCopyPayload: TMermaidCopyPayload = { text: "graph LR", ok: true };

--- a/test/fixtures/package-types/index.ts
+++ b/test/fixtures/package-types/index.ts
@@ -94,6 +94,7 @@ import {
   TMermaid as AgentMermaid,
   TMermaidText as AgentMermaidText,
   computeCommandPaletteMatchRanges,
+  isSimpleMermaidFlowchartSource as isAgentSimpleMermaidFlowchartSource,
   type TCommandPaletteItem as AgentTCommandPaletteItem,
   type TCommandPaletteMatchRange,
   type TMermaidRenderEligibility as AgentMermaidRenderEligibility,
@@ -225,6 +226,7 @@ const simpleMermaidFromVue = isSimpleMermaidFlowchartSource("graph LR\n  A --> B
 const simpleMermaidFromEntry = isMermaidEntrySimpleMermaidFlowchartSource("graph LR\n  A --> B");
 const simpleMermaidFromAgentEntry =
   isAgentBeautifulMermaidSimpleMermaidFlowchartSource("graph LR\n  A --> B");
+const simpleMermaidFromAgent = isAgentSimpleMermaidFlowchartSource("graph LR\n  A --> B");
 const createdMermaidRenderer = createBeautifulMermaidRenderer();
 const fatalMermaidError = markMermaidRenderErrorFatal(new Error("fatal"));
 const fatalAgentMermaidError = markAgentMermaidRenderErrorFatal(new Error("fatal-agent"));
@@ -333,6 +335,7 @@ console.log(
   simpleMermaidFromVue,
   simpleMermaidFromEntry,
   simpleMermaidFromAgentEntry,
+  simpleMermaidFromAgent,
   beautifulMermaidRenderer,
   agentBeautifulMermaidRenderer,
   createdMermaidRenderer,

--- a/test/package-exports.test.ts
+++ b/test/package-exports.test.ts
@@ -464,6 +464,7 @@ describe("package exports", () => {
       "detectTerminalGraphicsCapabilities",
       "dispatchTLogPluginLinkAction",
       "getTLogPluginMetadata",
+      "isSimpleMermaidFlowchartSource",
       "markMermaidRenderErrorFatal",
       "parseTLogAnnotatedText",
       "resolveTLogLinksPanelTheme",
@@ -618,6 +619,7 @@ describe("package exports", () => {
     expect(agent.TVirtualMarkdown).toBe(markdown.TVirtualMarkdown);
     expect(agent.createMarkdownBlockSource).toBe(markdown.createMarkdownBlockSource);
     expect(agent.TMermaidText).toBe(vue.TMermaidText);
+    expect(agent.isSimpleMermaidFlowchartSource).toBe(vue.isSimpleMermaidFlowchartSource);
     expect(agent.markMermaidRenderErrorFatal).toBe(vue.markMermaidRenderErrorFatal);
     expect(mermaid.TMermaidText).toBe(mermaid.TBeautifulMermaidText);
     expect(mermaid.TMermaid).toBe(mermaid.TBeautifulMermaid);
@@ -1055,6 +1057,7 @@ describe("package exports", () => {
     expect(agent.TToolCallView).toBeTruthy();
     expect(agent.TToolLogView).toBe(experimental.TLogView);
     expect(agent.TUserMessageView).toBeTruthy();
+    expect(agent.isSimpleMermaidFlowchartSource).toBeTruthy();
     expect(mermaid.TBeautifulMermaidText).toBeTruthy();
     expect(mermaid.TMermaidText).toBe(mermaid.TBeautifulMermaidText);
     expect(mermaid.TMermaid).toBe(mermaid.TBeautifulMermaid);

--- a/test/package-exports.test.ts
+++ b/test/package-exports.test.ts
@@ -331,6 +331,7 @@ describe("package exports", () => {
       "createTerminalRouter",
       "createTextRestrictionPlugin",
       "createTheme",
+      "isSimpleMermaidFlowchartSource",
       "linkifyTextSegments",
       "lintJsonText",
       "markMermaidRenderErrorFatal",
@@ -496,6 +497,7 @@ describe("package exports", () => {
       "TMermaidText",
       "beautifulMermaidRenderer",
       "createBeautifulMermaidRenderer",
+      "isSimpleMermaidFlowchartSource",
       "markMermaidRenderErrorFatal",
     ]);
     expect(Object.keys(agentMermaid).sort()).toEqual(Object.keys(mermaid).sort());
@@ -620,10 +622,14 @@ describe("package exports", () => {
     expect(mermaid.TMermaidText).toBe(mermaid.TBeautifulMermaidText);
     expect(mermaid.TMermaid).toBe(mermaid.TBeautifulMermaid);
     expect(mermaid.createBeautifulMermaidRenderer).toBeTruthy();
+    expect(mermaid.isSimpleMermaidFlowchartSource).toBe(vue.isSimpleMermaidFlowchartSource);
     expect(mermaid.markMermaidRenderErrorFatal).toBe(vue.markMermaidRenderErrorFatal);
     expect(agentMermaid.TMermaidText).toBe(mermaid.TMermaidText);
     expect(agentMermaid.TMermaid).toBe(mermaid.TMermaid);
     expect(agentMermaid.beautifulMermaidRenderer).toBe(mermaid.beautifulMermaidRenderer);
+    expect(agentMermaid.isSimpleMermaidFlowchartSource).toBe(
+      mermaid.isSimpleMermaidFlowchartSource,
+    );
     expect(agentMermaid.markMermaidRenderErrorFatal).toBe(mermaid.markMermaidRenderErrorFatal);
   });
 
@@ -1053,15 +1059,20 @@ describe("package exports", () => {
     expect(mermaid.TMermaidText).toBe(mermaid.TBeautifulMermaidText);
     expect(mermaid.TMermaid).toBe(mermaid.TBeautifulMermaid);
     expect(mermaid.createBeautifulMermaidRenderer).toBeTruthy();
+    expect(mermaid.isSimpleMermaidFlowchartSource).toBeTruthy();
     expect(mermaid.markMermaidRenderErrorFatal).toBeTruthy();
     expect(agentMermaid.TMermaidText).toBe(mermaid.TMermaidText);
     expect(agentMermaid.TMermaid).toBe(mermaid.TMermaid);
     expect(agentMermaid.beautifulMermaidRenderer).toBe(mermaid.beautifulMermaidRenderer);
+    expect(agentMermaid.isSimpleMermaidFlowchartSource).toBe(
+      mermaid.isSimpleMermaidFlowchartSource,
+    );
     expect(agentMermaid.markMermaidRenderErrorFatal).toBe(mermaid.markMermaidRenderErrorFatal);
     expect(mermaidCjs.TBeautifulMermaidText).toBeTruthy();
     expect(mermaidCjs.TMermaidText).toBe(mermaidCjs.TBeautifulMermaidText);
     expect(mermaidCjs.TMermaid).toBe(mermaidCjs.TBeautifulMermaid);
     expect(mermaidCjs.createBeautifulMermaidRenderer).toBeTruthy();
+    expect(mermaidCjs.isSimpleMermaidFlowchartSource).toBeTruthy();
     expect(mermaidCjs.markMermaidRenderErrorFatal).toBeTruthy();
     expect(agentMermaidCjs.TMermaidText).toBeTruthy();
     expect(agentMermaidCjs.TMermaidText).toBe(agentMermaidCjs.TBeautifulMermaidText);

--- a/test/runtime-browser.test.ts
+++ b/test/runtime-browser.test.ts
@@ -14,4 +14,45 @@ describe("runtime (browser-ish)", () => {
     const w = r.measureText("hello", { font: "12px monospace" });
     expect(w === null || (typeof w === "number" && Number.isFinite(w))).toBe(true);
   });
+
+  it("reads browser clipboard dynamically", async () => {
+    const originalClipboard = Object.getOwnPropertyDescriptor(globalThis.navigator, "clipboard");
+
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+    });
+
+    try {
+      const r = createRuntime("browser");
+      expect(r.clipboard.supported).toBe(false);
+      expect(r.clipboard.canRead).toBe(false);
+      expect(r.clipboard.canWrite).toBe(false);
+
+      const writes: string[] = [];
+      Object.defineProperty(globalThis.navigator, "clipboard", {
+        value: {
+          readText: async () => writes[writes.length - 1] ?? "",
+          writeText: async (text: string) => {
+            writes.push(text);
+          },
+        },
+        configurable: true,
+      });
+
+      expect(r.clipboard.supported).toBe(true);
+      expect(r.clipboard.canRead).toBe(true);
+      expect(r.clipboard.canWrite).toBe(true);
+
+      await r.clipboard.writeText("selected text");
+      expect(await r.clipboard.readText()).toBe("selected text");
+      expect(writes).toEqual(["selected text"]);
+    } finally {
+      if (originalClipboard) {
+        Object.defineProperty(globalThis.navigator, "clipboard", originalClipboard);
+      } else {
+        delete (globalThis.navigator as any).clipboard;
+      }
+    }
+  });
 });

--- a/test/runtime-terminal.test.ts
+++ b/test/runtime-terminal.test.ts
@@ -65,6 +65,30 @@ describe("runtime (terminal/node)", () => {
     expect(writes).toEqual(["selected text"]);
   });
 
+  it("supports write-only browser clipboard for copy operations", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    Object.defineProperty(globalThis, "navigator", {
+      value: {
+        clipboard: {
+          writeText,
+        },
+      },
+      configurable: true,
+    });
+
+    const r = createRuntime("browser");
+
+    expect(r.clipboard.supported).toBe(true);
+
+    await r.clipboard.writeText("graph LR\n  A --> B");
+    expect(writeText).toHaveBeenCalledWith("graph LR\n  A --> B");
+
+    await expect(r.clipboard.readText()).rejects.toThrow(
+      "Clipboard read not available in this runtime",
+    );
+  });
+
   it("writes OSC52 clipboard sequences when explicitly configured", async () => {
     const writes: string[] = [];
     const clipboard = createOsc52ClipboardProvider({

--- a/test/runtime-terminal.test.ts
+++ b/test/runtime-terminal.test.ts
@@ -79,7 +79,9 @@ describe("runtime (terminal/node)", () => {
 
     const r = createRuntime("browser");
 
-    expect(r.clipboard.supported).toBe(true);
+    expect(r.clipboard.supported).toBe(false);
+    expect(r.clipboard.canRead).toBe(false);
+    expect(r.clipboard.canWrite).toBe(true);
 
     await r.clipboard.writeText("graph LR\n  A --> B");
     expect(writeText).toHaveBeenCalledWith("graph LR\n  A --> B");

--- a/test/runtime-terminal.test.ts
+++ b/test/runtime-terminal.test.ts
@@ -103,7 +103,13 @@ describe("runtime (terminal/node)", () => {
     await clipboard.writeText("copy me");
 
     expect(clipboard.supported).toBe(true);
+    expect(clipboard.canRead).toBe(false);
+    expect(clipboard.canWrite).toBe(true);
     expect(writes).toEqual(["\u001B]52;c;Y29weSBtZQ==\u0007"]);
+
+    await expect(clipboard.readText()).rejects.toThrow(
+      "Clipboard read not available in this runtime",
+    );
   });
 
   it("rejects oversized OSC52 clipboard payloads", async () => {

--- a/test/terminal-selection.test.ts
+++ b/test/terminal-selection.test.ts
@@ -206,6 +206,37 @@ describe("terminal selection", () => {
     expect(copies).toMatchObject([{ text: "abc", ok: false }]);
   });
 
+  it("copies selections through write-only clipboard", async () => {
+    const terminal = createTerminal({ cols: 6, rows: 1 });
+    terminal.write("abcdef", { x: 0, y: 0 });
+    const writes: string[] = [];
+    const copies: unknown[] = [];
+    const clipboard: ClipboardApi = {
+      supported: false,
+      canRead: false,
+      canWrite: true,
+      async readText() {
+        return writes[writes.length - 1] ?? "";
+      },
+      async writeText(text) {
+        writes.push(text);
+      },
+    };
+    const selection = createTerminalSelectionController({
+      terminal,
+      overlayTerminal: getPlaneTerminal(terminal, "overlay"),
+      clipboard,
+      onCopy: (payload) => copies.push(payload),
+    });
+
+    selection.start({ x: 0, y: 0 });
+    selection.update({ x: 2, y: 0 });
+    await selection.finish();
+
+    expect(writes).toEqual(["abc"]);
+    expect(copies).toMatchObject([{ text: "abc", ok: true }]);
+  });
+
   it("paints and clears the overlay rows", () => {
     const terminal = createTerminal({ cols: 6, rows: 1 });
     terminal.write("abcdef", { x: 0, y: 0, style: { fg: "whiteBright" } });

--- a/test/tmarkdown-layout.test.ts
+++ b/test/tmarkdown-layout.test.ts
@@ -714,6 +714,54 @@ describe("markdown layout", () => {
     expect(rows.some((row) => row.plainText.includes("    const a = 1"))).toBe(true);
   });
 
+  it("preserves fenced code language metadata", () => {
+    const blocks = markdownAstToBlocks(
+      [
+        {
+          type: "code_block",
+          raw: "",
+          code: "graph LR\n  A --> B",
+          info: "Mermaid title",
+        } as TuiMarkdownNode,
+      ],
+      DEFAULT_TUI_MARKDOWN_THEME,
+    );
+    const code = blocks[0];
+
+    expect(code?.type).toBe("code_block");
+    if (code?.type !== "code_block") throw new Error("expected code block");
+    expect(code.language).toBe("mermaid");
+  });
+
+  it("does not reuse cached code rows when only language changes", () => {
+    const first = layoutMarkdownBlocksCached(
+      [
+        {
+          type: "code_block",
+          key: "code",
+          language: "ts",
+          lines: ["const a = 1"],
+        },
+      ],
+      40,
+    );
+    const next = layoutMarkdownBlocksCached(
+      [
+        {
+          type: "code_block",
+          key: "code",
+          language: "js",
+          lines: ["const a = 1"],
+        },
+      ],
+      40,
+      first.cache,
+    );
+
+    expect(next.rows.map((row) => row.plainText)).toEqual(first.rows.map((row) => row.plainText));
+    expect(next.rows[0]).not.toBe(first.rows[0]);
+  });
+
   it("does not hang when list and blockquote prefixes are wider than width", () => {
     const parser = createTuiMarkdownParser();
     const listRows = buildMarkdownVisualRows("- a", 1, parser);

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -374,38 +374,9 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("keeps non-flowchart Mermaid source by default even with a custom renderer", async () => {
+  it("renders non-flowchart Mermaid source by default when a custom renderer is supplied", async () => {
     const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
     const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
-
-    const mounted = await mountTerminal(
-      () =>
-        h(TMermaidText, {
-          x: 0,
-          y: 0,
-          w: 40,
-          h: 3,
-          box: false,
-          content: source,
-          renderer,
-        }),
-      48,
-      5,
-    );
-
-    await settleMermaid(mounted);
-
-    expect(renderer).not.toHaveBeenCalled();
-    expect(rowText(mounted, 0)).toBe("sequenceDiagram");
-    expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
-    expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
-
-    mounted.unmount();
-  });
-
-  it("allows renderer-agnostic callers to explicitly render complex Mermaid source", async () => {
-    const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
-    const renderer: TMermaidRenderer = vi.fn((code) => `rendered:${code.split("\n")[0]}`);
 
     const mounted = await mountTerminal(
       () =>
@@ -417,10 +388,9 @@ describe("TMermaidText", () => {
           box: false,
           content: source,
           renderer,
-          shouldRenderSource: () => true,
         }),
       48,
-      3,
+      5,
     );
 
     await settleMermaid(mounted);
@@ -432,7 +402,37 @@ describe("TMermaidText", () => {
         colorMode: "none",
       }),
     );
-    expect(rowText(mounted, 0)).toBe("rendered:sequenceDiagram");
+    expect(rowText(mounted, 0)).toBe("sequence rendered");
+
+    mounted.unmount();
+  });
+
+  it("allows renderer-agnostic callers to explicitly skip complex Mermaid source", async () => {
+    const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
+    const renderer: TMermaidRenderer = vi.fn(() => "should not render");
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 40,
+          h: 3,
+          box: false,
+          content: source,
+          renderer,
+          shouldRenderSource: isSimpleMermaidFlowchartSource,
+        }),
+      48,
+      5,
+    );
+
+    await settleMermaid(mounted);
+
+    expect(renderer).not.toHaveBeenCalled();
+    expect(rowText(mounted, 0)).toBe("sequenceDiagram");
+    expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
+    expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
 
     mounted.unmount();
   });
@@ -477,7 +477,7 @@ describe("TMermaidText", () => {
     }
   });
 
-  it("allows an explicit shouldRenderSource opt-in for complex custom Mermaid rendering", async () => {
+  it("renders complex Mermaid source by default when the mermaid wrapper receives a custom renderer", async () => {
     vi.resetModules();
 
     try {
@@ -496,7 +496,6 @@ describe("TMermaidText", () => {
             box: false,
             content: source,
             renderer,
-            shouldRenderSource: () => true,
           }),
         48,
         3,
@@ -653,7 +652,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("keeps styled flowchart source by default instead of attempting a complex Mermaid render", async () => {
+  it("uses shouldRenderSource to keep styled complex flowchart source", async () => {
     const source = [
       "graph LR",
       "  A[Start] --> B[Done]",
@@ -672,6 +671,7 @@ describe("TMermaidText", () => {
           box: false,
           content: source,
           renderer,
+          shouldRenderSource: isSimpleMermaidFlowchartSource,
         }),
       64,
       6,

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -736,9 +736,12 @@ describe("TMermaidText", () => {
     expect(isSimpleMermaidFlowchartSource("graph LR\nA -->|100%% ready| B")).toBe(true);
     expect(isSimpleMermaidFlowchartSource("graph LR\nA -->|foo:::bar| B")).toBe(true);
     expect(isSimpleMermaidFlowchartSource("graph LR\nA -->|shape @{text}| B")).toBe(true);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA(user@example.com) --> B")).toBe(true);
 
     expect(isSimpleMermaidFlowchartSource("graph LR")).toBe(false);
     expect(isSimpleMermaidFlowchartSource("sequenceDiagram\nAlice->>Bob: hi")).toBe(false);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA e1@--> B")).toBe(false);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA --> B@{ shape: rect }")).toBe(false);
     expect(isSimpleMermaidFlowchartSource("graph LR\nsubgraph X\nA --> B\nend")).toBe(false);
     expect(isSimpleMermaidFlowchartSource("graph LR\nsubgraph X; A --> B; end")).toBe(false);
     expect(isSimpleMermaidFlowchartSource("graph LR\nstyle A fill:#f00")).toBe(false);

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -374,9 +374,9 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("lets renderer-agnostic custom renderer handle non-flowchart Mermaid source by default", async () => {
+  it("keeps complex Mermaid source by default even with a renderer-agnostic custom renderer", async () => {
     const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
-    const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
+    const renderer: TMermaidRenderer = vi.fn(() => "should not render");
 
     const mounted = await mountTerminal(
       () =>
@@ -384,25 +384,21 @@ describe("TMermaidText", () => {
           x: 0,
           y: 0,
           w: 40,
-          h: 1,
+          h: 3,
           box: false,
           content: source,
           renderer,
         }),
       48,
-      3,
+      5,
     );
 
     await settleMermaid(mounted);
 
-    expect(renderer).toHaveBeenCalledTimes(1);
-    expect(renderer).toHaveBeenCalledWith(
-      source,
-      expect.objectContaining({
-        colorMode: "none",
-      }),
-    );
-    expect(rowText(mounted, 0)).toBe("sequence rendered");
+    expect(renderer).not.toHaveBeenCalled();
+    expect(rowText(mounted, 0)).toBe("sequenceDiagram");
+    expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
+    expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
 
     mounted.unmount();
   });
@@ -511,7 +507,7 @@ describe("TMermaidText", () => {
     }
   });
 
-  it("lets the mermaid wrapper custom renderer handle complex Mermaid source by default", async () => {
+  it("lets the mermaid wrapper custom renderer opt into complex Mermaid rendering", async () => {
     vi.resetModules();
 
     try {
@@ -530,6 +526,7 @@ describe("TMermaidText", () => {
             box: false,
             content: source,
             renderer,
+            shouldRenderSource: () => true,
           }),
         48,
         3,
@@ -540,6 +537,43 @@ describe("TMermaidText", () => {
       expect(renderer).toHaveBeenCalledTimes(1);
       expect(renderer).toHaveBeenCalledWith(source, expect.objectContaining({ colorMode: "none" }));
       expect(rowText(mounted, 0)).toBe("sequence rendered");
+
+      mounted.unmount();
+    } finally {
+      vi.resetModules();
+    }
+  });
+
+  it("keeps complex Mermaid source by default even with a mermaid wrapper custom renderer", async () => {
+    vi.resetModules();
+
+    try {
+      const { TMermaidText: TMermaidTextWithBeautifulRenderer } = await import("../src/mermaid.js");
+
+      const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
+      const renderer: TMermaidRenderer = vi.fn(() => "should not render");
+
+      const mounted = await mountTerminal(
+        () =>
+          h(TMermaidTextWithBeautifulRenderer, {
+            x: 0,
+            y: 0,
+            w: 40,
+            h: 3,
+            box: false,
+            content: source,
+            renderer,
+          }),
+        48,
+        5,
+      );
+
+      await settleMermaid(mounted);
+
+      expect(renderer).not.toHaveBeenCalled();
+      expect(rowText(mounted, 0)).toBe("sequenceDiagram");
+      expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
+      expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
 
       mounted.unmount();
     } finally {

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -425,36 +425,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("keeps complex Mermaid source by default even with a custom renderer", async () => {
-    const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
-    const renderer: TMermaidRenderer = vi.fn(() => "should not render");
-
-    const mounted = await mountTerminal(
-      () =>
-        h(TMermaidText, {
-          x: 0,
-          y: 0,
-          w: 40,
-          h: 3,
-          box: false,
-          content: source,
-          renderer,
-        }),
-      48,
-      3,
-    );
-
-    await settleMermaid(mounted);
-
-    expect(renderer).not.toHaveBeenCalled();
-    expect(rowText(mounted, 0)).toBe("sequenceDiagram");
-    expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
-    expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
-
-    mounted.unmount();
-  });
-
-  it("allows callers to opt into complex Mermaid rendering with shouldRenderSource", async () => {
+  it("renders complex Mermaid source by default when the renderer succeeds", async () => {
     const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
     const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
 
@@ -468,7 +439,6 @@ describe("TMermaidText", () => {
           box: false,
           content: source,
           renderer,
-          shouldRenderSource: () => true,
         }),
       48,
       5,
@@ -488,10 +458,40 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("keeps complex Mermaid source by default when the mermaid wrapper uses the built-in renderer", async () => {
+  it("allows callers to explicitly keep complex Mermaid source with shouldRenderSource", async () => {
+    const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
+    const renderer: TMermaidRenderer = vi.fn(() => "should not render");
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 40,
+          h: 3,
+          box: false,
+          content: source,
+          renderer,
+          shouldRenderSource: isSimpleMermaidFlowchartSource,
+        }),
+      48,
+      3,
+    );
+
+    await settleMermaid(mounted);
+
+    expect(renderer).not.toHaveBeenCalled();
+    expect(rowText(mounted, 0)).toBe("sequenceDiagram");
+    expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
+    expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
+
+    mounted.unmount();
+  });
+
+  it("tries complex Mermaid source by default in the beautiful-mermaid wrapper", async () => {
     vi.resetModules();
 
-    const renderMermaidASCII = vi.fn(() => "should not render");
+    const renderMermaidASCII = vi.fn(() => "sequence rendered");
     vi.doMock("beautiful-mermaid", () => ({
       renderMermaidASCII,
     }));
@@ -516,10 +516,14 @@ describe("TMermaidText", () => {
 
       await settleMermaid(mounted);
 
-      expect(renderMermaidASCII).not.toHaveBeenCalled();
-      expect(rowText(mounted, 0)).toBe("sequenceDiagram");
-      expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
-      expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
+      expect(renderMermaidASCII).toHaveBeenCalledTimes(1);
+      expect(renderMermaidASCII).toHaveBeenCalledWith(
+        source,
+        expect.objectContaining({
+          colorMode: "none",
+        }),
+      );
+      expect(rowText(mounted, 0)).toBe("sequence rendered");
 
       mounted.unmount();
     } finally {
@@ -528,14 +532,14 @@ describe("TMermaidText", () => {
     }
   });
 
-  it("keeps complex Mermaid source by default even when the mermaid wrapper receives a custom renderer", async () => {
+  it("lets the mermaid wrapper custom renderer render complex Mermaid by default", async () => {
     vi.resetModules();
 
     try {
       const { TMermaidText: TMermaidTextWithBeautifulRenderer } = await import("../src/mermaid.js");
 
       const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
-      const renderer: TMermaidRenderer = vi.fn(() => "should not render");
+      const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
 
       const mounted = await mountTerminal(
         () =>
@@ -554,10 +558,14 @@ describe("TMermaidText", () => {
 
       await settleMermaid(mounted);
 
-      expect(renderer).not.toHaveBeenCalled();
-      expect(rowText(mounted, 0)).toBe("sequenceDiagram");
-      expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
-      expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
+      expect(renderer).toHaveBeenCalledTimes(1);
+      expect(renderer).toHaveBeenCalledWith(
+        source,
+        expect.objectContaining({
+          colorMode: "none",
+        }),
+      );
+      expect(rowText(mounted, 0)).toBe("sequence rendered");
 
       mounted.unmount();
     } finally {
@@ -565,14 +573,14 @@ describe("TMermaidText", () => {
     }
   });
 
-  it("lets the mermaid wrapper custom renderer render complex Mermaid when explicitly allowed", async () => {
+  it("lets the mermaid wrapper custom renderer skip complex Mermaid when explicitly guarded", async () => {
     vi.resetModules();
 
     try {
       const { TMermaidText: TMermaidTextWithBeautifulRenderer } = await import("../src/mermaid.js");
 
       const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
-      const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
+      const renderer: TMermaidRenderer = vi.fn(() => "should not render");
 
       const mounted = await mountTerminal(
         () =>
@@ -580,11 +588,11 @@ describe("TMermaidText", () => {
             x: 0,
             y: 0,
             w: 40,
-            h: 1,
+            h: 3,
             box: false,
             content: source,
             renderer,
-            shouldRenderSource: () => true,
+            shouldRenderSource: isSimpleMermaidFlowchartSource,
           }),
         48,
         3,
@@ -592,9 +600,10 @@ describe("TMermaidText", () => {
 
       await settleMermaid(mounted);
 
-      expect(renderer).toHaveBeenCalledTimes(1);
-      expect(renderer).toHaveBeenCalledWith(source, expect.objectContaining({ colorMode: "none" }));
-      expect(rowText(mounted, 0)).toBe("sequence rendered");
+      expect(renderer).not.toHaveBeenCalled();
+      expect(rowText(mounted, 0)).toBe("sequenceDiagram");
+      expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
+      expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
 
       mounted.unmount();
     } finally {

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -374,7 +374,36 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("renders non-flowchart Mermaid source by default when a custom renderer is supplied", async () => {
+  it("keeps non-flowchart Mermaid source by default even when a custom renderer is supplied", async () => {
+    const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
+    const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 40,
+          h: 3,
+          box: false,
+          content: source,
+          renderer,
+        }),
+      48,
+      5,
+    );
+
+    await settleMermaid(mounted);
+
+    expect(renderer).not.toHaveBeenCalled();
+    expect(rowText(mounted, 0)).toBe("sequenceDiagram");
+    expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
+    expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
+
+    mounted.unmount();
+  });
+
+  it("allows custom renderer callers to explicitly opt into non-flowchart Mermaid rendering", async () => {
     const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
     const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
 
@@ -388,6 +417,7 @@ describe("TMermaidText", () => {
           box: false,
           content: source,
           renderer,
+          shouldRenderSource: () => true,
         }),
       48,
       5,
@@ -477,7 +507,44 @@ describe("TMermaidText", () => {
     }
   });
 
-  it("renders complex Mermaid source by default when the mermaid wrapper receives a custom renderer", async () => {
+  it("keeps complex Mermaid source by default when the mermaid wrapper receives a custom renderer", async () => {
+    vi.resetModules();
+
+    try {
+      const { TMermaidText: TMermaidTextWithBeautifulRenderer } = await import("../src/mermaid.js");
+
+      const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
+      const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
+
+      const mounted = await mountTerminal(
+        () =>
+          h(TMermaidTextWithBeautifulRenderer, {
+            x: 0,
+            y: 0,
+            w: 40,
+            h: 3,
+            box: false,
+            content: source,
+            renderer,
+          }),
+        48,
+        5,
+      );
+
+      await settleMermaid(mounted);
+
+      expect(renderer).not.toHaveBeenCalled();
+      expect(rowText(mounted, 0)).toBe("sequenceDiagram");
+      expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
+      expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
+
+      mounted.unmount();
+    } finally {
+      vi.resetModules();
+    }
+  });
+
+  it("allows the mermaid wrapper custom renderer to explicitly opt into complex Mermaid rendering", async () => {
     vi.resetModules();
 
     try {
@@ -496,6 +563,7 @@ describe("TMermaidText", () => {
             box: false,
             content: source,
             renderer,
+            shouldRenderSource: () => true,
           }),
         48,
         3,

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -462,7 +462,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("keeps complex Mermaid source by default without calling the renderer", async () => {
+  it("lets an explicit custom renderer render complex Mermaid source by default", async () => {
     const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
     const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
 
@@ -483,10 +483,14 @@ describe("TMermaidText", () => {
 
     await settleMermaid(mounted);
 
-    expect(renderer).not.toHaveBeenCalled();
-    expect(rowText(mounted, 0)).toBe("sequenceDiagram");
-    expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
-    expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
+    expect(renderer).toHaveBeenCalledTimes(1);
+    expect(renderer).toHaveBeenCalledWith(
+      source,
+      expect.objectContaining({
+        colorMode: "none",
+      }),
+    );
+    expect(rowText(mounted, 0)).toBe("sequence rendered");
 
     mounted.unmount();
   });
@@ -525,7 +529,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("allows callers to explicitly keep complex Mermaid source with shouldRenderSource", async () => {
+  it("keeps complex Mermaid source when shouldRenderSource rejects it", async () => {
     const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
     const renderer: TMermaidRenderer = vi.fn(() => "should not render");
 
@@ -595,7 +599,7 @@ describe("TMermaidText", () => {
     }
   });
 
-  it("keeps complex Mermaid source by default even with a custom renderer in the wrapper", async () => {
+  it("lets a custom renderer in the mermaid wrapper render complex Mermaid by default", async () => {
     vi.resetModules();
 
     try {
@@ -621,10 +625,8 @@ describe("TMermaidText", () => {
 
       await settleMermaid(mounted);
 
-      expect(renderer).not.toHaveBeenCalled();
-      expect(rowText(mounted, 0)).toBe("sequenceDiagram");
-      expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
-      expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
+      expect(renderer).toHaveBeenCalledTimes(1);
+      expect(rowText(mounted, 0)).toBe("sequence rendered");
 
       mounted.unmount();
     } finally {

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -439,6 +439,92 @@ describe("TMermaidText", () => {
     }
   });
 
+  it("forwards copy events through the mermaid entry wrapper", async () => {
+    vi.resetModules();
+    vi.doMock("beautiful-mermaid", () => ({
+      renderMermaidASCII: vi.fn(() => "rendered diagram"),
+    }));
+
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const onCopy = vi.fn();
+    const source = "graph LR\n  A --> B";
+    const originalClipboard = Object.getOwnPropertyDescriptor(globalThis.navigator, "clipboard");
+
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    try {
+      const { TMermaidText: TMermaidTextWithBeautifulRenderer } = await import("../src/mermaid.js");
+
+      const cols = 32;
+      const rows = 5;
+      const mounted = await mountTerminal(
+        () =>
+          h(TMermaidTextWithBeautifulRenderer, {
+            x: 0,
+            y: 0,
+            w: 28,
+            content: source,
+            onCopy,
+          }),
+        cols,
+        rows,
+      );
+
+      await settleMermaid(mounted);
+
+      expect(rowText(mounted, 0)).toContain("mermaid");
+      expect(rowText(mounted, 0)).toContain("copy");
+      expect(rowText(mounted, 1)).toContain("rendered diagram");
+
+      setDeterministicMetrics(mounted, cols, rows);
+      clickCell(mounted, 22, 0);
+      await settleMermaid(mounted);
+
+      expect(writeText).toHaveBeenCalledWith(source);
+      expect(onCopy).toHaveBeenCalledWith({ text: source, ok: true });
+
+      mounted.unmount();
+    } finally {
+      if (originalClipboard) {
+        Object.defineProperty(globalThis.navigator, "clipboard", originalClipboard);
+      } else {
+        delete (globalThis.navigator as any).clipboard;
+      }
+      vi.doUnmock("beautiful-mermaid");
+      vi.resetModules();
+    }
+  });
+
+  it("treats explicit h as content height when the default mermaid box is enabled", async () => {
+    const renderer: TMermaidRenderer = vi.fn(() => "diagram line 1\ndiagram line 2");
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 28,
+          h: 2,
+          content: "graph LR\n  A --> B",
+          renderer,
+        }),
+      32,
+      6,
+    );
+
+    await settleMermaid(mounted);
+
+    expect(rowText(mounted, 0)).toContain("mermaid");
+    expect(rowText(mounted, 1)).toContain("diagram line 1");
+    expect(rowText(mounted, 2)).toContain("diagram line 2");
+    expect(rowText(mounted, 3)).toContain("└");
+
+    mounted.unmount();
+  });
+
   it("the mermaid entry TMermaidText supplies the beautiful-mermaid renderer", async () => {
     vi.resetModules();
     vi.doMock("beautiful-mermaid", () => ({

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import {
-  markMermaidRenderErrorFatal,
-  TMermaidText,
-  type TMermaidRenderer,
-  type TMermaidTransientErrorClassifier,
-} from "../src/vue.js";
+import { TMermaidText, type TMermaidRenderer } from "../src/vue.js";
 import { isMissingBeautifulMermaid } from "../src/vue/mermaid/beautiful-mermaid.js";
 import { h, mountTerminal, nextTick, ref } from "./ui-regressions-support.js";
 
@@ -16,6 +11,37 @@ function rowText(mounted: MountedTerminal, y: number): string {
     .map((cell) => cell.ch)
     .join("")
     .trimEnd();
+}
+
+function clickCell(mounted: MountedTerminal, cellX: number, cellY: number): void {
+  mounted.container()?.dispatchEvent(
+    new MouseEvent("click", {
+      clientX: cellX * 10 + 1,
+      clientY: cellY * 20 + 1,
+      bubbles: true,
+    }),
+  );
+}
+
+function setDeterministicMetrics(mounted: MountedTerminal, cols: number, rows: number): void {
+  const container = mounted.container();
+  const events = mounted.events();
+  if (!container || !events) throw new Error("expected mounted terminal events");
+  const cellWidth = 10;
+  const cellHeight = 20;
+  events.setMetrics({ cellWidth, cellHeight });
+  container.getBoundingClientRect = () =>
+    ({
+      left: 0,
+      top: 0,
+      x: 0,
+      y: 0,
+      width: cols * cellWidth,
+      height: rows * cellHeight,
+      right: cols * cellWidth,
+      bottom: rows * cellHeight,
+      toJSON() {},
+    }) as any;
 }
 
 async function settleMermaid(mounted: MountedTerminal): Promise<void> {
@@ -45,6 +71,7 @@ describe("TMermaidText", () => {
           y: 1,
           w: 8,
           h: 3,
+          box: false,
           content: "graph LR\n  A --> B",
           code: "graph TD\n  X --> Y",
           ascii: true,
@@ -91,6 +118,7 @@ describe("TMermaidText", () => {
           y: 0,
           w: 20,
           h: 2,
+          box: false,
           content: "graph LR\n  A --> B",
           renderer,
         }),
@@ -118,6 +146,7 @@ describe("TMermaidText", () => {
           y: 0,
           w: 5,
           h: 3,
+          box: false,
           content: content.value,
           renderer,
         }),
@@ -142,7 +171,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("keeps existing one-line output style while re-rendering", async () => {
+  it("shows source while a new render is pending", async () => {
     const content = ref("graph LR\n  A --> B");
     const resolvers: Array<(value: string) => void> = [];
     const renderer: TMermaidRenderer = vi.fn(
@@ -159,6 +188,7 @@ describe("TMermaidText", () => {
           y: 0,
           w: 24,
           h: 1,
+          box: false,
           content: content.value,
           streaming: true,
           style: { fg: "greenBright" },
@@ -184,7 +214,7 @@ describe("TMermaidText", () => {
     }
 
     expect(resolvers).toHaveLength(2);
-    expect(rowText(mounted, 0)).toBe("ready");
+    expect(rowText(mounted, 0)).toBe("graph LR");
     expect(mounted.terminal.getCell(0, 0).style.fg).toBe("greenBright");
 
     resolvers[1]?.("next");
@@ -194,58 +224,27 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("renders renderer guidance when no renderer is provided", async () => {
-    const mounted = await mountTerminal(
-      () =>
-        h(TMermaidText, {
-          x: 0,
-          y: 0,
-          w: 160,
-          h: 2,
-          content: "graph LR\n  A --> B",
-          errorText: "diagram error",
-          missingDependencyText: "Pass renderer or import @simon_he/vue-tui/mermaid.",
-        }),
-      120,
-      4,
-    );
-
-    await settleMermaid(mounted);
-
-    expect(rowText(mounted, 0)).toContain(
-      "diagram error: Pass renderer or import @simon_he/vue-tui/mermaid.",
-    );
-
-    mounted.unmount();
-  });
-
-  it("repaints custom missing-dependency text after entering error state", async () => {
-    const missingText = ref("install peer first");
-
+  it("keeps source when no renderer is provided", async () => {
     const mounted = await mountTerminal(
       () =>
         h(TMermaidText, {
           x: 0,
           y: 0,
           w: 80,
-          h: 1,
+          h: 2,
+          box: false,
           content: "graph LR\n  A --> B",
           errorText: "diagram error",
-          missingDependencyText: missingText.value,
+          missingDependencyText: "Pass renderer or import @simon_he/vue-tui/mermaid.",
         }),
-      80,
-      3,
+      100,
+      4,
     );
 
     await settleMermaid(mounted);
-    expect(rowText(mounted, 0)).toContain("diagram error: install peer first");
 
-    missingText.value = "pass renderer or import @simon_he/vue-tui/mermaid";
-    await settleMermaid(mounted);
-
-    expect(rowText(mounted, 0)).toContain(
-      "diagram error: pass renderer or import @simon_he/vue-tui/mermaid",
-    );
+    expect(rowText(mounted, 0)).toBe("graph LR");
+    expect(rowText(mounted, 1)).toBe("  A --> B");
 
     mounted.unmount();
   });
@@ -261,6 +260,7 @@ describe("TMermaidText", () => {
           y: 0,
           w: 24,
           h: 1,
+          box: false,
           content: content.value,
           streaming: true,
           renderer,
@@ -285,7 +285,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("does not classify normal render errors as missing dependency", async () => {
+  it("keeps source when final rendering fails", async () => {
     const renderer: TMermaidRenderer = vi.fn(() => {
       throw new Error("beautiful-mermaid parser rejected invalid graph syntax");
     });
@@ -297,6 +297,7 @@ describe("TMermaidText", () => {
           y: 0,
           w: 100,
           h: 2,
+          box: false,
           content: "graph LR\n  A -->",
           errorText: "diagram error",
           missingDependencyText: "Missing optional peer.",
@@ -308,22 +309,18 @@ describe("TMermaidText", () => {
 
     await settleMermaid(mounted);
 
-    expect(rowText(mounted, 0)).toContain(
-      "diagram error: beautiful-mermaid parser rejected invalid graph syntax",
-    );
+    expect(rowText(mounted, 0)).toBe("graph LR");
+    expect(rowText(mounted, 1)).toBe("  A -->");
+    expect(rowText(mounted, 0)).not.toContain("diagram error");
     expect(rowText(mounted, 0)).not.toContain("Missing optional peer.");
 
     mounted.unmount();
   });
 
-  it("keeps the last successful diagram while streaming source is temporarily invalid", async () => {
+  it("shows streaming source without calling the renderer until final", async () => {
     const content = ref("graph LR\n  A --> B");
-    const renderer: TMermaidRenderer = vi.fn((code) => {
-      if (code.includes("BROKEN")) {
-        throw new Error("Mermaid source is incomplete");
-      }
-      return `rendered:${code.split("\n")[1]?.trim() ?? ""}`;
-    });
+    const final = ref(false);
+    const renderer: TMermaidRenderer = vi.fn((code) => `rendered:${code.split("\n")[1]?.trim()}`);
 
     const mounted = await mountTerminal(
       () =>
@@ -331,39 +328,40 @@ describe("TMermaidText", () => {
           x: 0,
           y: 0,
           w: 48,
-          h: 1,
+          h: 2,
+          box: false,
           content: content.value,
-          final: false,
+          final: final.value,
           streaming: true,
+          incompleteText: "waiting for complete Mermaid source",
           renderer,
         }),
       64,
-      3,
+      4,
     );
 
     await settleMermaid(mounted);
-    expect(rowText(mounted, 0)).toBe("rendered:A --> B");
+    expect(renderer).not.toHaveBeenCalled();
+    expect(rowText(mounted, 0)).toBe("graph LR");
+    expect(rowText(mounted, 1)).toBe("  A --> B");
 
     content.value = "graph LR\n  BROKEN";
     await settleMermaid(mounted);
-    expect(rowText(mounted, 0)).toBe("rendered:A --> B");
-    expect(rowText(mounted, 0)).not.toContain("Mermaid source is incomplete");
+    expect(renderer).not.toHaveBeenCalled();
+    expect(rowText(mounted, 1)).toBe("  BROKEN");
+    expect(rowText(mounted, 0)).not.toContain("waiting for complete Mermaid source");
 
+    final.value = true;
     content.value = "graph LR\n  A --> C";
     await settleMermaid(mounted);
+    expect(renderer).toHaveBeenCalledTimes(1);
     expect(rowText(mounted, 0)).toBe("rendered:A --> C");
 
     mounted.unmount();
   });
 
-  it("does not keep blank renderer output as the last successful streaming diagram", async () => {
-    const content = ref("graph LR\n  A --> B");
-    let mode: "blank" | "throw" = "blank";
-
-    const renderer: TMermaidRenderer = vi.fn(() => {
-      if (mode === "throw") throw new Error("Mermaid source is incomplete");
-      return "   \n\t";
-    });
+  it("keeps source when the renderer returns blank output", async () => {
+    const renderer: TMermaidRenderer = vi.fn(() => "   \n\t");
 
     const mounted = await mountTerminal(
       () =>
@@ -372,10 +370,8 @@ describe("TMermaidText", () => {
           y: 0,
           w: 80,
           h: 2,
-          content: content.value,
-          final: false,
-          streaming: true,
-          incompleteText: "waiting for complete Mermaid source",
+          box: false,
+          content: "graph LR\n  A --> B",
           renderer,
         }),
       100,
@@ -384,359 +380,63 @@ describe("TMermaidText", () => {
 
     await settleMermaid(mounted);
 
-    mode = "throw";
-    content.value = "graph LR\n  A -->";
-    await settleMermaid(mounted);
-
-    expect(rowText(mounted, 0)).toContain("waiting for complete Mermaid source");
+    expect(rowText(mounted, 0)).toBe("graph LR");
+    expect(rowText(mounted, 1)).toBe("  A --> B");
 
     mounted.unmount();
   });
 
-  it("shows an incomplete placeholder during streaming and a hard error after final", async () => {
-    const final = ref(false);
-    const renderer: TMermaidRenderer = vi.fn(() => {
-      throw new Error("expected node id after arrow");
+  it("draws the default mermaid box and copies source text", async () => {
+    const source = "graph LR\n  A --> B";
+    const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const onCopy = vi.fn();
+    const originalClipboard = Object.getOwnPropertyDescriptor(globalThis.navigator, "clipboard");
+
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
     });
 
-    const mounted = await mountTerminal(
-      () =>
-        h(TMermaidText, {
-          x: 0,
-          y: 0,
-          w: 96,
-          h: 2,
-          content: "graph LR\n  A -->",
-          final: final.value,
-          streaming: true,
-          incompleteText: "waiting for complete Mermaid source",
-          errorText: "diagram failed",
-          renderer,
-        }),
-      120,
-      4,
-    );
-
-    await settleMermaid(mounted);
-    expect(rowText(mounted, 0)).toContain("waiting for complete Mermaid source");
-    expect(rowText(mounted, 0)).not.toContain("expected node id after arrow");
-
-    final.value = true;
-    await settleMermaid(mounted);
-    expect(rowText(mounted, 0)).toContain("diagram failed: expected node id after arrow");
-
-    mounted.unmount();
-  });
-
-  it("re-renders when streaming error classification changes", async () => {
-    const streaming = ref(false);
-    const renderer: TMermaidRenderer = vi.fn(() => {
-      throw new Error("source incomplete");
-    });
-
-    const mounted = await mountTerminal(
-      () =>
-        h(TMermaidText, {
-          x: 0,
-          y: 0,
-          w: 96,
-          h: 1,
-          content: "graph LR\n  A -->",
-          final: false,
-          streaming: streaming.value,
-          incompleteText: "waiting for complete Mermaid source",
-          errorText: "diagram failed",
-          renderer,
-        }),
-      120,
-      3,
-    );
-
-    await settleMermaid(mounted);
-    expect(rowText(mounted, 0)).toContain("diagram failed: source incomplete");
-
-    streaming.value = true;
-    await settleMermaid(mounted);
-
-    expect(rowText(mounted, 0)).toContain("waiting for complete Mermaid source");
-    expect(rowText(mounted, 0)).not.toContain("source incomplete");
-    expect(renderer).toHaveBeenCalledTimes(2);
-
-    mounted.unmount();
-  });
-
-  it("does not hide fatal renderer integration errors during streaming", async () => {
-    const renderer: TMermaidRenderer = vi.fn(() => {
-      throw markMermaidRenderErrorFatal(new Error("Install beautiful-mermaid first"));
-    });
-
-    const mounted = await mountTerminal(
-      () =>
-        h(TMermaidText, {
-          x: 0,
-          y: 0,
-          w: 96,
-          h: 2,
-          content: "graph LR\n  A --> B",
-          final: false,
-          streaming: true,
-          incompleteText: "waiting for complete Mermaid source",
-          errorText: "diagram failed",
-          renderer,
-        }),
-      120,
-      4,
-    );
-
-    await settleMermaid(mounted);
-    expect(rowText(mounted, 0)).toContain("diagram failed: Install beautiful-mermaid first");
-    expect(rowText(mounted, 0)).not.toContain("waiting for complete Mermaid source");
-
-    mounted.unmount();
-  });
-
-  it("does not hide fatal renderer integration errors from causes during streaming", async () => {
-    const renderer: TMermaidRenderer = vi.fn(() => {
-      throw Object.assign(new Error("renderer wrapper failed"), {
-        cause: markMermaidRenderErrorFatal(new Error("missing renderer setup")),
-      });
-    });
-
-    const mounted = await mountTerminal(
-      () =>
-        h(TMermaidText, {
-          x: 0,
-          y: 0,
-          w: 96,
-          h: 2,
-          content: "graph LR\n  A --> B",
-          final: false,
-          streaming: true,
-          incompleteText: "waiting for complete Mermaid source",
-          errorText: "diagram failed",
-          renderer,
-        }),
-      120,
-      4,
-    );
-
-    await settleMermaid(mounted);
-    expect(rowText(mounted, 0)).toContain("diagram failed: renderer wrapper failed");
-    expect(rowText(mounted, 0)).not.toContain("waiting for complete Mermaid source");
-
-    mounted.unmount();
-  });
-
-  it("does not hide a missing beautiful-mermaid peer as a streaming transient error", async () => {
-    vi.resetModules();
-    vi.doMock("beautiful-mermaid", () => ({
-      renderMermaidASCII: vi.fn(() => {
-        throw Object.assign(
-          new Error("Cannot find package 'beautiful-mermaid' imported from /app"),
-          { code: "ERR_MODULE_NOT_FOUND" },
-        );
-      }),
-    }));
-
-    const { TMermaidText: TMermaidTextWithBeautifulRenderer } = await import("../src/mermaid.js");
-
-    const mounted = await mountTerminal(
-      () =>
-        h(TMermaidTextWithBeautifulRenderer, {
-          x: 0,
-          y: 0,
-          w: 140,
-          h: 2,
-          content: "graph LR\n  A --> B",
-          final: false,
-          streaming: true,
-          incompleteText: "waiting for complete Mermaid source",
-          errorText: "diagram failed",
-        }),
-      160,
-      4,
-    );
-
-    await settleMermaid(mounted);
-
-    expect(rowText(mounted, 0)).toContain("diagram failed: Install beautiful-mermaid");
-    expect(rowText(mounted, 0)).not.toContain("waiting for complete Mermaid source");
-
-    mounted.unmount();
-    vi.doUnmock("beautiful-mermaid");
-    vi.resetModules();
-  });
-
-  it("does not hide coded renderer setup errors as streaming transient errors", async () => {
-    const renderer: TMermaidRenderer = vi.fn(() => {
-      throw Object.assign(new Error("renderer setup failed"), {
-        code: "VUE_TUI_MERMAID_RENDERER_SETUP",
-      });
-    });
-
-    const mounted = await mountTerminal(
-      () =>
-        h(TMermaidText, {
-          x: 0,
-          y: 0,
-          w: 120,
-          h: 2,
-          content: "graph LR\n  A --> B",
-          final: false,
-          streaming: true,
-          errorText: "diagram failed",
-          renderer,
-        }),
-      140,
-      4,
-    );
-
-    await settleMermaid(mounted);
-    expect(rowText(mounted, 0)).toContain("diagram failed: renderer setup failed");
-
-    mounted.unmount();
-  });
-
-  it("does not hide coded renderer setup errors from causes as streaming transient errors", async () => {
-    const renderer: TMermaidRenderer = vi.fn(() => {
-      throw Object.assign(new Error("renderer wrapper failed"), {
-        cause: Object.assign(new Error("renderer setup failed"), {
-          code: "VUE_TUI_MERMAID_RENDERER_SETUP",
-        }),
-      });
-    });
-
-    const mounted = await mountTerminal(
-      () =>
-        h(TMermaidText, {
-          x: 0,
-          y: 0,
-          w: 120,
-          h: 2,
-          content: "graph LR\n  A --> B",
-          final: false,
-          streaming: true,
-          errorText: "diagram failed",
-          renderer,
-        }),
-      140,
-      4,
-    );
-
-    await settleMermaid(mounted);
-    expect(rowText(mounted, 0)).toContain("diagram failed: renderer wrapper failed");
-
-    mounted.unmount();
-  });
-
-  it("can mark frozen renderer errors as fatal during non-final streaming", async () => {
-    const frozenError = Object.freeze(new Error("renderer setup failed"));
-    const renderer: TMermaidRenderer = vi.fn(() => {
-      throw markMermaidRenderErrorFatal(frozenError);
-    });
-
-    const mounted = await mountTerminal(
-      () =>
-        h(TMermaidText, {
-          x: 0,
-          y: 0,
-          w: 96,
-          h: 2,
-          content: "graph LR\n  A --> B",
-          final: false,
-          streaming: true,
-          incompleteText: "waiting for complete Mermaid source",
-          errorText: "diagram failed",
-          renderer,
-        }),
-      120,
-      4,
-    );
-
-    await settleMermaid(mounted);
-    expect(rowText(mounted, 0)).toContain("diagram failed: renderer setup failed");
-    expect(rowText(mounted, 0)).not.toContain("waiting for complete Mermaid source");
-
-    mounted.unmount();
-  });
-
-  it("allows callers to override transient Mermaid error classification", async () => {
-    const contexts: Parameters<TMermaidTransientErrorClassifier>[1][] = [];
-    const renderer: TMermaidRenderer = vi.fn(() => {
-      throw new Error("custom permanent Mermaid error");
-    });
-    const isTransientError: TMermaidTransientErrorClassifier = (_error, context) => {
-      contexts.push(context);
-      return false;
-    };
-
-    const mounted = await mountTerminal(
-      () =>
-        h(TMermaidText, {
-          x: 0,
-          y: 0,
-          w: 96,
-          h: 2,
-          content: "graph LR\n  A --> B",
-          final: false,
-          streaming: true,
-          errorText: "diagram failed",
-          renderer,
-          isTransientError,
-        }),
-      120,
-      4,
-    );
-
-    await settleMermaid(mounted);
-    expect(rowText(mounted, 0)).toContain("diagram failed: custom permanent Mermaid error");
-    expect(contexts).toEqual([
-      {
-        code: "graph LR\n  A --> B",
-        final: false,
-        streaming: true,
-      },
-    ]);
-
-    mounted.unmount();
-  });
-
-  it("does not hide beautiful-mermaid loader setup errors during streaming", async () => {
-    vi.resetModules();
-    vi.doMock("beautiful-mermaid", () => {
-      throw Object.assign(
-        new Error(
-          "Cannot find package 'elkjs' imported from /app/node_modules/beautiful-mermaid/dist/index.js",
-        ),
-        { code: "ERR_MODULE_NOT_FOUND" },
+    try {
+      const cols = 32;
+      const rows = 5;
+      const mounted = await mountTerminal(
+        () =>
+          h(TMermaidText, {
+            x: 0,
+            y: 0,
+            w: 28,
+            content: source,
+            renderer,
+            onCopy,
+          }),
+        cols,
+        rows,
       );
-    });
 
-    const { TMermaidText: TMermaidTextWithBeautifulRenderer } = await import("../src/mermaid.js");
-    const mounted = await mountTerminal(
-      () =>
-        h(TMermaidTextWithBeautifulRenderer, {
-          x: 0,
-          y: 0,
-          w: 120,
-          h: 2,
-          content: "graph LR\n  A -->",
-          final: false,
-          streaming: true,
-          incompleteText: "waiting for complete Mermaid source",
-          errorText: "diagram failed",
-        }),
-      140,
-      4,
-    );
+      await settleMermaid(mounted);
 
-    await settleMermaid(mounted);
-    expect(rowText(mounted, 0)).toContain("diagram failed:");
-    expect(rowText(mounted, 0)).not.toContain("waiting for complete Mermaid source");
+      expect(rowText(mounted, 0)).toContain("mermaid");
+      expect(rowText(mounted, 0)).toContain("copy");
+      expect(rowText(mounted, 1)).toContain("rendered diagram");
 
-    mounted.unmount();
-    vi.doUnmock("beautiful-mermaid");
-    vi.resetModules();
+      setDeterministicMetrics(mounted, cols, rows);
+      clickCell(mounted, 22, 0);
+      await settleMermaid(mounted);
+
+      expect(writeText).toHaveBeenCalledWith(source);
+      expect(onCopy).toHaveBeenCalledWith({ text: source, ok: true });
+      expect(rowText(mounted, 0)).toContain("copied");
+
+      mounted.unmount();
+    } finally {
+      if (originalClipboard) {
+        Object.defineProperty(globalThis.navigator, "clipboard", originalClipboard);
+      } else {
+        delete (globalThis.navigator as any).clipboard;
+      }
+    }
   });
 
   it("the mermaid entry TMermaidText supplies the beautiful-mermaid renderer", async () => {
@@ -756,6 +456,7 @@ describe("TMermaidText", () => {
           y: 0,
           w: 40,
           h: 1,
+          box: false,
           content: "graph LR\n  A --> B",
         }),
       40,
@@ -884,6 +585,7 @@ describe("TMermaidText", () => {
           y: 0,
           w: 12,
           h: 1,
+          box: false,
           content: content.value,
           renderer,
         }),

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -454,7 +454,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("skips rendering whenever final is false even when streaming is not enabled", async () => {
+  it("renders when final is false but streaming is not enabled", async () => {
     const final = ref(false);
     const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
 
@@ -468,6 +468,7 @@ describe("TMermaidText", () => {
           box: false,
           content: "graph LR\n  A --> B",
           final: final.value,
+          streaming: false,
           renderer,
         }),
       64,
@@ -475,11 +476,48 @@ describe("TMermaidText", () => {
     );
 
     await settleMermaid(mounted);
+
+    expect(renderer).toHaveBeenCalledTimes(1);
+    expect(rowText(mounted, 0)).toBe("rendered diagram");
+
+    final.value = true;
+    await settleMermaid(mounted);
+
+    expect(renderer).toHaveBeenCalledTimes(2);
+    expect(rowText(mounted, 0)).toBe("rendered diagram");
+
+    mounted.unmount();
+  });
+
+  it("skips renderer only for unfinished streaming Mermaid source", async () => {
+    const final = ref(false);
+    const streaming = ref(true);
+    const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 48,
+          h: 2,
+          box: false,
+          content: "graph LR\n  A --> B",
+          final: final.value,
+          streaming: streaming.value,
+          renderer,
+        }),
+      64,
+      4,
+    );
+
+    await settleMermaid(mounted);
+
     expect(renderer).not.toHaveBeenCalled();
     expect(rowText(mounted, 0)).toBe("graph LR");
     expect(rowText(mounted, 1)).toBe("  A --> B");
 
-    final.value = true;
+    streaming.value = false;
     await settleMermaid(mounted);
 
     expect(renderer).toHaveBeenCalledTimes(1);

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -8,6 +8,7 @@ import {
   mountTerminal,
   nextTick,
   ref,
+  TText,
   TView,
 } from "./ui-regressions-support.js";
 
@@ -374,9 +375,9 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("keeps complex Mermaid source by default even with a renderer-agnostic custom renderer", async () => {
+  it("lets renderer-agnostic custom renderers handle complex Mermaid by default", async () => {
     const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
-    const renderer: TMermaidRenderer = vi.fn(() => "should not render");
+    const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
 
     const mounted = await mountTerminal(
       () =>
@@ -384,7 +385,7 @@ describe("TMermaidText", () => {
           x: 0,
           y: 0,
           w: 40,
-          h: 3,
+          h: 1,
           box: false,
           content: source,
           renderer,
@@ -395,10 +396,14 @@ describe("TMermaidText", () => {
 
     await settleMermaid(mounted);
 
-    expect(renderer).not.toHaveBeenCalled();
-    expect(rowText(mounted, 0)).toBe("sequenceDiagram");
-    expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
-    expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
+    expect(renderer).toHaveBeenCalledTimes(1);
+    expect(renderer).toHaveBeenCalledWith(
+      source,
+      expect.objectContaining({
+        colorMode: "none",
+      }),
+    );
+    expect(rowText(mounted, 0)).toBe("sequence rendered");
 
     mounted.unmount();
   });
@@ -544,14 +549,14 @@ describe("TMermaidText", () => {
     }
   });
 
-  it("keeps complex Mermaid source by default even with a mermaid wrapper custom renderer", async () => {
+  it("lets mermaid entry custom renderers handle complex Mermaid by default", async () => {
     vi.resetModules();
 
     try {
       const { TMermaidText: TMermaidTextWithBeautifulRenderer } = await import("../src/mermaid.js");
 
       const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
-      const renderer: TMermaidRenderer = vi.fn(() => "should not render");
+      const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
 
       const mounted = await mountTerminal(
         () =>
@@ -559,7 +564,7 @@ describe("TMermaidText", () => {
             x: 0,
             y: 0,
             w: 40,
-            h: 3,
+            h: 1,
             box: false,
             content: source,
             renderer,
@@ -570,10 +575,14 @@ describe("TMermaidText", () => {
 
       await settleMermaid(mounted);
 
-      expect(renderer).not.toHaveBeenCalled();
-      expect(rowText(mounted, 0)).toBe("sequenceDiagram");
-      expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
-      expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
+      expect(renderer).toHaveBeenCalledTimes(1);
+      expect(renderer).toHaveBeenCalledWith(
+        source,
+        expect.objectContaining({
+          colorMode: "none",
+        }),
+      );
+      expect(rowText(mounted, 0)).toBe("sequence rendered");
 
       mounted.unmount();
     } finally {
@@ -1107,6 +1116,32 @@ describe("TMermaidText", () => {
     expect(rowText(mounted, 1)).toContain("rendered diagram");
     expect(rowText(mounted, 2).startsWith("+")).toBe(true);
     expect(rowText(mounted, 2).endsWith("+")).toBe(true);
+
+    mounted.unmount();
+  });
+
+  it("does not reserve box rows when auto-sized width is too narrow to draw the box", async () => {
+    const renderer: TMermaidRenderer = vi.fn(() => "R");
+
+    const mounted = await mountTerminal(
+      () => [
+        h(TText, { x: 0, y: 1, zIndex: -1, value: "below", w: 8 }),
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 1,
+          content: "graph LR\n  A --> B",
+          renderer,
+        }),
+      ],
+      12,
+      4,
+    );
+
+    await settleMermaid(mounted);
+
+    expect(rowText(mounted, 0)).toBe("R");
+    expect(rowText(mounted, 1)).toBe("below");
 
     mounted.unmount();
   });

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -447,6 +447,63 @@ describe("TMermaidText", () => {
     }
   });
 
+  it("only treats plain id-to-id flowchart edges as simple Mermaid flowcharts", () => {
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA --> B\nB --- C")).toBe(true);
+    expect(isSimpleMermaidFlowchartSource("flowchart TD; A --> B; B --- C")).toBe(true);
+
+    expect(isSimpleMermaidFlowchartSource("graph LR")).toBe(false);
+    expect(isSimpleMermaidFlowchartSource("sequenceDiagram\nAlice->>Bob: hi")).toBe(false);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA[Start] --> B")).toBe(false);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA -->|yes| B")).toBe(false);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA -.-> B")).toBe(false);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA ==> B")).toBe(false);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA --> B --> C")).toBe(false);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA & B --> C")).toBe(false);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA --> B & C")).toBe(false);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nsubgraph X\nA --> B\nend")).toBe(false);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nstyle A fill:#f00")).toBe(false);
+    expect(isSimpleMermaidFlowchartSource("%%{init: {}}%%\ngraph LR\nA --> B")).toBe(false);
+  });
+
+  it("keeps labeled flowchart source in the beautiful-mermaid wrapper", async () => {
+    vi.resetModules();
+
+    const renderMermaidASCII = vi.fn(() => "should not render");
+    vi.doMock("beautiful-mermaid", () => ({
+      renderMermaidASCII,
+    }));
+
+    try {
+      const { TMermaidText: TMermaidTextWithBeautifulRenderer } = await import("../src/mermaid.js");
+      const source = "graph LR\nA[Start] --> B";
+
+      const mounted = await mountTerminal(
+        () =>
+          h(TMermaidTextWithBeautifulRenderer, {
+            x: 0,
+            y: 0,
+            w: 40,
+            h: 4,
+            box: false,
+            content: source,
+          }),
+        48,
+        6,
+      );
+
+      await settleMermaid(mounted);
+
+      expect(renderMermaidASCII).not.toHaveBeenCalled();
+      expect(rowText(mounted, 0)).toBe("graph LR");
+      expect(rowText(mounted, 1)).toBe("A[Start] --> B");
+
+      mounted.unmount();
+    } finally {
+      vi.doUnmock("beautiful-mermaid");
+      vi.resetModules();
+    }
+  });
+
   it("uses shouldRenderSource to skip complex flowchart features", async () => {
     const renderer: TMermaidRenderer = vi.fn(() => "should not render");
 

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -485,35 +485,42 @@ describe("TMermaidText", () => {
     }
   });
 
-  it("only treats plain id-to-id flowchart edges as simple Mermaid flowcharts", () => {
+  it("treats normal flowchart syntax as renderable and rejects complex Mermaid features", () => {
     expect(isSimpleMermaidFlowchartSource("graph LR\nA --> B\nB --- C")).toBe(true);
     expect(isSimpleMermaidFlowchartSource("flowchart TD; A --> B; B --- C")).toBe(true);
 
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA[Start] --> B")).toBe(true);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA -->|yes| B")).toBe(true);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA -.-> B")).toBe(true);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA ==> B")).toBe(true);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA --> B --> C")).toBe(true);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA & B --> C")).toBe(true);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA --> B & C")).toBe(true);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA[Start] -->|ok| B{Done}")).toBe(true);
+
     expect(isSimpleMermaidFlowchartSource("graph LR")).toBe(false);
     expect(isSimpleMermaidFlowchartSource("sequenceDiagram\nAlice->>Bob: hi")).toBe(false);
-    expect(isSimpleMermaidFlowchartSource("graph LR\nA[Start] --> B")).toBe(false);
-    expect(isSimpleMermaidFlowchartSource("graph LR\nA -->|yes| B")).toBe(false);
-    expect(isSimpleMermaidFlowchartSource("graph LR\nA -.-> B")).toBe(false);
-    expect(isSimpleMermaidFlowchartSource("graph LR\nA ==> B")).toBe(false);
-    expect(isSimpleMermaidFlowchartSource("graph LR\nA --> B --> C")).toBe(false);
-    expect(isSimpleMermaidFlowchartSource("graph LR\nA & B --> C")).toBe(false);
-    expect(isSimpleMermaidFlowchartSource("graph LR\nA --> B & C")).toBe(false);
     expect(isSimpleMermaidFlowchartSource("graph LR\nsubgraph X\nA --> B\nend")).toBe(false);
     expect(isSimpleMermaidFlowchartSource("graph LR\nstyle A fill:#f00")).toBe(false);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nclassDef hot fill:#f00")).toBe(false);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA:::hot --> B")).toBe(false);
+    expect(isSimpleMermaidFlowchartSource('graph LR\nclick A href "https://example.com"')).toBe(
+      false,
+    );
     expect(isSimpleMermaidFlowchartSource("%%{init: {}}%%\ngraph LR\nA --> B")).toBe(false);
   });
 
-  it("keeps labeled flowchart source in the beautiful-mermaid wrapper", async () => {
+  it("renders labeled flowchart source in the beautiful-mermaid wrapper", async () => {
     vi.resetModules();
 
-    const renderMermaidASCII = vi.fn(() => "should not render");
+    const renderMermaidASCII = vi.fn(() => "labeled rendered");
     vi.doMock("beautiful-mermaid", () => ({
       renderMermaidASCII,
     }));
 
     try {
       const { TMermaidText: TMermaidTextWithBeautifulRenderer } = await import("../src/mermaid.js");
-      const source = "graph LR\nA[Start] --> B";
+      const source = "graph LR\nA[Start] -->|ok| B{Done}";
 
       const mounted = await mountTerminal(
         () =>
@@ -531,15 +538,50 @@ describe("TMermaidText", () => {
 
       await settleMermaid(mounted);
 
-      expect(renderMermaidASCII).not.toHaveBeenCalled();
-      expect(rowText(mounted, 0)).toBe("graph LR");
-      expect(rowText(mounted, 1)).toBe("A[Start] --> B");
+      expect(renderMermaidASCII).toHaveBeenCalledTimes(1);
+      expect(renderMermaidASCII).toHaveBeenCalledWith(
+        source,
+        expect.objectContaining({
+          colorMode: "none",
+        }),
+      );
+      expect(rowText(mounted, 0)).toBe("labeled rendered");
 
       mounted.unmount();
     } finally {
       vi.doUnmock("beautiful-mermaid");
       vi.resetModules();
     }
+  });
+
+  it("keeps labeled flowchart source when the renderer rejects it", async () => {
+    const source = "graph LR\nA[Start] -->|ok| B{Done}";
+    const renderer: TMermaidRenderer = vi.fn(() => {
+      throw new Error("renderer rejected labeled flowchart");
+    });
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 48,
+          h: 2,
+          box: false,
+          content: source,
+          renderer,
+        }),
+      64,
+      4,
+    );
+
+    await settleMermaid(mounted);
+
+    expect(renderer).toHaveBeenCalledTimes(1);
+    expect(rowText(mounted, 0)).toBe("graph LR");
+    expect(rowText(mounted, 1)).toBe("A[Start] -->|ok| B{Done}");
+
+    mounted.unmount();
   });
 
   it("uses shouldRenderSource to skip complex flowchart features", async () => {

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -431,6 +431,93 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
+  it("skips semicolon-delimited complex flowchart features and keeps source visible", async () => {
+    const source = "graph LR; subgraph Cluster; A --> B; end";
+    const renderer: TMermaidRenderer = vi.fn(() => "should not render");
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 80,
+          h: 1,
+          box: false,
+          content: source,
+          renderer,
+        }),
+      90,
+      3,
+    );
+
+    await settleMermaid(mounted);
+
+    expect(renderer).not.toHaveBeenCalled();
+    expect(rowText(mounted, 0)).toBe(source);
+
+    mounted.unmount();
+  });
+
+  it("counts semicolon-delimited flow statements before rendering", async () => {
+    const source = [
+      "graph LR",
+      Array.from({ length: 121 }, (_, index) => `A${index} --> A${index + 1}`).join("; "),
+    ].join("; ");
+    const renderer: TMermaidRenderer = vi.fn(() => "should not render");
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 120,
+          h: 1,
+          box: false,
+          content: source,
+          renderer,
+        }),
+      130,
+      3,
+    );
+
+    await settleMermaid(mounted);
+
+    expect(renderer).not.toHaveBeenCalled();
+    expect(rowText(mounted, 0)).toContain("graph LR; A0 --> A1");
+
+    mounted.unmount();
+  });
+
+  it("applies the max line guard consistently for CR-only Mermaid source", async () => {
+    const source = "graph LR\r  A --> B\r  B --> C";
+    const renderer: TMermaidRenderer = vi.fn(() => "should not render");
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 40,
+          h: 3,
+          box: false,
+          content: source,
+          renderer,
+          maxRenderSourceLines: 2,
+        }),
+      48,
+      5,
+    );
+
+    await settleMermaid(mounted);
+
+    expect(renderer).not.toHaveBeenCalled();
+    expect(rowText(mounted, 0)).toBe("graph LR");
+    expect(rowText(mounted, 1)).toBe("  A --> B");
+    expect(rowText(mounted, 2)).toBe("  B --> C");
+
+    mounted.unmount();
+  });
+
   it("keeps source when Mermaid rendering times out", async () => {
     vi.useFakeTimers();
 

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -541,9 +541,7 @@ describe("TMermaidText", () => {
     expect(isSimpleMermaidFlowchartSource("graph LR\nsubgraph X; A --> B; end")).toBe(false);
     expect(isSimpleMermaidFlowchartSource("graph LR\nstyle A fill:#f00")).toBe(false);
     expect(isSimpleMermaidFlowchartSource("graph LR\nclassDef hot fill:#f00")).toBe(false);
-    expect(isSimpleMermaidFlowchartSource("graph LR\nA --> B; classDef hot fill:#f00")).toBe(
-      false,
-    );
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA --> B; classDef hot fill:#f00")).toBe(false);
     expect(isSimpleMermaidFlowchartSource("graph LR\nA:::hot --> B")).toBe(false);
     expect(isSimpleMermaidFlowchartSource('graph LR\nclick A href "https://example.com"')).toBe(
       false,
@@ -651,6 +649,39 @@ describe("TMermaidText", () => {
     expect(rowText(mounted, 1)).toBe("  subgraph Cluster");
     expect(rowText(mounted, 2)).toBe("    A --> B");
     expect(rowText(mounted, 3)).toBe("  end");
+
+    mounted.unmount();
+  });
+
+  it("keeps styled flowchart source by default instead of attempting a complex Mermaid render", async () => {
+    const source = [
+      "graph LR",
+      "  A[Start] --> B[Done]",
+      "  classDef hot fill:#f00,color:#fff",
+      "  class A hot",
+    ].join("\n");
+    const renderer: TMermaidRenderer = vi.fn(() => "should not render");
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 56,
+          h: 4,
+          box: false,
+          content: source,
+          renderer,
+        }),
+      64,
+      6,
+    );
+
+    await settleMermaid(mounted);
+
+    expect(renderer).not.toHaveBeenCalled();
+    expect(rowText(mounted, 0)).toBe("graph LR");
+    expect(rowText(mounted, 2)).toBe("  classDef hot fill:#f00,color:#fff");
 
     mounted.unmount();
   });

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -374,8 +374,9 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("skips unsupported complex Mermaid diagram types and keeps source visible", async () => {
-    const renderer: TMermaidRenderer = vi.fn(() => "should not render");
+  it("lets non-flowchart Mermaid diagram types render when the renderer supports them", async () => {
+    const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
+    const renderer: TMermaidRenderer = vi.fn(() => "rendered sequence");
 
     const mounted = await mountTerminal(
       () =>
@@ -385,7 +386,7 @@ describe("TMermaidText", () => {
           w: 40,
           h: 4,
           box: false,
-          content: ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n"),
+          content: source,
           renderer,
         }),
       48,
@@ -394,10 +395,47 @@ describe("TMermaidText", () => {
 
     await settleMermaid(mounted);
 
-    expect(renderer).not.toHaveBeenCalled();
+    expect(renderer).toHaveBeenCalledTimes(1);
+    expect(renderer).toHaveBeenCalledWith(
+      source,
+      expect.objectContaining({
+        colorMode: "none",
+        useAscii: false,
+      }),
+    );
+    expect(rowText(mounted, 0)).toBe("rendered sequence");
+
+    mounted.unmount();
+  });
+
+  it("keeps non-flowchart Mermaid source visible when rendering fails", async () => {
+    const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
+    const renderer: TMermaidRenderer = vi.fn(() => {
+      throw new Error("unsupported sequence diagram");
+    });
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 40,
+          h: 4,
+          box: false,
+          content: source,
+          renderer,
+        }),
+      48,
+      6,
+    );
+
+    await settleMermaid(mounted);
+
+    expect(renderer).toHaveBeenCalledTimes(1);
     expect(rowText(mounted, 0)).toBe("sequenceDiagram");
     expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
     expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
+    expect(rowText(mounted, 0)).not.toContain("unsupported sequence diagram");
 
     mounted.unmount();
   });

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -447,6 +447,47 @@ describe("TMermaidText", () => {
     }
   });
 
+  it("does not apply the built-in simple-flowchart eligibility to a custom renderer in the mermaid entry wrapper", async () => {
+    vi.resetModules();
+
+    try {
+      const { TMermaidText: TMermaidTextWithBeautifulRenderer } = await import("../src/mermaid.js");
+
+      const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
+      const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
+
+      const mounted = await mountTerminal(
+        () =>
+          h(TMermaidTextWithBeautifulRenderer, {
+            x: 0,
+            y: 0,
+            w: 40,
+            h: 1,
+            box: false,
+            content: source,
+            renderer,
+          }),
+        48,
+        3,
+      );
+
+      await settleMermaid(mounted);
+
+      expect(renderer).toHaveBeenCalledTimes(1);
+      expect(renderer).toHaveBeenCalledWith(
+        source,
+        expect.objectContaining({
+          colorMode: "none",
+        }),
+      );
+      expect(rowText(mounted, 0)).toBe("sequence rendered");
+
+      mounted.unmount();
+    } finally {
+      vi.resetModules();
+    }
+  });
+
   it("only treats plain id-to-id flowchart edges as simple Mermaid flowcharts", () => {
     expect(isSimpleMermaidFlowchartSource("graph LR\nA --> B\nB --- C")).toBe(true);
     expect(isSimpleMermaidFlowchartSource("flowchart TD; A --> B; B --- C")).toBe(true);

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -531,12 +531,19 @@ describe("TMermaidText", () => {
     expect(isSimpleMermaidFlowchartSource("graph LR\nA & B --> C")).toBe(true);
     expect(isSimpleMermaidFlowchartSource("graph LR\nA --> B & C")).toBe(true);
     expect(isSimpleMermaidFlowchartSource("graph LR\nA[Start] -->|ok| B{Done}")).toBe(true);
+    expect(isSimpleMermaidFlowchartSource('graph LR\nA["subgraph; end"] --> B')).toBe(true);
+    expect(isSimpleMermaidFlowchartSource('graph LR\nA["a;b;c"] --> B')).toBe(true);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA --> B %% inline comment")).toBe(true);
 
     expect(isSimpleMermaidFlowchartSource("graph LR")).toBe(false);
     expect(isSimpleMermaidFlowchartSource("sequenceDiagram\nAlice->>Bob: hi")).toBe(false);
     expect(isSimpleMermaidFlowchartSource("graph LR\nsubgraph X\nA --> B\nend")).toBe(false);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nsubgraph X; A --> B; end")).toBe(false);
     expect(isSimpleMermaidFlowchartSource("graph LR\nstyle A fill:#f00")).toBe(false);
     expect(isSimpleMermaidFlowchartSource("graph LR\nclassDef hot fill:#f00")).toBe(false);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA --> B; classDef hot fill:#f00")).toBe(
+      false,
+    );
     expect(isSimpleMermaidFlowchartSource("graph LR\nA:::hot --> B")).toBe(false);
     expect(isSimpleMermaidFlowchartSource('graph LR\nclick A href "https://example.com"')).toBe(
       false,
@@ -1158,6 +1165,49 @@ describe("TMermaidText", () => {
         delete (globalThis.navigator as any).clipboard;
       }
     }
+  });
+
+  it("uses write-only runtime clipboard for Mermaid copy without changing aggregate support", async () => {
+    const source = "graph LR\n  A --> B";
+    const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const onCopy = vi.fn();
+
+    const cols = 32;
+    const rows = 5;
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 28,
+          content: source,
+          renderer,
+          onCopy,
+        }),
+      cols,
+      rows,
+      {
+        clipboard: {
+          supported: false,
+          canRead: false,
+          canWrite: true,
+          readText: vi.fn(),
+          writeText,
+        },
+      },
+    );
+
+    await settleMermaid(mounted);
+    setDeterministicMetrics(mounted, cols, rows);
+
+    clickCell(mounted, 22, 0);
+    await settleMermaid(mounted);
+
+    expect(writeText).toHaveBeenCalledWith(source);
+    expect(onCopy).toHaveBeenCalledWith({ text: source, ok: true });
+
+    mounted.unmount();
   });
 
   it("does not bypass an explicitly unsupported injected clipboard", async () => {

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -1055,7 +1055,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("keeps source while final is false even when streaming is not enabled", async () => {
+  it("renders when final is false but streaming is not enabled", async () => {
     const final = ref(false);
     const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
 
@@ -1078,20 +1078,13 @@ describe("TMermaidText", () => {
 
     await settleMermaid(mounted);
 
-    expect(renderer).not.toHaveBeenCalled();
-    expect(rowText(mounted, 0)).toBe("graph LR");
-    expect(rowText(mounted, 1)).toBe("  A --> B");
-
-    final.value = true;
-    await settleMermaid(mounted);
-
     expect(renderer).toHaveBeenCalledTimes(1);
     expect(rowText(mounted, 0)).toBe("rendered diagram");
 
     mounted.unmount();
   });
 
-  it("skips renderer for any non-final Mermaid source", async () => {
+  it("skips renderer only while streaming Mermaid source is non-final", async () => {
     const final = ref(false);
     const streaming = ref(true);
     const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
@@ -1120,13 +1113,6 @@ describe("TMermaidText", () => {
     expect(rowText(mounted, 1)).toBe("  A --> B");
 
     streaming.value = false;
-    await settleMermaid(mounted);
-
-    expect(renderer).not.toHaveBeenCalled();
-    expect(rowText(mounted, 0)).toBe("graph LR");
-    expect(rowText(mounted, 1)).toBe("  A --> B");
-
-    final.value = true;
     await settleMermaid(mounted);
 
     expect(renderer).toHaveBeenCalledTimes(1);

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -1077,6 +1077,40 @@ describe("TMermaidText", () => {
     }
   });
 
+  it("uses ASCII border characters for the outer Mermaid box when ascii is true", async () => {
+    const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 28,
+          ascii: true,
+          content: "graph LR\n  A --> B",
+          renderer,
+        }),
+      32,
+      5,
+    );
+
+    await settleMermaid(mounted);
+
+    expect(rowText(mounted, 0)).toContain("mermaid");
+    expect(rowText(mounted, 0)).toContain("copy");
+    expect(rowText(mounted, 0).startsWith("+")).toBe(true);
+    expect(rowText(mounted, 0).endsWith("+")).toBe(true);
+    expect(rowText(mounted, 0)).not.toContain("┌");
+    expect(rowText(mounted, 0)).not.toContain("─");
+
+    expect(rowText(mounted, 1).startsWith("|")).toBe(true);
+    expect(rowText(mounted, 1)).toContain("rendered diagram");
+    expect(rowText(mounted, 2).startsWith("+")).toBe(true);
+    expect(rowText(mounted, 2).endsWith("+")).toBe(true);
+
+    mounted.unmount();
+  });
+
   it("resets copied label after copiedDurationMs", async () => {
     const source = "graph LR\n  A --> B";
     const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
@@ -1551,6 +1585,48 @@ describe("TMermaidText", () => {
     expect(rowText(mounted, 0)).toBe("rendered diagram");
 
     setDeterministicMetrics(mounted, cols, rows);
+    clickCell(mounted, 22, 0);
+    await settleMermaid(mounted);
+
+    expect(writeText).not.toHaveBeenCalled();
+    expect(onCopy).not.toHaveBeenCalled();
+
+    mounted.unmount();
+  });
+
+  it("respects explicit zero Mermaid height", async () => {
+    const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const onCopy = vi.fn();
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 28,
+          h: 0,
+          content: "graph LR\n  A --> B",
+          renderer,
+          onCopy,
+        }),
+      32,
+      4,
+      {
+        clipboard: {
+          supported: true,
+          readText: vi.fn(),
+          writeText,
+        },
+      },
+    );
+
+    await settleMermaid(mounted);
+
+    expect(rowText(mounted, 0)).toBe("");
+    expect(rowText(mounted, 1)).toBe("");
+
+    setDeterministicMetrics(mounted, 32, 4);
     clickCell(mounted, 22, 0);
     await settleMermaid(mounted);
 

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -1699,7 +1699,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("does not draw the box or expose copy hit node when explicit height has no content row", async () => {
+  it("draws a compact two-row Mermaid box and keeps copy active when explicit height has no content row", async () => {
     const source = "graph LR\n  A --> B";
     const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
     const writeText = vi.fn().mockResolvedValue(undefined);
@@ -1731,15 +1731,21 @@ describe("TMermaidText", () => {
 
     await settleMermaid(mounted);
 
-    expect(rowText(mounted, 0)).toBe("rendered diagram");
-    expect(rowText(mounted, 1)).toBe("");
+    expect(rowText(mounted, 0)).toContain("mermaid");
+    expect(rowText(mounted, 0)).toContain("copy");
+    expect(rowText(mounted, 0).startsWith("┌")).toBe(true);
+    expect(rowText(mounted, 0).endsWith("┐")).toBe(true);
+    expect(rowText(mounted, 1).startsWith("└")).toBe(true);
+    expect(rowText(mounted, 1).endsWith("┘")).toBe(true);
+    expect(rowText(mounted, 0)).not.toContain("rendered diagram");
+    expect(rowText(mounted, 1)).not.toContain("rendered diagram");
 
     setDeterministicMetrics(mounted, cols, rows);
     clickCell(mounted, 22, 0);
     await settleMermaid(mounted);
 
-    expect(writeText).not.toHaveBeenCalled();
-    expect(onCopy).not.toHaveBeenCalled();
+    expect(writeText).toHaveBeenCalledWith(source);
+    expect(onCopy).toHaveBeenCalledWith({ text: source, ok: true });
 
     mounted.unmount();
   });

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -375,40 +375,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("lets the renderer-agnostic base component try custom renderer output by default", async () => {
-    const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
-    const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
-
-    const mounted = await mountTerminal(
-      () =>
-        h(TMermaidText, {
-          x: 0,
-          y: 0,
-          w: 40,
-          h: 1,
-          box: false,
-          content: source,
-          renderer,
-        }),
-      48,
-      3,
-    );
-
-    await settleMermaid(mounted);
-
-    expect(renderer).toHaveBeenCalledTimes(1);
-    expect(renderer).toHaveBeenCalledWith(
-      source,
-      expect.objectContaining({
-        colorMode: "none",
-      }),
-    );
-    expect(rowText(mounted, 0)).toBe("sequence rendered");
-
-    mounted.unmount();
-  });
-
-  it("allows callers to explicitly skip complex Mermaid source with shouldRenderSource", async () => {
+  it("keeps complex Mermaid source by default even with a custom renderer", async () => {
     const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
     const renderer: TMermaidRenderer = vi.fn(() => "should not render");
 
@@ -422,10 +389,9 @@ describe("TMermaidText", () => {
           box: false,
           content: source,
           renderer,
-          shouldRenderSource: isSimpleMermaidFlowchartSource,
         }),
       48,
-      5,
+      3,
     );
 
     await settleMermaid(mounted);
@@ -434,6 +400,40 @@ describe("TMermaidText", () => {
     expect(rowText(mounted, 0)).toBe("sequenceDiagram");
     expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
     expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
+
+    mounted.unmount();
+  });
+
+  it("allows callers to opt into complex Mermaid rendering with shouldRenderSource", async () => {
+    const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
+    const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 40,
+          h: 3,
+          box: false,
+          content: source,
+          renderer,
+          shouldRenderSource: () => true,
+        }),
+      48,
+      5,
+    );
+
+    await settleMermaid(mounted);
+
+    expect(renderer).toHaveBeenCalledTimes(1);
+    expect(renderer).toHaveBeenCalledWith(
+      source,
+      expect.objectContaining({
+        colorMode: "none",
+      }),
+    );
+    expect(rowText(mounted, 0)).toBe("sequence rendered");
 
     mounted.unmount();
   });
@@ -478,7 +478,44 @@ describe("TMermaidText", () => {
     }
   });
 
-  it("lets the mermaid wrapper custom renderer render complex Mermaid by default", async () => {
+  it("keeps complex Mermaid source by default even when the mermaid wrapper receives a custom renderer", async () => {
+    vi.resetModules();
+
+    try {
+      const { TMermaidText: TMermaidTextWithBeautifulRenderer } = await import("../src/mermaid.js");
+
+      const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
+      const renderer: TMermaidRenderer = vi.fn(() => "should not render");
+
+      const mounted = await mountTerminal(
+        () =>
+          h(TMermaidTextWithBeautifulRenderer, {
+            x: 0,
+            y: 0,
+            w: 40,
+            h: 3,
+            box: false,
+            content: source,
+            renderer,
+          }),
+        48,
+        3,
+      );
+
+      await settleMermaid(mounted);
+
+      expect(renderer).not.toHaveBeenCalled();
+      expect(rowText(mounted, 0)).toBe("sequenceDiagram");
+      expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
+      expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
+
+      mounted.unmount();
+    } finally {
+      vi.resetModules();
+    }
+  });
+
+  it("lets the mermaid wrapper custom renderer render complex Mermaid when explicitly allowed", async () => {
     vi.resetModules();
 
     try {
@@ -497,6 +534,7 @@ describe("TMermaidText", () => {
             box: false,
             content: source,
             renderer,
+            shouldRenderSource: () => true,
           }),
         48,
         3,

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -838,6 +838,84 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
+  it("does not expose copy hit node when explicit height is too small to draw the box", async () => {
+    const source = "graph LR\n  A --> B";
+    const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const onCopy = vi.fn();
+
+    const cols = 32;
+    const rows = 4;
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 28,
+          h: 1,
+          content: source,
+          renderer,
+          onCopy,
+        }),
+      cols,
+      rows,
+      {
+        clipboard: {
+          supported: true,
+          readText: vi.fn(),
+          writeText,
+        },
+      },
+    );
+
+    await settleMermaid(mounted);
+
+    expect(rowText(mounted, 0)).toBe("rendered diagram");
+
+    setDeterministicMetrics(mounted, cols, rows);
+    clickCell(mounted, 22, 0);
+    await settleMermaid(mounted);
+
+    expect(writeText).not.toHaveBeenCalled();
+    expect(onCopy).not.toHaveBeenCalled();
+
+    mounted.unmount();
+  });
+
+  it("adds parent event zIndex to the Mermaid copy hit node", async () => {
+    const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TView, { x: 0, y: 0, w: 28, h: 4, zIndex: 120 }, () =>
+          h(TMermaidText, {
+            x: 0,
+            y: 0,
+            w: 28,
+            zIndex: 3,
+            content: "graph LR\n  A --> B",
+            renderer,
+          }),
+        ),
+      32,
+      5,
+    );
+
+    await settleMermaid(mounted);
+
+    const events = mounted.events();
+    if (!events) throw new Error("expected terminal events");
+
+    const copyNode = events
+      .debugNodes()
+      .find((node) => node.visible && node.focusable && node.rect.y === 0 && node.rect.w > 0);
+
+    expect(copyNode).toBeDefined();
+    expect(copyNode?.zIndex).toBe(124);
+
+    mounted.unmount();
+  });
+
   it("makes the copy hit node inactive when the copy button is hidden", async () => {
     const copyButton = ref(true);
     const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
 import { TMermaidText, type TMermaidRenderer } from "../src/vue.js";
 import { isMissingBeautifulMermaid } from "../src/vue/mermaid/beautiful-mermaid.js";
-import { h, mountTerminal, nextTick, ref } from "./ui-regressions-support.js";
+import {
+  createTerminalApp,
+  defineComponent,
+  h,
+  mountTerminal,
+  nextTick,
+  ref,
+  TView,
+} from "./ui-regressions-support.js";
 
 type MountedTerminal = Awaited<ReturnType<typeof mountTerminal>>;
 
@@ -50,6 +58,15 @@ async function settleMermaid(mounted: MountedTerminal): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, 0));
     await nextTick();
     mounted.scheduler()?.flushNow();
+  }
+}
+
+async function settleTerminalApp(app: ReturnType<typeof createTerminalApp>): Promise<void> {
+  for (let i = 0; i < 8; i++) {
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await nextTick();
+    app.scheduler.flushNow();
   }
 }
 
@@ -439,6 +456,183 @@ describe("TMermaidText", () => {
     }
   });
 
+  it("uses the injected clipboard for copy", async () => {
+    const source = "graph LR\n  A --> B";
+    const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const onCopy = vi.fn();
+    const originalClipboard = Object.getOwnPropertyDescriptor(globalThis.navigator, "clipboard");
+
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      value: {
+        writeText: vi.fn().mockRejectedValue(new Error("navigator should not be used")),
+      },
+      configurable: true,
+    });
+
+    try {
+      const cols = 32;
+      const rows = 5;
+      const mounted = await mountTerminal(
+        () =>
+          h(TMermaidText, {
+            x: 0,
+            y: 0,
+            w: 28,
+            content: source,
+            renderer,
+            onCopy,
+          }),
+        cols,
+        rows,
+        {
+          clipboard: {
+            supported: true,
+            readText: vi.fn(),
+            writeText,
+          },
+        },
+      );
+
+      await settleMermaid(mounted);
+
+      setDeterministicMetrics(mounted, cols, rows);
+      clickCell(mounted, 22, 0);
+      await settleMermaid(mounted);
+
+      expect(writeText).toHaveBeenCalledWith(source);
+      expect(onCopy).toHaveBeenCalledWith({ text: source, ok: true });
+
+      mounted.unmount();
+    } finally {
+      if (originalClipboard) {
+        Object.defineProperty(globalThis.navigator, "clipboard", originalClipboard);
+      } else {
+        delete (globalThis.navigator as any).clipboard;
+      }
+    }
+  });
+
+  it("uses the createTerminalApp clipboard for copy", async () => {
+    const source = "graph LR\n  A --> B";
+    const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const onCopy = vi.fn();
+    const App = defineComponent({
+      setup() {
+        return () =>
+          h(TMermaidText, {
+            x: 0,
+            y: 0,
+            w: 28,
+            content: source,
+            renderer,
+            onCopy,
+          });
+      },
+    });
+
+    const app = createTerminalApp({
+      cols: 32,
+      rows: 5,
+      component: App,
+      clipboard: {
+        supported: true,
+        readText: vi.fn(),
+        writeText,
+      },
+    });
+
+    try {
+      app.mount();
+      await settleTerminalApp(app);
+
+      app.events.dispatch({ type: "click", cellX: 22, cellY: 0, time: Date.now() } as any);
+      await settleTerminalApp(app);
+
+      expect(writeText).toHaveBeenCalledWith(source);
+      expect(onCopy).toHaveBeenCalledWith({ text: source, ok: true });
+    } finally {
+      app.dispose();
+    }
+  });
+
+  it("does not expose the copy hit rect outside a clipped parent", async () => {
+    const source = "graph LR\n  A --> B";
+    const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const onCopy = vi.fn();
+
+    const cols = 32;
+    const rows = 5;
+    const mounted = await mountTerminal(
+      () =>
+        h(TView, { x: 0, y: 1, w: 28, h: 2, scrollY: 1 }, () =>
+          h(TMermaidText, {
+            x: 0,
+            y: 0,
+            w: 28,
+            content: source,
+            renderer,
+            onCopy,
+          }),
+        ),
+      cols,
+      rows,
+      {
+        clipboard: {
+          supported: true,
+          readText: vi.fn(),
+          writeText,
+        },
+      },
+    );
+
+    await settleMermaid(mounted);
+
+    setDeterministicMetrics(mounted, cols, rows);
+    clickCell(mounted, 22, 0);
+    await settleMermaid(mounted);
+
+    expect(writeText).not.toHaveBeenCalled();
+    expect(onCopy).not.toHaveBeenCalled();
+
+    mounted.unmount();
+  });
+
+  it("does not pad unboxed content when clear is false", async () => {
+    const content = ref("graph LR\n  A --> B");
+    const renderer: TMermaidRenderer = vi.fn(() => content.value);
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 8,
+          h: 1,
+          box: false,
+          clear: false,
+          content: content.value,
+          renderer,
+        }),
+      12,
+      3,
+    );
+
+    await settleMermaid(mounted);
+    expect(rowText(mounted, 0)).toBe("graph LR");
+
+    const writeSpy = vi.spyOn(mounted.terminal, "write");
+    content.value = "x";
+    await settleMermaid(mounted);
+
+    expect(writeSpy).toHaveBeenCalledWith("x", expect.objectContaining({ x: 0, y: 0 }));
+    expect(writeSpy).not.toHaveBeenCalledWith("x       ", expect.anything());
+
+    mounted.unmount();
+  });
+
   it("forwards copy events through the mermaid entry wrapper", async () => {
     vi.resetModules();
     vi.doMock("beautiful-mermaid", () => ({
@@ -498,7 +692,7 @@ describe("TMermaidText", () => {
     }
   });
 
-  it("treats explicit h as content height when the default mermaid box is enabled", async () => {
+  it("treats explicit h as the outer mermaid box height", async () => {
     const renderer: TMermaidRenderer = vi.fn(() => "diagram line 1\ndiagram line 2");
 
     const mounted = await mountTerminal(
@@ -507,7 +701,7 @@ describe("TMermaidText", () => {
           x: 0,
           y: 0,
           w: 28,
-          h: 2,
+          h: 4,
           content: "graph LR\n  A --> B",
           renderer,
         }),

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -250,6 +250,56 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
+  it("clears a same-source rendered snapshot before a queued streaming re-render", async () => {
+    const source = "graph LR\n  A --> B";
+    const renderAllowed = ref(true);
+    const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 48,
+          h: 2,
+          box: false,
+          content: source,
+          final: true,
+          streaming: true,
+          renderer,
+          shouldRenderSource: renderAllowed.value ? () => true : () => false,
+        }),
+      64,
+      4,
+    );
+
+    await settleMermaid(mounted);
+
+    expect(renderer).toHaveBeenCalledTimes(1);
+    expect(rowText(mounted, 0)).toBe("rendered diagram");
+
+    const scheduler = mounted.scheduler();
+    const originalQueueFrameTask = scheduler?.queueFrameTask.bind(scheduler);
+
+    try {
+      // Simulate an accepted low-priority frame task that has not run yet.
+      // The component must still repaint source immediately.
+      (scheduler as any).queueFrameTask = () => true;
+
+      renderAllowed.value = false;
+      await settleMermaidMicrotasks(mounted);
+
+      expect(renderer).toHaveBeenCalledTimes(1);
+      expect(rowText(mounted, 0)).toBe("graph LR");
+      expect(rowText(mounted, 1)).toBe("  A --> B");
+    } finally {
+      if (originalQueueFrameTask) {
+        (scheduler as any).queueFrameTask = originalQueueFrameTask;
+      }
+      mounted.unmount();
+    }
+  });
+
   it("keeps source when no renderer is provided", async () => {
     const mounted = await mountTerminal(
       () =>

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -374,6 +374,63 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
+  it("skips unsupported complex Mermaid diagram types and keeps source visible", async () => {
+    const renderer: TMermaidRenderer = vi.fn(() => "should not render");
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 40,
+          h: 4,
+          box: false,
+          content: ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n"),
+          renderer,
+        }),
+      48,
+      6,
+    );
+
+    await settleMermaid(mounted);
+
+    expect(renderer).not.toHaveBeenCalled();
+    expect(rowText(mounted, 0)).toBe("sequenceDiagram");
+    expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
+    expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
+
+    mounted.unmount();
+  });
+
+  it("skips complex flowchart features and keeps source visible", async () => {
+    const renderer: TMermaidRenderer = vi.fn(() => "should not render");
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 40,
+          h: 5,
+          box: false,
+          content: ["graph LR", "  subgraph Cluster", "    A --> B", "  end"].join("\n"),
+          renderer,
+        }),
+      48,
+      7,
+    );
+
+    await settleMermaid(mounted);
+
+    expect(renderer).not.toHaveBeenCalled();
+    expect(rowText(mounted, 0)).toBe("graph LR");
+    expect(rowText(mounted, 1)).toBe("  subgraph Cluster");
+    expect(rowText(mounted, 2)).toBe("    A --> B");
+    expect(rowText(mounted, 3)).toBe("  end");
+
+    mounted.unmount();
+  });
+
   it("keeps source when Mermaid rendering times out", async () => {
     vi.useFakeTimers();
 

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -374,7 +374,36 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("lets the renderer-agnostic component render non-flowchart source with a custom renderer", async () => {
+  it("keeps non-flowchart Mermaid source by default even with a custom renderer", async () => {
+    const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
+    const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 40,
+          h: 3,
+          box: false,
+          content: source,
+          renderer,
+        }),
+      48,
+      5,
+    );
+
+    await settleMermaid(mounted);
+
+    expect(renderer).not.toHaveBeenCalled();
+    expect(rowText(mounted, 0)).toBe("sequenceDiagram");
+    expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
+    expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
+
+    mounted.unmount();
+  });
+
+  it("allows renderer-agnostic callers to explicitly render complex Mermaid source", async () => {
     const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
     const renderer: TMermaidRenderer = vi.fn((code) => `rendered:${code.split("\n")[0]}`);
 
@@ -388,6 +417,7 @@ describe("TMermaidText", () => {
           box: false,
           content: source,
           renderer,
+          shouldRenderSource: () => true,
         }),
       48,
       3,
@@ -403,36 +433,6 @@ describe("TMermaidText", () => {
       }),
     );
     expect(rowText(mounted, 0)).toBe("rendered:sequenceDiagram");
-
-    mounted.unmount();
-  });
-
-  it("allows renderer-agnostic callers to opt into simple-flowchart eligibility", async () => {
-    const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
-    const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
-
-    const mounted = await mountTerminal(
-      () =>
-        h(TMermaidText, {
-          x: 0,
-          y: 0,
-          w: 40,
-          h: 3,
-          box: false,
-          content: source,
-          renderer,
-          shouldRenderSource: isSimpleMermaidFlowchartSource,
-        }),
-      48,
-      5,
-    );
-
-    await settleMermaid(mounted);
-
-    expect(renderer).not.toHaveBeenCalled();
-    expect(rowText(mounted, 0)).toBe("sequenceDiagram");
-    expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
-    expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
 
     mounted.unmount();
   });

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -61,6 +61,14 @@ async function settleMermaid(mounted: MountedTerminal): Promise<void> {
   }
 }
 
+async function settleMermaidMicrotasks(mounted: MountedTerminal): Promise<void> {
+  for (let i = 0; i < 8; i++) {
+    await Promise.resolve();
+    await nextTick();
+    mounted.scheduler()?.flushNow();
+  }
+}
+
 async function settleTerminalApp(app: ReturnType<typeof createTerminalApp>): Promise<void> {
   for (let i = 0; i < 8; i++) {
     await Promise.resolve();
@@ -334,6 +342,75 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
+  it("skips renderer for oversized Mermaid source and keeps source visible", async () => {
+    const source = [
+      "graph LR",
+      ...Array.from({ length: 6 }, (_, i) => `  A${i} --> A${i + 1}`),
+    ].join("\n");
+    const renderer: TMermaidRenderer = vi.fn(() => "should not render");
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 40,
+          h: 8,
+          box: false,
+          content: source,
+          renderer,
+          maxRenderSourceLines: 3,
+        }),
+      48,
+      10,
+    );
+
+    await settleMermaid(mounted);
+
+    expect(renderer).not.toHaveBeenCalled();
+    expect(rowText(mounted, 0)).toBe("graph LR");
+    expect(rowText(mounted, 1)).toBe("  A0 --> A1");
+
+    mounted.unmount();
+  });
+
+  it("keeps source when Mermaid rendering times out", async () => {
+    vi.useFakeTimers();
+
+    let mounted: MountedTerminal | null = null;
+    const renderer: TMermaidRenderer = vi.fn(() => new Promise<string>(() => {}));
+
+    try {
+      mounted = await mountTerminal(
+        () =>
+          h(TMermaidText, {
+            x: 0,
+            y: 0,
+            w: 40,
+            h: 2,
+            box: false,
+            content: "graph LR\n  A --> B",
+            renderer,
+            renderTimeoutMs: 25,
+          }),
+        48,
+        4,
+      );
+
+      await settleMermaidMicrotasks(mounted);
+      expect(renderer).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(25);
+      await settleMermaidMicrotasks(mounted);
+
+      expect(rowText(mounted, 0)).toBe("graph LR");
+      expect(rowText(mounted, 1)).toBe("  A --> B");
+    } finally {
+      mounted?.unmount();
+      vi.useRealTimers();
+    }
+  });
+
   it("shows streaming source without calling the renderer until final", async () => {
     const content = ref("graph LR\n  A --> B");
     const final = ref(false);
@@ -454,6 +531,85 @@ describe("TMermaidText", () => {
         delete (globalThis.navigator as any).clipboard;
       }
     }
+  });
+
+  it("resets copied label after copiedDurationMs", async () => {
+    const source = "graph LR\n  A --> B";
+    const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const originalClipboard = Object.getOwnPropertyDescriptor(globalThis.navigator, "clipboard");
+
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    const cols = 32;
+    const rows = 5;
+    let mounted: MountedTerminal | null = null;
+
+    try {
+      mounted = await mountTerminal(
+        () =>
+          h(TMermaidText, {
+            x: 0,
+            y: 0,
+            w: 28,
+            content: source,
+            renderer,
+            copiedDurationMs: 50,
+          }),
+        cols,
+        rows,
+      );
+
+      await settleMermaid(mounted);
+      setDeterministicMetrics(mounted, cols, rows);
+
+      vi.useFakeTimers();
+      clickCell(mounted, 22, 0);
+      await settleMermaidMicrotasks(mounted);
+
+      expect(rowText(mounted, 0)).toContain("copied");
+
+      await vi.advanceTimersByTimeAsync(50);
+      await settleMermaidMicrotasks(mounted);
+
+      expect(rowText(mounted, 0)).toContain("copy");
+      expect(rowText(mounted, 0)).not.toContain("copied");
+    } finally {
+      vi.useRealTimers();
+      mounted?.unmount();
+      if (originalClipboard) {
+        Object.defineProperty(globalThis.navigator, "clipboard", originalClipboard);
+      } else {
+        delete (globalThis.navigator as any).clipboard;
+      }
+    }
+  });
+
+  it("keeps title and copy label separated in narrow Mermaid headers", async () => {
+    const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 12,
+          content: "graph LR\n  A --> B",
+          title: "very-long-mermaid-title",
+          renderer,
+        }),
+      16,
+      4,
+    );
+
+    await settleMermaid(mounted);
+
+    expect(rowText(mounted, 0)).toBe("┌ ve─ copy ┐");
+
+    mounted.unmount();
   });
 
   it("uses the injected clipboard for copy", async () => {

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -393,6 +393,43 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
+  it("never paints loading/error/incomplete text in source-first mode", async () => {
+    const final = ref(true);
+    const renderer: TMermaidRenderer = vi.fn(() => {
+      throw new Error("renderer exploded");
+    });
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 80,
+          h: 2,
+          box: false,
+          content: "graph LR\n  A --> B",
+          final: final.value,
+          streaming: true,
+          loadingText: "LOADING SHOULD NOT PAINT",
+          errorText: "ERROR SHOULD NOT PAINT",
+          incompleteText: "INCOMPLETE SHOULD NOT PAINT",
+          renderer,
+        }),
+      100,
+      4,
+    );
+
+    await settleMermaid(mounted);
+
+    expect(rowText(mounted, 0)).toBe("graph LR");
+    expect(rowText(mounted, 1)).toBe("  A --> B");
+    expect(rowText(mounted, 0)).not.toContain("LOADING");
+    expect(rowText(mounted, 0)).not.toContain("ERROR");
+    expect(rowText(mounted, 0)).not.toContain("INCOMPLETE");
+
+    mounted.unmount();
+  });
+
   it("skips renderer for oversized Mermaid source and keeps source visible", async () => {
     const source = [
       "graph LR",

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -538,10 +538,7 @@ describe("TMermaidText", () => {
       await settleMermaid(mounted);
 
       expect(renderer).toHaveBeenCalledTimes(1);
-      expect(renderer).toHaveBeenCalledWith(
-        source,
-        expect.objectContaining({ colorMode: "none" }),
-      );
+      expect(renderer).toHaveBeenCalledWith(source, expect.objectContaining({ colorMode: "none" }));
       expect(rowText(mounted, 0)).toBe("sequence rendered");
 
       mounted.unmount();

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { TMermaidText, type TMermaidRenderer } from "../src/vue.js";
+import { TMermaidText, isSimpleMermaidFlowchartSource, type TMermaidRenderer } from "../src/vue.js";
 import { isMissingBeautifulMermaid } from "../src/vue/mermaid/beautiful-mermaid.js";
 import {
   createTerminalApp,
@@ -374,9 +374,9 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("skips non-flowchart Mermaid diagram types and keeps source visible", async () => {
+  it("lets a custom renderer render non-flowchart Mermaid source", async () => {
     const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
-    const renderer: TMermaidRenderer = vi.fn(() => "should not render");
+    const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
 
     const mounted = await mountTerminal(
       () =>
@@ -384,58 +384,70 @@ describe("TMermaidText", () => {
           x: 0,
           y: 0,
           w: 40,
-          h: 4,
+          h: 1,
           box: false,
           content: source,
           renderer,
         }),
       48,
-      6,
+      3,
     );
 
     await settleMermaid(mounted);
 
-    expect(renderer).not.toHaveBeenCalled();
-    expect(rowText(mounted, 0)).toBe("sequenceDiagram");
-    expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
-    expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
-
-    mounted.unmount();
-  });
-
-  it("does not call renderer for non-flowchart Mermaid source", async () => {
-    const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
-    const renderer: TMermaidRenderer = vi.fn(() => {
-      throw new Error("unsupported sequence diagram");
-    });
-
-    const mounted = await mountTerminal(
-      () =>
-        h(TMermaidText, {
-          x: 0,
-          y: 0,
-          w: 40,
-          h: 4,
-          box: false,
-          content: source,
-          renderer,
-        }),
-      48,
-      6,
+    expect(renderer).toHaveBeenCalledTimes(1);
+    expect(renderer).toHaveBeenCalledWith(
+      source,
+      expect.objectContaining({
+        colorMode: "none",
+      }),
     );
-
-    await settleMermaid(mounted);
-
-    expect(renderer).not.toHaveBeenCalled();
-    expect(rowText(mounted, 0)).toBe("sequenceDiagram");
-    expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
-    expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
-    expect(rowText(mounted, 0)).not.toContain("unsupported sequence diagram");
+    expect(rowText(mounted, 0)).toBe("sequence rendered");
 
     mounted.unmount();
   });
 
-  it("skips complex flowchart features and keeps source visible", async () => {
+  it("keeps non-flowchart Mermaid source in the beautiful-mermaid wrapper", async () => {
+    vi.resetModules();
+
+    const renderMermaidASCII = vi.fn(() => "should not render");
+    vi.doMock("beautiful-mermaid", () => ({
+      renderMermaidASCII,
+    }));
+
+    try {
+      const { TMermaidText: TMermaidTextWithBeautifulRenderer } = await import("../src/mermaid.js");
+      const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
+
+      const mounted = await mountTerminal(
+        () =>
+          h(TMermaidTextWithBeautifulRenderer, {
+            x: 0,
+            y: 0,
+            w: 40,
+            h: 3,
+            box: false,
+            content: source,
+          }),
+        48,
+        5,
+      );
+
+      await settleMermaid(mounted);
+
+      expect(renderMermaidASCII).not.toHaveBeenCalled();
+      expect(rowText(mounted, 0)).toBe("sequenceDiagram");
+      expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
+      expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
+
+      mounted.unmount();
+    } finally {
+      vi.doUnmock("beautiful-mermaid");
+      vi.resetModules();
+    }
+  });
+
+  it("uses shouldRenderSource to skip complex flowchart features", async () => {
     const renderer: TMermaidRenderer = vi.fn(() => "should not render");
 
     const mounted = await mountTerminal(
@@ -448,6 +460,7 @@ describe("TMermaidText", () => {
           box: false,
           content: ["graph LR", "  subgraph Cluster", "    A --> B", "  end"].join("\n"),
           renderer,
+          shouldRenderSource: isSimpleMermaidFlowchartSource,
         }),
       48,
       7,
@@ -464,7 +477,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("skips semicolon-delimited complex flowchart features and keeps source visible", async () => {
+  it("uses shouldRenderSource to skip semicolon-delimited complex flowchart features", async () => {
     const source = "graph LR; subgraph Cluster; A --> B; end";
     const renderer: TMermaidRenderer = vi.fn(() => "should not render");
 
@@ -478,6 +491,7 @@ describe("TMermaidText", () => {
           box: false,
           content: source,
           renderer,
+          shouldRenderSource: isSimpleMermaidFlowchartSource,
         }),
       90,
       3,
@@ -491,7 +505,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("counts semicolon-delimited flow statements before rendering", async () => {
+  it("uses shouldRenderSource to count semicolon-delimited flow statements before rendering", async () => {
     const source = [
       "graph LR",
       Array.from({ length: 121 }, (_, index) => `A${index} --> A${index + 1}`).join("; "),
@@ -508,6 +522,7 @@ describe("TMermaidText", () => {
           box: false,
           content: source,
           renderer,
+          shouldRenderSource: isSimpleMermaidFlowchartSource,
         }),
       130,
       3,

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -727,6 +727,11 @@ describe("TMermaidText", () => {
     expect(isSimpleMermaidFlowchartSource('graph LR\nA["subgraph; end"] --> B')).toBe(true);
     expect(isSimpleMermaidFlowchartSource('graph LR\nA["a;b;c"] --> B')).toBe(true);
     expect(isSimpleMermaidFlowchartSource("graph LR\nA --> B %% inline comment")).toBe(true);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA -->|yes; no| B")).toBe(true);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA -->|subgraph; end| B")).toBe(true);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA -->|100%% ready| B")).toBe(true);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA -->|foo:::bar| B")).toBe(true);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA -->|shape @{text}| B")).toBe(true);
 
     expect(isSimpleMermaidFlowchartSource("graph LR")).toBe(false);
     expect(isSimpleMermaidFlowchartSource("sequenceDiagram\nAlice->>Bob: hi")).toBe(false);
@@ -736,6 +741,7 @@ describe("TMermaidText", () => {
     expect(isSimpleMermaidFlowchartSource("graph LR\nclassDef hot fill:#f00")).toBe(false);
     expect(isSimpleMermaidFlowchartSource("graph LR\nA --> B; classDef hot fill:#f00")).toBe(false);
     expect(isSimpleMermaidFlowchartSource("graph LR\nA:::hot --> B")).toBe(false);
+    expect(isSimpleMermaidFlowchartSource("graph LR\nA@{ shape: rect } --> B")).toBe(false);
     expect(isSimpleMermaidFlowchartSource('graph LR\nclick A href "https://example.com"')).toBe(
       false,
     );

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -462,7 +462,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("keeps complex Mermaid source by default even with a custom renderer", async () => {
+  it("lets the primitive custom renderer render complex Mermaid by default", async () => {
     const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
     const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
 
@@ -483,10 +483,14 @@ describe("TMermaidText", () => {
 
     await settleMermaid(mounted);
 
-    expect(renderer).not.toHaveBeenCalled();
-    expect(rowText(mounted, 0)).toBe("sequenceDiagram");
-    expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
-    expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
+    expect(renderer).toHaveBeenCalledTimes(1);
+    expect(renderer).toHaveBeenCalledWith(
+      source,
+      expect.objectContaining({
+        colorMode: "none",
+      }),
+    );
+    expect(rowText(mounted, 0)).toBe("sequence rendered");
 
     mounted.unmount();
   });
@@ -525,7 +529,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("keeps complex Mermaid source when shouldRenderSource rejects it", async () => {
+  it("lets the primitive caller explicitly skip complex Mermaid with shouldRenderSource", async () => {
     const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
     const renderer: TMermaidRenderer = vi.fn(() => "should not render");
 

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -374,7 +374,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("keeps non-flowchart Mermaid source by default even when a custom renderer is supplied", async () => {
+  it("lets renderer-agnostic custom renderer handle non-flowchart Mermaid source by default", async () => {
     const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
     const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
 
@@ -384,21 +384,25 @@ describe("TMermaidText", () => {
           x: 0,
           y: 0,
           w: 40,
-          h: 3,
+          h: 1,
           box: false,
           content: source,
           renderer,
         }),
       48,
-      5,
+      3,
     );
 
     await settleMermaid(mounted);
 
-    expect(renderer).not.toHaveBeenCalled();
-    expect(rowText(mounted, 0)).toBe("sequenceDiagram");
-    expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
-    expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
+    expect(renderer).toHaveBeenCalledTimes(1);
+    expect(renderer).toHaveBeenCalledWith(
+      source,
+      expect.objectContaining({
+        colorMode: "none",
+      }),
+    );
+    expect(rowText(mounted, 0)).toBe("sequence rendered");
 
     mounted.unmount();
   });
@@ -467,7 +471,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("keeps non-flowchart Mermaid source in the beautiful-mermaid wrapper", async () => {
+  it("keeps complex Mermaid source by default when the mermaid wrapper uses the built-in renderer", async () => {
     vi.resetModules();
 
     const renderMermaidASCII = vi.fn(() => "should not render");
@@ -507,44 +511,7 @@ describe("TMermaidText", () => {
     }
   });
 
-  it("keeps complex Mermaid source by default when the mermaid wrapper receives a custom renderer", async () => {
-    vi.resetModules();
-
-    try {
-      const { TMermaidText: TMermaidTextWithBeautifulRenderer } = await import("../src/mermaid.js");
-
-      const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
-      const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
-
-      const mounted = await mountTerminal(
-        () =>
-          h(TMermaidTextWithBeautifulRenderer, {
-            x: 0,
-            y: 0,
-            w: 40,
-            h: 3,
-            box: false,
-            content: source,
-            renderer,
-          }),
-        48,
-        5,
-      );
-
-      await settleMermaid(mounted);
-
-      expect(renderer).not.toHaveBeenCalled();
-      expect(rowText(mounted, 0)).toBe("sequenceDiagram");
-      expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
-      expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
-
-      mounted.unmount();
-    } finally {
-      vi.resetModules();
-    }
-  });
-
-  it("allows the mermaid wrapper custom renderer to explicitly opt into complex Mermaid rendering", async () => {
+  it("lets the mermaid wrapper custom renderer handle complex Mermaid source by default", async () => {
     vi.resetModules();
 
     try {
@@ -563,7 +530,6 @@ describe("TMermaidText", () => {
             box: false,
             content: source,
             renderer,
-            shouldRenderSource: () => true,
           }),
         48,
         3,
@@ -574,9 +540,7 @@ describe("TMermaidText", () => {
       expect(renderer).toHaveBeenCalledTimes(1);
       expect(renderer).toHaveBeenCalledWith(
         source,
-        expect.objectContaining({
-          colorMode: "none",
-        }),
+        expect.objectContaining({ colorMode: "none" }),
       );
       expect(rowText(mounted, 0)).toBe("sequence rendered");
 

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -374,7 +374,40 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("keeps non-flowchart Mermaid source by default even with a custom renderer", async () => {
+  it("lets the renderer-agnostic component render non-flowchart source with a custom renderer", async () => {
+    const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
+    const renderer: TMermaidRenderer = vi.fn((code) => `rendered:${code.split("\n")[0]}`);
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 40,
+          h: 1,
+          box: false,
+          content: source,
+          renderer,
+        }),
+      48,
+      3,
+    );
+
+    await settleMermaid(mounted);
+
+    expect(renderer).toHaveBeenCalledTimes(1);
+    expect(renderer).toHaveBeenCalledWith(
+      source,
+      expect.objectContaining({
+        colorMode: "none",
+      }),
+    );
+    expect(rowText(mounted, 0)).toBe("rendered:sequenceDiagram");
+
+    mounted.unmount();
+  });
+
+  it("allows renderer-agnostic callers to opt into simple-flowchart eligibility", async () => {
     const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
     const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
 
@@ -388,9 +421,10 @@ describe("TMermaidText", () => {
           box: false,
           content: source,
           renderer,
+          shouldRenderSource: isSimpleMermaidFlowchartSource,
         }),
       48,
-      3,
+      5,
     );
 
     await settleMermaid(mounted);

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -425,7 +425,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("renders complex Mermaid source by default when the renderer succeeds", async () => {
+  it("keeps complex Mermaid source by default without calling the renderer", async () => {
     const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
     const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
 
@@ -439,6 +439,36 @@ describe("TMermaidText", () => {
           box: false,
           content: source,
           renderer,
+        }),
+      48,
+      5,
+    );
+
+    await settleMermaid(mounted);
+
+    expect(renderer).not.toHaveBeenCalled();
+    expect(rowText(mounted, 0)).toBe("sequenceDiagram");
+    expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
+    expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
+
+    mounted.unmount();
+  });
+
+  it("allows callers to opt into rendering complex Mermaid source", async () => {
+    const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
+    const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 40,
+          h: 3,
+          box: false,
+          content: source,
+          renderer,
+          shouldRenderSource: () => true,
         }),
       48,
       5,
@@ -488,7 +518,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("tries complex Mermaid source by default in the beautiful-mermaid wrapper", async () => {
+  it("keeps complex Mermaid source by default in the beautiful-mermaid wrapper", async () => {
     vi.resetModules();
 
     const renderMermaidASCII = vi.fn(() => "sequence rendered");
@@ -516,14 +546,10 @@ describe("TMermaidText", () => {
 
       await settleMermaid(mounted);
 
-      expect(renderMermaidASCII).toHaveBeenCalledTimes(1);
-      expect(renderMermaidASCII).toHaveBeenCalledWith(
-        source,
-        expect.objectContaining({
-          colorMode: "none",
-        }),
-      );
-      expect(rowText(mounted, 0)).toBe("sequence rendered");
+      expect(renderMermaidASCII).not.toHaveBeenCalled();
+      expect(rowText(mounted, 0)).toBe("sequenceDiagram");
+      expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
+      expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
 
       mounted.unmount();
     } finally {
@@ -532,7 +558,7 @@ describe("TMermaidText", () => {
     }
   });
 
-  it("lets the mermaid wrapper custom renderer render complex Mermaid by default", async () => {
+  it("keeps complex Mermaid source by default even with a custom renderer in the wrapper", async () => {
     vi.resetModules();
 
     try {
@@ -551,6 +577,44 @@ describe("TMermaidText", () => {
             box: false,
             content: source,
             renderer,
+          }),
+        48,
+        3,
+      );
+
+      await settleMermaid(mounted);
+
+      expect(renderer).not.toHaveBeenCalled();
+      expect(rowText(mounted, 0)).toBe("sequenceDiagram");
+      expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
+      expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
+
+      mounted.unmount();
+    } finally {
+      vi.resetModules();
+    }
+  });
+
+  it("lets the mermaid wrapper custom renderer render complex Mermaid when explicitly opted in", async () => {
+    vi.resetModules();
+
+    try {
+      const { TMermaidText: TMermaidTextWithBeautifulRenderer } = await import("../src/mermaid.js");
+
+      const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
+      const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
+
+      const mounted = await mountTerminal(
+        () =>
+          h(TMermaidTextWithBeautifulRenderer, {
+            x: 0,
+            y: 0,
+            w: 40,
+            h: 3,
+            box: false,
+            content: source,
+            renderer,
+            shouldRenderSource: () => true,
           }),
         48,
         3,

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -375,7 +375,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("lets renderer-agnostic custom renderers handle complex Mermaid by default", async () => {
+  it("keeps complex Mermaid source by default even with a custom renderer", async () => {
     const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
     const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
 
@@ -385,7 +385,7 @@ describe("TMermaidText", () => {
           x: 0,
           y: 0,
           w: 40,
-          h: 1,
+          h: 3,
           box: false,
           content: source,
           renderer,
@@ -396,14 +396,10 @@ describe("TMermaidText", () => {
 
     await settleMermaid(mounted);
 
-    expect(renderer).toHaveBeenCalledTimes(1);
-    expect(renderer).toHaveBeenCalledWith(
-      source,
-      expect.objectContaining({
-        colorMode: "none",
-      }),
-    );
-    expect(rowText(mounted, 0)).toBe("sequence rendered");
+    expect(renderer).not.toHaveBeenCalled();
+    expect(rowText(mounted, 0)).toBe("sequenceDiagram");
+    expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
+    expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
 
     mounted.unmount();
   });
@@ -549,7 +545,7 @@ describe("TMermaidText", () => {
     }
   });
 
-  it("lets mermaid entry custom renderers handle complex Mermaid by default", async () => {
+  it("keeps complex Mermaid source by default in the mermaid entry even with a custom renderer", async () => {
     vi.resetModules();
 
     try {
@@ -564,7 +560,7 @@ describe("TMermaidText", () => {
             x: 0,
             y: 0,
             w: 40,
-            h: 1,
+            h: 3,
             box: false,
             content: source,
             renderer,
@@ -575,14 +571,10 @@ describe("TMermaidText", () => {
 
       await settleMermaid(mounted);
 
-      expect(renderer).toHaveBeenCalledTimes(1);
-      expect(renderer).toHaveBeenCalledWith(
-        source,
-        expect.objectContaining({
-          colorMode: "none",
-        }),
-      );
-      expect(rowText(mounted, 0)).toBe("sequence rendered");
+      expect(renderer).not.toHaveBeenCalled();
+      expect(rowText(mounted, 0)).toBe("sequenceDiagram");
+      expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
+      expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
 
       mounted.unmount();
     } finally {

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -375,36 +375,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("keeps complex Mermaid source by default even with a custom renderer", async () => {
-    const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
-    const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
-
-    const mounted = await mountTerminal(
-      () =>
-        h(TMermaidText, {
-          x: 0,
-          y: 0,
-          w: 40,
-          h: 3,
-          box: false,
-          content: source,
-          renderer,
-        }),
-      48,
-      5,
-    );
-
-    await settleMermaid(mounted);
-
-    expect(renderer).not.toHaveBeenCalled();
-    expect(rowText(mounted, 0)).toBe("sequenceDiagram");
-    expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
-    expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
-
-    mounted.unmount();
-  });
-
-  it("allows custom renderer callers to explicitly opt into non-flowchart Mermaid rendering", async () => {
+  it("lets the renderer-agnostic base component try custom renderer output by default", async () => {
     const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
     const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
 
@@ -418,10 +389,9 @@ describe("TMermaidText", () => {
           box: false,
           content: source,
           renderer,
-          shouldRenderSource: () => true,
         }),
       48,
-      5,
+      3,
     );
 
     await settleMermaid(mounted);
@@ -438,7 +408,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("allows renderer-agnostic callers to explicitly skip complex Mermaid source", async () => {
+  it("allows callers to explicitly skip complex Mermaid source with shouldRenderSource", async () => {
     const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
     const renderer: TMermaidRenderer = vi.fn(() => "should not render");
 
@@ -508,7 +478,7 @@ describe("TMermaidText", () => {
     }
   });
 
-  it("lets the mermaid wrapper custom renderer opt into complex Mermaid rendering", async () => {
+  it("lets the mermaid wrapper custom renderer render complex Mermaid by default", async () => {
     vi.resetModules();
 
     try {
@@ -527,7 +497,6 @@ describe("TMermaidText", () => {
             box: false,
             content: source,
             renderer,
-            shouldRenderSource: () => true,
           }),
         48,
         3,
@@ -538,43 +507,6 @@ describe("TMermaidText", () => {
       expect(renderer).toHaveBeenCalledTimes(1);
       expect(renderer).toHaveBeenCalledWith(source, expect.objectContaining({ colorMode: "none" }));
       expect(rowText(mounted, 0)).toBe("sequence rendered");
-
-      mounted.unmount();
-    } finally {
-      vi.resetModules();
-    }
-  });
-
-  it("keeps complex Mermaid source by default in the mermaid entry even with a custom renderer", async () => {
-    vi.resetModules();
-
-    try {
-      const { TMermaidText: TMermaidTextWithBeautifulRenderer } = await import("../src/mermaid.js");
-
-      const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
-      const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
-
-      const mounted = await mountTerminal(
-        () =>
-          h(TMermaidTextWithBeautifulRenderer, {
-            x: 0,
-            y: 0,
-            w: 40,
-            h: 3,
-            box: false,
-            content: source,
-            renderer,
-          }),
-        48,
-        5,
-      );
-
-      await settleMermaid(mounted);
-
-      expect(renderer).not.toHaveBeenCalled();
-      expect(rowText(mounted, 0)).toBe("sequenceDiagram");
-      expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
-      expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
 
       mounted.unmount();
     } finally {

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -560,7 +560,7 @@ describe("TMermaidText", () => {
     const originalClipboard = Object.getOwnPropertyDescriptor(globalThis.navigator, "clipboard");
 
     Object.defineProperty(globalThis.navigator, "clipboard", {
-      value: { writeText },
+      value: { readText: vi.fn().mockResolvedValue(""), writeText },
       configurable: true,
     });
 
@@ -612,7 +612,7 @@ describe("TMermaidText", () => {
     const originalClipboard = Object.getOwnPropertyDescriptor(globalThis.navigator, "clipboard");
 
     Object.defineProperty(globalThis.navigator, "clipboard", {
-      value: { writeText },
+      value: { readText: vi.fn().mockResolvedValue(""), writeText },
       configurable: true,
     });
 
@@ -667,7 +667,7 @@ describe("TMermaidText", () => {
     const originalClipboard = Object.getOwnPropertyDescriptor(globalThis.navigator, "clipboard");
 
     Object.defineProperty(globalThis.navigator, "clipboard", {
-      value: { writeText },
+      value: { readText: vi.fn().mockResolvedValue(""), writeText },
       configurable: true,
     });
 
@@ -787,6 +787,131 @@ describe("TMermaidText", () => {
         delete (globalThis.navigator as any).clipboard;
       }
     }
+  });
+
+  it("does not bypass an explicitly unsupported injected clipboard", async () => {
+    const source = "graph LR\n  A --> B";
+    const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
+    const navigatorWriteText = vi.fn().mockResolvedValue(undefined);
+    const injectedWriteText = vi.fn().mockResolvedValue(undefined);
+    const onCopy = vi.fn();
+    const originalClipboard = Object.getOwnPropertyDescriptor(globalThis.navigator, "clipboard");
+
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      value: { writeText: navigatorWriteText },
+      configurable: true,
+    });
+
+    try {
+      const cols = 32;
+      const rows = 5;
+      const mounted = await mountTerminal(
+        () =>
+          h(TMermaidText, {
+            x: 0,
+            y: 0,
+            w: 28,
+            content: source,
+            renderer,
+            onCopy,
+          }),
+        cols,
+        rows,
+        {
+          clipboard: {
+            supported: false,
+            readText: vi.fn(),
+            writeText: injectedWriteText,
+          },
+        },
+      );
+
+      await settleMermaid(mounted);
+      setDeterministicMetrics(mounted, cols, rows);
+
+      clickCell(mounted, 22, 0);
+      await settleMermaid(mounted);
+
+      expect(injectedWriteText).not.toHaveBeenCalled();
+      expect(navigatorWriteText).not.toHaveBeenCalled();
+      expect(onCopy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: source,
+          ok: false,
+          error: expect.any(Error),
+        }),
+      );
+      expect(rowText(mounted, 0)).toContain("copy");
+      expect(rowText(mounted, 0)).not.toContain("copied");
+
+      mounted.unmount();
+    } finally {
+      if (originalClipboard) {
+        Object.defineProperty(globalThis.navigator, "clipboard", originalClipboard);
+      } else {
+        delete (globalThis.navigator as any).clipboard;
+      }
+    }
+  });
+
+  it("does not show copied feedback for a stale async copy after source changes", async () => {
+    const firstSource = "graph LR\n  A --> B";
+    const nextSource = "graph LR\n  A --> C";
+    const content = ref(firstSource);
+    const renderer: TMermaidRenderer = vi.fn((code) => `rendered:${code.split("\n")[1]?.trim()}`);
+    const onCopy = vi.fn();
+
+    let resolveWrite!: () => void;
+    const writeText = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveWrite = resolve;
+        }),
+    );
+
+    const cols = 32;
+    const rows = 5;
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 28,
+          content: content.value,
+          renderer,
+          onCopy,
+        }),
+      cols,
+      rows,
+      {
+        clipboard: {
+          supported: true,
+          readText: vi.fn(),
+          writeText,
+        },
+      },
+    );
+
+    await settleMermaid(mounted);
+    setDeterministicMetrics(mounted, cols, rows);
+
+    clickCell(mounted, 22, 0);
+    await settleMermaidMicrotasks(mounted);
+
+    expect(writeText).toHaveBeenCalledWith(firstSource);
+
+    content.value = nextSource;
+    await settleMermaid(mounted);
+
+    resolveWrite();
+    await settleMermaid(mounted);
+
+    expect(onCopy).toHaveBeenCalledWith({ text: firstSource, ok: true });
+    expect(rowText(mounted, 0)).toContain("copy");
+    expect(rowText(mounted, 0)).not.toContain("copied");
+    expect(rowText(mounted, 1)).toContain("rendered:A --> C");
+
+    mounted.unmount();
   });
 
   it("uses the createTerminalApp clipboard for copy", async () => {
@@ -1039,7 +1164,7 @@ describe("TMermaidText", () => {
     const originalClipboard = Object.getOwnPropertyDescriptor(globalThis.navigator, "clipboard");
 
     Object.defineProperty(globalThis.navigator, "clipboard", {
-      value: { writeText },
+      value: { readText: vi.fn().mockResolvedValue(""), writeText },
       configurable: true,
     });
 

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -374,7 +374,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("lets a custom renderer render non-flowchart Mermaid source", async () => {
+  it("keeps non-flowchart Mermaid source by default even with a custom renderer", async () => {
     const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
     const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
 
@@ -384,7 +384,7 @@ describe("TMermaidText", () => {
           x: 0,
           y: 0,
           w: 40,
-          h: 1,
+          h: 3,
           box: false,
           content: source,
           renderer,
@@ -395,14 +395,10 @@ describe("TMermaidText", () => {
 
     await settleMermaid(mounted);
 
-    expect(renderer).toHaveBeenCalledTimes(1);
-    expect(renderer).toHaveBeenCalledWith(
-      source,
-      expect.objectContaining({
-        colorMode: "none",
-      }),
-    );
-    expect(rowText(mounted, 0)).toBe("sequence rendered");
+    expect(renderer).not.toHaveBeenCalled();
+    expect(rowText(mounted, 0)).toBe("sequenceDiagram");
+    expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
+    expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
 
     mounted.unmount();
   });
@@ -447,7 +443,7 @@ describe("TMermaidText", () => {
     }
   });
 
-  it("does not apply the built-in simple-flowchart eligibility to a custom renderer in the mermaid entry wrapper", async () => {
+  it("allows an explicit shouldRenderSource opt-in for complex custom Mermaid rendering", async () => {
     vi.resetModules();
 
     try {
@@ -466,6 +462,7 @@ describe("TMermaidText", () => {
             box: false,
             content: source,
             renderer,
+            shouldRenderSource: () => true,
           }),
         48,
         3,

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -374,9 +374,9 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("lets non-flowchart Mermaid diagram types render when the renderer supports them", async () => {
+  it("skips non-flowchart Mermaid diagram types and keeps source visible", async () => {
     const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
-    const renderer: TMermaidRenderer = vi.fn(() => "rendered sequence");
+    const renderer: TMermaidRenderer = vi.fn(() => "should not render");
 
     const mounted = await mountTerminal(
       () =>
@@ -395,20 +395,15 @@ describe("TMermaidText", () => {
 
     await settleMermaid(mounted);
 
-    expect(renderer).toHaveBeenCalledTimes(1);
-    expect(renderer).toHaveBeenCalledWith(
-      source,
-      expect.objectContaining({
-        colorMode: "none",
-        useAscii: false,
-      }),
-    );
-    expect(rowText(mounted, 0)).toBe("rendered sequence");
+    expect(renderer).not.toHaveBeenCalled();
+    expect(rowText(mounted, 0)).toBe("sequenceDiagram");
+    expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
+    expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
 
     mounted.unmount();
   });
 
-  it("keeps non-flowchart Mermaid source visible when rendering fails", async () => {
+  it("does not call renderer for non-flowchart Mermaid source", async () => {
     const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
     const renderer: TMermaidRenderer = vi.fn(() => {
       throw new Error("unsupported sequence diagram");
@@ -431,7 +426,7 @@ describe("TMermaidText", () => {
 
     await settleMermaid(mounted);
 
-    expect(renderer).toHaveBeenCalledTimes(1);
+    expect(renderer).not.toHaveBeenCalled();
     expect(rowText(mounted, 0)).toBe("sequenceDiagram");
     expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
     expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
@@ -636,7 +631,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("renders when final is false but streaming is not enabled", async () => {
+  it("keeps source while final is false even when streaming is not enabled", async () => {
     const final = ref(false);
     const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
 
@@ -659,19 +654,20 @@ describe("TMermaidText", () => {
 
     await settleMermaid(mounted);
 
-    expect(renderer).toHaveBeenCalledTimes(1);
-    expect(rowText(mounted, 0)).toBe("rendered diagram");
+    expect(renderer).not.toHaveBeenCalled();
+    expect(rowText(mounted, 0)).toBe("graph LR");
+    expect(rowText(mounted, 1)).toBe("  A --> B");
 
     final.value = true;
     await settleMermaid(mounted);
 
-    expect(renderer).toHaveBeenCalledTimes(2);
+    expect(renderer).toHaveBeenCalledTimes(1);
     expect(rowText(mounted, 0)).toBe("rendered diagram");
 
     mounted.unmount();
   });
 
-  it("skips renderer only for unfinished streaming Mermaid source", async () => {
+  it("skips renderer for any non-final Mermaid source", async () => {
     const final = ref(false);
     const streaming = ref(true);
     const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
@@ -700,6 +696,13 @@ describe("TMermaidText", () => {
     expect(rowText(mounted, 1)).toBe("  A --> B");
 
     streaming.value = false;
+    await settleMermaid(mounted);
+
+    expect(renderer).not.toHaveBeenCalled();
+    expect(rowText(mounted, 0)).toBe("graph LR");
+    expect(rowText(mounted, 1)).toBe("  A --> B");
+
+    final.value = true;
     await settleMermaid(mounted);
 
     expect(renderer).toHaveBeenCalledTimes(1);

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -454,6 +454,40 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
+  it("skips rendering whenever final is false even when streaming is not enabled", async () => {
+    const final = ref(false);
+    const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 48,
+          h: 2,
+          box: false,
+          content: "graph LR\n  A --> B",
+          final: final.value,
+          renderer,
+        }),
+      64,
+      4,
+    );
+
+    await settleMermaid(mounted);
+    expect(renderer).not.toHaveBeenCalled();
+    expect(rowText(mounted, 0)).toBe("graph LR");
+    expect(rowText(mounted, 1)).toBe("  A --> B");
+
+    final.value = true;
+    await settleMermaid(mounted);
+
+    expect(renderer).toHaveBeenCalledTimes(1);
+    expect(rowText(mounted, 0)).toBe("rendered diagram");
+
+    mounted.unmount();
+  });
+
   it("keeps source when the renderer returns blank output", async () => {
     const renderer: TMermaidRenderer = vi.fn(() => "   \n\t");
 
@@ -580,6 +614,54 @@ describe("TMermaidText", () => {
     } finally {
       vi.useRealTimers();
       mounted?.unmount();
+      if (originalClipboard) {
+        Object.defineProperty(globalThis.navigator, "clipboard", originalClipboard);
+      } else {
+        delete (globalThis.navigator as any).clipboard;
+      }
+    }
+  });
+
+  it("does not leave copied feedback stuck when copiedDurationMs is zero", async () => {
+    const source = "graph LR\n  A --> B";
+    const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const originalClipboard = Object.getOwnPropertyDescriptor(globalThis.navigator, "clipboard");
+
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    try {
+      const cols = 32;
+      const rows = 5;
+      const mounted = await mountTerminal(
+        () =>
+          h(TMermaidText, {
+            x: 0,
+            y: 0,
+            w: 28,
+            content: source,
+            renderer,
+            copiedDurationMs: 0,
+          }),
+        cols,
+        rows,
+      );
+
+      await settleMermaid(mounted);
+      setDeterministicMetrics(mounted, cols, rows);
+
+      clickCell(mounted, 22, 0);
+      await settleMermaid(mounted);
+
+      expect(writeText).toHaveBeenCalledWith(source);
+      expect(rowText(mounted, 0)).toContain("copy");
+      expect(rowText(mounted, 0)).not.toContain("copied");
+
+      mounted.unmount();
+    } finally {
       if (originalClipboard) {
         Object.defineProperty(globalThis.navigator, "clipboard", originalClipboard);
       } else {
@@ -752,6 +834,46 @@ describe("TMermaidText", () => {
 
     expect(writeText).not.toHaveBeenCalled();
     expect(onCopy).not.toHaveBeenCalled();
+
+    mounted.unmount();
+  });
+
+  it("makes the copy hit node inactive when the copy button is hidden", async () => {
+    const copyButton = ref(true);
+    const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
+
+    const mounted = await mountTerminal(
+      () =>
+        h(TMermaidText, {
+          x: 0,
+          y: 0,
+          w: 28,
+          content: "graph LR\n  A --> B",
+          copyButton: copyButton.value,
+          renderer,
+        }),
+      32,
+      5,
+    );
+
+    await settleMermaid(mounted);
+
+    const events = mounted.events();
+    if (!events) throw new Error("expected terminal events");
+    const copyNode = events
+      .debugNodes()
+      .find((node) => node.visible && node.focusable && node.zIndex === 1 && node.rect.w > 0);
+
+    expect(copyNode).toBeDefined();
+
+    copyButton.value = false;
+    await settleMermaid(mounted);
+
+    const hiddenCopyNode = events.debugNodes().find((node) => node.id === copyNode!.id);
+    expect(hiddenCopyNode).toMatchObject({
+      visible: false,
+      focusable: false,
+    });
 
     mounted.unmount();
   });

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -749,6 +749,12 @@ describe("TMermaidText", () => {
     expect(isSimpleMermaidFlowchartSource("graph LR\nA --> B; classDef hot fill:#f00")).toBe(false);
     expect(isSimpleMermaidFlowchartSource("graph LR\nA:::hot --> B")).toBe(false);
     expect(isSimpleMermaidFlowchartSource("graph LR\nA@{ shape: rect } --> B")).toBe(false);
+    expect(isSimpleMermaidFlowchartSource("graph LR @{ shape: rect }\nA --> B")).toBe(false);
+    expect(
+      isSimpleMermaidFlowchartSource('graph LR click A href "https://example.com"\nA --> B'),
+    ).toBe(false);
+    expect(isSimpleMermaidFlowchartSource("graph LR whatever\nA --> B")).toBe(false);
+    expect(isSimpleMermaidFlowchartSource("flowchart TD extra\nA --> B")).toBe(false);
     expect(isSimpleMermaidFlowchartSource('graph LR\nclick A href "https://example.com"')).toBe(
       false,
     );

--- a/test/tmermaid-text.test.ts
+++ b/test/tmermaid-text.test.ts
@@ -462,7 +462,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("lets an explicit custom renderer render complex Mermaid source by default", async () => {
+  it("keeps complex Mermaid source by default even with a custom renderer", async () => {
     const source = ["sequenceDiagram", "  Alice->>Bob: Hello", "  Bob-->>Alice: Hi"].join("\n");
     const renderer: TMermaidRenderer = vi.fn(() => "sequence rendered");
 
@@ -483,14 +483,10 @@ describe("TMermaidText", () => {
 
     await settleMermaid(mounted);
 
-    expect(renderer).toHaveBeenCalledTimes(1);
-    expect(renderer).toHaveBeenCalledWith(
-      source,
-      expect.objectContaining({
-        colorMode: "none",
-      }),
-    );
-    expect(rowText(mounted, 0)).toBe("sequence rendered");
+    expect(renderer).not.toHaveBeenCalled();
+    expect(rowText(mounted, 0)).toBe("sequenceDiagram");
+    expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
+    expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
 
     mounted.unmount();
   });
@@ -599,7 +595,7 @@ describe("TMermaidText", () => {
     }
   });
 
-  it("lets a custom renderer in the mermaid wrapper render complex Mermaid by default", async () => {
+  it("keeps complex Mermaid source by default in the mermaid wrapper even with a custom renderer", async () => {
     vi.resetModules();
 
     try {
@@ -625,8 +621,10 @@ describe("TMermaidText", () => {
 
       await settleMermaid(mounted);
 
-      expect(renderer).toHaveBeenCalledTimes(1);
-      expect(rowText(mounted, 0)).toBe("sequence rendered");
+      expect(renderer).not.toHaveBeenCalled();
+      expect(rowText(mounted, 0)).toBe("sequenceDiagram");
+      expect(rowText(mounted, 1)).toBe("  Alice->>Bob: Hello");
+      expect(rowText(mounted, 2)).toBe("  Bob-->>Alice: Hi");
 
       mounted.unmount();
     } finally {
@@ -1701,7 +1699,7 @@ describe("TMermaidText", () => {
     mounted.unmount();
   });
 
-  it("does not expose copy hit node when explicit height is too small to draw the box", async () => {
+  it("does not draw the box or expose copy hit node when explicit height has no content row", async () => {
     const source = "graph LR\n  A --> B";
     const renderer: TMermaidRenderer = vi.fn(() => "rendered diagram");
     const writeText = vi.fn().mockResolvedValue(undefined);
@@ -1715,7 +1713,7 @@ describe("TMermaidText", () => {
           x: 0,
           y: 0,
           w: 28,
-          h: 1,
+          h: 2,
           content: source,
           renderer,
           onCopy,
@@ -1734,6 +1732,7 @@ describe("TMermaidText", () => {
     await settleMermaid(mounted);
 
     expect(rowText(mounted, 0)).toBe("rendered diagram");
+    expect(rowText(mounted, 1)).toBe("");
 
     setDeterministicMetrics(mounted, cols, rows);
     clickCell(mounted, 22, 0);


### PR DESCRIPTION
## Summary
- Make `TMermaidText` source-first: unfinished streaming shows source and skips renderer work; successful final renders atomically replace source; failures and blank output keep source visible.
- Add the default Mermaid box with title/copy affordance and export the `TMermaidCopyPayload` type through the public entrypoints.
- Preserve Markdown code fence language metadata and include it in layout cache signatures.

## Validation
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm vitest run test/tmermaid-text.test.ts test/tmarkdown-layout.test.ts test/api-surface.test.ts test/docs-components.test.ts test/docs-export-contract.test.ts test/package-exports.test.ts`
- `pnpm run test`
- `pnpm run build`
