### PR TITLE
fix: detect WezTerm as kitty-protocol capable instead of iterm2-only

### DIFF
--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -101,7 +101,7 @@ type RendererCapabilities = Readonly<{
 | 协议     | 代表终端                                  | 说明                             |
 | -------- | ----------------------------------------- | -------------------------------- |
 | `kitty`  | kitty、WezTerm、foot、Ghostty、Konsole    | 推荐；支持像素精确渲染和增量更新 |
-| `iterm2` | iTerm2、WezTerm                           | PNG inline image protocol        |
+| `iterm2` | iTerm2                                    | PNG inline image protocol        |
 | `sixel`  | xterm、mlterm、Windows Terminal（需开启） | 仅 `TAgentTerminalGraphic` 使用  |
 
 协议通过 `registerTerminalGraphicsOutput()` / `createStdoutRenderer()` 注入到渲染管线；组件本身不直接检测 TTY 能力。

--- a/src/renderer/terminal-graphics.ts
+++ b/src/renderer/terminal-graphics.ts
@@ -269,17 +269,15 @@ function detectCandidates(env: Record<string, unknown>): TerminalGraphicsProtoco
     envString(env, "GHOSTTY_RESOURCES_DIR") ||
     /(?:^|-)kitty(?:-|$)/i.test(term) ||
     term.includes("ghostty") ||
-    termProgram.includes("ghostty")
-  ) {
-    candidates.push("kitty");
-  }
-
-  if (
-    termProgram.includes("iterm") ||
+    termProgram.includes("ghostty") ||
     termProgram.includes("wezterm") ||
     envString(env, "WEZTERM_PANE") ||
     envString(env, "WEZTERM_EXECUTABLE")
   ) {
+    candidates.push("kitty");
+  }
+
+  if (termProgram.includes("iterm")) {
     candidates.push("iterm2");
   }
 

--- a/terminal-flappy-bird/src/run.ts
+++ b/terminal-flappy-bird/src/run.ts
@@ -50,7 +50,7 @@ export function checkTerminalSupport(): boolean {
     "  ║   Supported terminals:                                       ║",
     "  ║     • Kitty           (kitty)                               ║",
     "  ║     • iTerm2           (iterm2)                              ║",
-    "  ║     • WezTerm          (iterm2-compatible)                   ║",
+    "  ║     • WezTerm          (kitty-compatible)                    ║",
     "  ║     • Ghostty          (kitty-compatible)                     ║",
     "  ║     • Any Sixel terminal                                     ║",
     "  ║                                                              ║",


### PR DESCRIPTION
## Problem

WezTerm was detected as **iTerm2-compatible** and received OSC 1337 inline image sequences instead of the higher-fidelity kitty APC graphics protocol. This caused degraded rendering in apps like `terminal-flappy-bird` when run in WezTerm vs Ghostty (which uses kitty protocol).

## Solution

WezTerm has supported the kitty graphics protocol since v20240127-113634-bbcac862. This PR moves WezTerm detection from the iTerm2 block into the kitty block so it receives kitty APC graphics sequences.

<img width="1279" height="847" alt="image" src="https://github.com/user-attachments/assets/90ddc995-9566-4944-a1e8-9d54ab2bf853" />

## Changes

- **`src/renderer/terminal-graphics.ts`** — Move wezterm env var checks into the kitty protocol candidate detection
- **`terminal-flappy-bird/src/run.ts`** — Update help text: WezTerm is now shown as `kitty-compatible`
- **`docs/platform-contracts.md`** — Remove WezTerm from iterm2 row (already listed in kitty row)