### PR TITLE
feat(markdown): render math formulas as terminal graphics; dedupe video/image graphic sequences; bottom-anchored REPL bar

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -244,6 +244,13 @@ const pageMeta: Record<
     keywords:
       "markdown transcript, streaming markdown, Vue markdown renderer, terminal markdown UI",
   },
+  "guide/markdown-math.md": {
+    title: "Markdown 数学公式渲染",
+    description:
+      "在终端里渲染 LaTeX/KaTeX 数学公式：块级公式输出为 Kitty 图形协议图片，行内公式混排进文字行，无图形能力时回退为 box 包裹或原始文本。",
+    keywords:
+      "markdown math, latex, katex, mathjax, kitty graphics, terminal math, 公式渲染",
+  },
 };
 
 function pageUrl(page: string): string {
@@ -428,6 +435,7 @@ export default defineConfig({
           { text: "CLI Stdout Renderer", link: "/guide/cli-stdout-renderer" },
           { text: "Terminal Log Viewer", link: "/guide/terminal-log-viewer" },
           { text: "Markdown Transcript", link: "/guide/markdown-transcript" },
+          { text: "Markdown Math", link: "/guide/markdown-math" },
         ],
       },
       { text: "Examples", link: "/examples" },
@@ -461,6 +469,7 @@ export default defineConfig({
           { text: "CLI Stdout Renderer", link: "/guide/cli-stdout-renderer" },
           { text: "Terminal Log Viewer", link: "/guide/terminal-log-viewer" },
           { text: "Markdown Transcript", link: "/guide/markdown-transcript" },
+          { text: "Markdown Math", link: "/guide/markdown-math" },
           { text: "Examples Index", link: "/examples" },
           { text: "Agent Console", link: "/agent-console" },
           { text: "TLogView Lab", link: "/tlog-view-lab" },

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -248,8 +248,7 @@ const pageMeta: Record<
     title: "Markdown 数学公式渲染",
     description:
       "在终端里渲染 LaTeX/KaTeX 数学公式：块级公式输出为 Kitty 图形协议图片，行内公式混排进文字行，无图形能力时回退为 box 包裹或原始文本。",
-    keywords:
-      "markdown math, latex, katex, mathjax, kitty graphics, terminal math, 公式渲染",
+    keywords: "markdown math, latex, katex, mathjax, kitty graphics, terminal math, 公式渲染",
   },
 };
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -958,9 +958,9 @@ Markdown renderer for static or streaming text content。它走独立的 `parser
 > Markdown import: `@simon_he/vue-tui/markdown`
 >
 > 数学公式：`$...$` 块级公式在支持图形协议的终端（Kitty/Ghostty/WezTerm/iTerm2）渲染为图片，否则以 box 包裹原始 TeX；`$...---
-title: Vue Terminal UI Components
-description: Reference for Vue TUI components such as TerminalProvider, TBox, TInput, TList, TTable, TLogView, TVirtualMarkdown, and agent primitives.
----
+> title: Vue Terminal UI Components
+
+## description: Reference for Vue TUI components such as TerminalProvider, TBox, TInput, TList, TTable, TLogView, TVirtualMarkdown, and agent primitives.
 
 # Components 使用文档
 
@@ -1916,7 +1916,7 @@ Markdown renderer for static or streaming text content。它走独立的 `parser
 
 > Markdown import: `@simon_he/vue-tui/markdown`
 >
- 行内公式在图形终端混排进文字行（≤2 行高），超高公式（矩阵等）与无图形环境保持原始文本，格式错误的公式也会回退为原始文本。需要安装可选 peer `mathjax-full` + `@resvg/resvg-js` 才会启用图片路径。详见 [Markdown 数学公式渲染](/guide/markdown-math)。
+> 行内公式在图形终端混排进文字行（≤2 行高），超高公式（矩阵等）与无图形环境保持原始文本，格式错误的公式也会回退为原始文本。需要安装可选 peer `mathjax-full` + `@resvg/resvg-js` 才会启用图片路径。详见 [Markdown 数学公式渲染](/guide/markdown-math)。
 >
 > `content` string 路径仍然只做 **per-frame coalescing**：一帧内多次 append 会合并成一次 rebuild，但 rebuild 本身仍然会从当前 full markdown string parse。长文档 streaming transcript 场景可以使用 `createMarkdownBlockSource()`，在消息、tool fence 或代码块完成时 `finalizeBlock()`，再把 `blocks` 传给 `TVirtualMarkdown`，避免反复重 parse 已 finalize 的历史。
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -957,7 +957,966 @@ Markdown renderer for static or streaming text content。它走独立的 `parser
 
 > Markdown import: `@simon_he/vue-tui/markdown`
 >
-> Inline math initially keeps the original KaTeX/LaTeX syntax, including `$...$` delimiters. When the optional `katex` peer is installed, the Markdown renderer loads it on demand and automatically replaces supported formulas with terminal text; when it is absent, the raw syntax remains visible.
+> 数学公式：`$...$` 块级公式在支持图形协议的终端（Kitty/Ghostty/WezTerm/iTerm2）渲染为图片，否则以 box 包裹原始 TeX；`$...---
+title: Vue Terminal UI Components
+description: Reference for Vue TUI components such as TerminalProvider, TBox, TInput, TList, TTable, TLogView, TVirtualMarkdown, and agent primitives.
+---
+
+# Components 使用文档
+
+本文档覆盖 `@simon_he/vue-tui` 当前内置的 Vue 组件，用于统一「渲染/参数/事件」的契约，便于实现一致的验收与测试。
+
+> 坐标/尺寸单位：所有 `x/y/w/h` 均以「cell（字符格）」为单位，而不是像素。
+
+> 完整的 Props/Events 列表请以自动生成文件为准：`docs/generated/components-api.md`（运行 `pnpm run docs:gen` 生成）。
+
+## 导入入口
+
+| API maturity | Import                            | 组件                                                                                                                                                                                                                                                                                                          |
+| ------------ | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Public       | `@simon_he/vue-tui`               | `TerminalProvider` `TBox` `TCommandPalette` `TDataTable` `TDialog` `TInput` `TLink` `TLinkifyText` `TList` `TSelect` `TTable` `TText` `TTree` `TView` form helpers 和 `TBadge`/`TTag`/`TDivider`/`TCode`                                                                                                      |
+| Advanced     | `@simon_he/vue-tui/vue`           | `TAnchor` `TDebugOverlay` `TFlex` `TFlexItem` `TFlow` `TForm` `TInputBox` `TJsonEditor` `TMermaid` `TMermaidText` `TMultilineModal` `TPathPicker` `TProgress` `TSpinner` `TSplitPane` `TTabs` `TToastViewport` `TRenderLayer` `TRenderPlane` `TRouterView` `TTransition` 和 overlay/navigation/status helpers |
+| Public       | `@simon_he/vue-tui/markdown`      | `TMarkdownText` `TVirtualMarkdown`                                                                                                                                                                                                                                                                            |
+| Public       | `@simon_he/vue-tui/mermaid`       | `TMermaid` `TMermaidText` `TBeautifulMermaidText` `beautifulMermaidRenderer` `createBeautifulMermaidRenderer`                                                                                                                                                                                                 |
+| Experimental | `@simon_he/vue-tui/experimental`  | `TCandlestickChart` `TContributionGraph` `TLineChart` `TPieChart` `TVideo` `TVirtualList` `TTranscriptView` `TLogView` `TLogSearchBar` `TLogSearchResults` `TLogSearchPager` `TLogLinksPanel` `TLogVirtualSearchResults` `TLogVirtualLinksPanel` `TLogScrollbar` `TLogMinimap`                                |
+| Experimental | `@simon_he/vue-tui/agent`         | `TAgentTerminalGraphic` `TAgentTranscript` `TMermaid` `TMermaidText` `TThinkingView` `TUserMessageView` `TToolCallView` `TToolLogView` `TVirtualMarkdown` `TVirtualList` `TRenderPlane` 和 agent/console 常用基础组件                                                                                         |
+| Experimental | `@simon_he/vue-tui/agent/mermaid` | `TMermaid` `TMermaidText` `TBeautifulMermaidText` `beautifulMermaidRenderer` `createBeautifulMermaidRenderer`                                                                                                                                                                                                 |
+
+下面的组件速读按用途分组，不代表 root entrypoint 导出。每个组件的 primary import 以生成的 [组件 API](/generated/components-api) 为准。
+
+## 组件速读
+
+| 类别          | 组件                                                                                                                                                                                               | 典型用途                                          | 适配性判断                                         |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- | -------------------------------------------------- |
+| Root          | `TerminalProvider`                                                                                                                                                                                 | 创建 terminal / renderer / event manager 上下文   | 通用，适合所有宿主                                 |
+| Layout        | `TBox` `TView` `TAnchor` `TFlex` `TFlexItem` `TFlow` `TRenderLayer` `TRenderPlane`                                                                                                                 | 布局、裁剪、层级、分层组合                        | 通用，和 CLI 业务无关                              |
+| Text / Action | `TText` `TLink` `TLinkifyText` `TMermaid` `TMermaidText` `TBadge` `TTag` `TDivider` `TCode` `TKeyHint` `TTransition`                                                                               | 文本渲染、链接操作、结构图、徽标、分隔符          | 通用                                               |
+| Input / Form  | `TInput` `TInputBox` `TAutocompleteInput` `TCheckbox` `TFormField` `TPasswordInput` `TRadioGroup` `TSlider` `TSwitch` `TJsonEditor`                                                                | prompt、表单、结构化文本编辑                      | 通用，但推荐把补全/校验放到插件层                  |
+| Data / Tree   | `TTable` `TDataTable` `TTree`                                                                                                                                                                      | 多列数据、排序过滤、层级选择                      | 通用                                               |
+| Charts        | `TContributionGraph` `TLineChart` `TCandlestickChart` `TPieChart`                                                                                                                                  | 贡献热力图、趋势、K 线、占比图                    | 通用，适合 dashboard / agent token usage           |
+| Pickers       | `TCommandPalette` `TList` `TVirtualList` `TTranscriptView` `TLogView` `TLogSearchBar` `TLogSearchResults` `TLogSearchPager` `TLogLinksPanel` `TLogScrollbar` `TLogMinimap` `TSelect` `TPathPicker` | palette、列表、transcript、日志、路径选择         | `TPathPicker` 本体可复用，路径语义由 provider 注入 |
+| Overlay       | `TDialog` `TContextMenu` `TPopover` `TTooltip` `TToastViewport` `TMultilineModal` `TDebugOverlay`                                                                                                  | 对话框、菜单、提示、toast、详情查看、调试覆盖层   | 通用，适合多种宿主                                 |
+| Navigation    | `TBreadcrumb` `TStatusBar` `TTabs` `TSplitPane` `TRouterView` + `createTerminalRouter()`                                                                                                           | 路径导航、状态栏、多页面 TUI / shell              | 通用                                               |
+| Media         | `TVideo`                                                                                                                                                                                           | terminal video、动态 ASCII 降级                   | Experimental；按终端图形能力自适应                 |
+| Agent Chrome  | `TAgentTerminalGraphic` `TThinkingView` `TUserMessageView` `TToolCallView`                                                                                                                         | terminal graphics、thinking/user/tool-call chrome | 默认对齐 best-agent 风格，可通过 style props 覆盖  |
+
+如果你更关心“哪些地方还应该继续做插件化”，建议配合阅读：[扩展性与插件化](./extensibility.md)。
+
+如果你在实现完整 CLI surface、dialog/input 交互、transcript 或高频渲染区域，建议先读：[Terminal UI Best Practices](./terminal-ui-best-practices.md)。
+
+## 基础约定
+
+### Style（样式）
+
+`style` 使用 `Style`（ANSI 风格语义）：
+
+- `fg`/`bg`: ANSI 颜色名（例如 `whiteBright`/`blue` 等）
+- `bold`/`dim`/`italic`/`underline`/`inverse`: 布尔开关
+
+`TerminalProvider` 提供 `defaultStyle` 作为默认渲染样式；组件的 `style` 传入后会覆盖默认值（通常是整行/整块生效）。
+未显式传入时，`defaultStyle` 仍是普通可变对象；如果要触发依赖它的组件重新绘制，推荐替换整个对象，而不是原地修改字段。
+
+`TThinkingView`、`TUserMessageView`、`TToolCallView` 这种 agent/console 组件保留通用数据边界：只接收 `title`、`content`、`status`、`collapsed`、`suffix`、`preview` 等渲染语义，不接收 provider/session/tool schema。默认样式对齐 best-agent CLI 的 transcript chrome；宿主可以用各组件的 `style`、`headerStyle`、`contentStyle`、`titleStyle`、`suffixStyle`、`previewStyle` 等 props 覆盖颜色。
+
+### zIndex（层级）
+
+- 渲染层：同一 stack 内按 `zIndex` 决定覆盖顺序（大者覆盖小者）。
+- 事件层：可交互组件会注册到 EventManager，命中测试会偏向 **更高 zIndex** 或 **更小面积** 的节点。
+
+### 事件（点击/键盘/焦点）
+
+可交互组件遵循 Vue 事件命名习惯：
+
+- 监听：`@click` / `@keydown` / `@focus` / `@blur` …
+- v-model：`modelValue` + `update:modelValue`
+
+事件 payload 为终端事件（`TerminalPointerEvent` / `TerminalKeyboardEvent`），携带 `cellX/cellY` 等信息。
+
+## TerminalProvider
+
+终端 UI 的根组件：创建 `terminal`、DOM renderer、EventManager、调度器（rAF）。
+
+### Props
+
+- `cols` `(number, required)`: 终端列数
+- `rows` `(number, required)`: 终端行数
+- `defaultStyle` `(Style)`: 默认样式（默认 `{}`）
+- `autoResize` `(boolean)`: 是否根据容器尺寸自动 resize（默认 `false`）
+- `minCols`/`minRows` `(number)`: autoResize 下最小尺寸
+- `recordEvents` `(fn?)`: 录制事件回调（用于 record/replay）
+- `selection` `(boolean | TerminalProviderSelectionOptions)`: 开启 terminal cell selection；鼠标松开时可自动复制；`toast` 只影响 `TerminalProvider` 的复制提示 UI
+- `clipboard` `(ClipboardApi?)`: 给 selection auto-copy 注入 clipboard；不传时 browser 使用运行时 clipboard
+- `inputPlugins` `(TInputPlugin[])`: 给子树里的 `TInput` / `TInputBox` 注入宿主插件（例如 terminal clipboard、TTY 风格快捷键）；init-only，修改后需重新挂载 provider/input
+- `pathPickerProvider` `(PathPickerProvider?)`: 给子树里的 `TPathPicker` 注入宿主路径 provider
+- `linkOpener` `(TerminalLinkOpener | function?)`: 给 `TLink openMode="host"` 注入外部链接打开能力；浏览器 `TerminalProvider` 默认使用 `window.open`，CLI/headless 需要通过 `createTerminalApp({ linkOpener })` 显式提供
+- `theme` `(TuiThemeOverrides?)`: 组件主题 token 覆盖；传入 partial overrides 即可，例如 `{ colors: { link: "blueBright" } }`，`TerminalProvider` 会用 `createTheme()` 归一化；局部 `style` props 仍然优先
+- `debugIme` `(boolean)`: 输出 IME 调试信息
+- `debugTrace` `(boolean)`: 开启 trace（commit/event/focus）
+- `domRendererOptions` `(DomRendererOptions?)`: DOM renderer 配置，例如 `syncFlushMaxRows` / `syncFlushCellBudget`；link options 会在更新时刷新，其他选项按 mount-time 使用，修改后需重新挂载 provider
+
+### Slots
+
+- `default`: 渲染你的 TUI 组件树
+
+### Example
+
+```vue
+<TerminalProvider :cols="80" :rows="24" :default-style="{ fg: 'whiteBright' }">
+  <TBox :x="0" :y="0" :w="80" :h="24" title="Demo" border :padding="1">
+    <TText :x="0" :y="0" :w="78" value="Hello" />
+  </TBox>
+</TerminalProvider>
+```
+
+## TText
+
+渲染纯文本（可多行、可自动换行），并会对控制字符做清洗，避免写出组件矩形区域。
+
+### Props
+
+- `x`/`y` `(number, required)`
+- `zIndex` `(number)`
+- `value` `(string, required)`
+- `w`/`h` `(number?)`: 不传则按文本实际宽高推导
+- `style` `(Style?)`
+- `clear` `(boolean)`: 每次 paint 是否先清空区域（默认 `true`）
+- `wrap` `(boolean)`: 是否按 `w` 自动换行（默认 `false`）
+- `depsKey` `(unknown?)`: 参与 render-node 依赖追踪的可选 key（用于强制 repaint）
+
+### Notes
+
+- `wrap=true` 会保留显式 `\n` 为硬换行，并按 cell 宽度进行自动折行。
+- 多字节/宽字符（例如中文）按 cell 宽度计算，不会半个字符被截断。
+
+## TBox
+
+绘制一个矩形容器（可选边框/标题/内边距），并为子节点提供 layout（clipRect + origin 偏移），支持 `scrollX/scrollY`。
+
+### Props
+
+- `x`/`y`/`w`/`h` `(number, required)`
+- `zIndex` `(number)`
+- `border` `(boolean)`: 是否绘制边框（默认 `true`）
+- `title` `(string)`: 标题（会被安全截断）
+- `padding` `(number)`: 内边距（会自动 clamp，避免把内容挤没）
+- `scrollX`/`scrollY` `(number)`: 内容滚动偏移（单位 cell）
+- `style` `(Style?)`
+- `clear` `(boolean)`: 是否先清空区域（默认 `true`）
+
+### Slots
+
+- `default`: 内容区子组件
+
+### Events
+
+`TBox` 主要用于绘制与裁剪，但也会对其矩形区域注册 hover 事件：
+
+`@pointerenter` / `@pointerleave`（含 Capture 版本）
+
+## TView
+
+一个可交互的矩形“视口”节点：提供 layout（origin/clipRect）与事件（click/key/focus/blur…），支持 `scrollX/scrollY`。
+
+### Props
+
+- `x`/`y`/`w`/`h` `(number, required)`
+- `zIndex` `(number)`
+- `scrollX`/`scrollY` `(number)`
+- `focusable` `(boolean)`: 是否可获得焦点（默认 `false`）
+- `selectable` `(boolean?)`: 是否允许文本选择（默认 `undefined` 由上层决定）
+- `autoFocus` `(boolean)`: 可见时自动聚焦（默认 `false`）
+
+### Events
+
+`@click`/`@dblclick`/`@pointerdown`/`@pointerup`/`@pointermove`/`@pointerenter`/`@pointerleave`/`@wheel`/`@keydown`/`@keyup`/`@focus`/`@blur`
+
+> 同时支持对应的 `Capture` 版本（例如 `@clickCapture`）。
+
+## TLink
+
+可点击、可聚焦、可键盘激活的单行链接组件。除 `disabled` / `openMode="none"` 外，它会把 DOM-safe `href` 写入 `Style.href`，因此 DOM renderer links 开启时可以得到原生 anchor，CLI/stdout renderer 可以继续输出 OSC8 hyperlink。
+
+默认 `openMode="host"`：点击或按 `Enter` 时会先 emit `activate`，再调用 `TerminalProvider.linkOpener` 或 `createTerminalApp({ linkOpener })` 注入的 `openExternal()` 尝试打开；浏览器 `TerminalProvider` 默认使用 `window.open`，CLI/headless 不会默认执行系统命令。
+
+`openMode` 语义：
+
+- `host`: emit `activate`，阻止 DOM native anchor 默认行为，并调用 `linkOpener`
+- `event`: emit `activate`，阻止组件处理的 DOM native anchor click，不调用 `linkOpener`；仍会写入 `Style.href` metadata，terminal OSC8 或 browser context menu 仍可能暴露 href，如需完全不输出 link metadata 请使用 `none`
+- `native`: click emit `activate` 并允许 renderer/native link activation；keyboard emit `activate` 后在有 `linkOpener` 时作为 terminal focus fallback 打开；如果 `modifierClick` 不满足，会阻止 native click
+- `none`: 只渲染文本，不写入 href metadata，不激活
+
+`TLink` 接受 absolute `https:` / `http:` / `mailto:` 和 `/docs`、`#section` 这类 relative href；宿主应按自己的策略重新解析或拒绝 relative href。`TLink` 有意拒绝 `file:` URL；terminal-specific `file:` opt-in 只适用于底层 `Style.href` 写入者、stdout renderer 或 TLog retained index 这类显式 provider。
+
+`modifierClick="meta"` 和 `ctrlOrMeta` 里的 Meta/Cmd 只对 browser/DOM 事件有意义；真实 CLI SGR mouse report 只携带 Shift/Alt/Ctrl，所以 CLI 下 `ctrlOrMeta` 等价于 Ctrl，`meta` 不会被真实鼠标输入满足。
+
+`domRendererOptions.links.activation="event"` 面向 markdown/static rich text 这类直接写入 `Style.href` 的链接。它会在 DOM anchor 层先 `preventDefault()` 并调用 renderer-level `onActivate`；`TLink` 会尊重这个 defaultPrevented 状态，不再执行组件级 `activate` / host opener。组件化链接推荐由 `TLink` 自己拥有 activation。
+
+### Props
+
+- `x`/`y` `(number, required)`
+- `w` `(number?)`: 不传时按 `label || href` 的 cell 宽度计算
+- `h` `(number)`: 命中区域高度，默认 `1`
+- `href` `(string, required)`
+- `label` `(string?)`
+- `style` / `hoverStyle` / `focusStyle` / `activeStyle` `(Style?)`
+- `disabled` `(boolean)`
+- `openMode` `('native' | 'host' | 'event' | 'none')`
+- `activationKeys` `(string[])`: 默认 `['Enter']`
+- `modifierClick` `('none' | 'ctrl' | 'meta' | 'ctrlOrMeta')`
+- `autoFocus` `(boolean)`
+
+### Events
+
+- `activate`: `{ href, label, source }`
+- `open`: `{ href, label, source }`，host opener 返回 true 时触发，表示请求已被接受/尝试；不保证 OS 或 browser 实际打开了目标
+- `invalidHref`: `{ href, reason }`
+- `click` / `keydown` / `focus` / `blur`
+
+```vue
+<TLink
+  :x="2"
+  :y="4"
+  href="https://example.com"
+  label="Open example.com"
+  :focus-style="{ inverse: true }"
+  @activate="onLinkActivate"
+/>
+```
+
+## TLinkifyText
+
+自动识别纯文本里的 URL，并把匹配片段渲染成带 `Style.href` metadata 的文本。它不自己打开链接，也不注册点击事件；DOM renderer 是否生成 `<a>` 仍由 `domRendererOptions.links` 控制，CLI/stdout 是否输出 OSC8 仍由 stdout renderer 的 href sanitizer 控制。
+
+默认只识别 `http:` / `https:` / `mailto:`。relative href 需要显式 opt in，避免把日志或路径文本误标成可打开链接；`file:` 不属于 public linkify 协议。
+
+Public helper `linkifyTextSegments("")` returns an empty segment array; non-empty plain text with no links returns one plain `{ text }` segment.
+
+### Props
+
+- `x`/`y` `(number, required)`
+- `w`/`h` `(number?)`
+- `value` `(string, required)`
+- `style` `(Style?)`
+- `linkStyle` `(Style?)`: 默认 `{ fg: 'cyanBright', underline: true }`
+- `clear` `(boolean)`
+- `wrap` `(boolean)`
+- `protocols` `(('http' | 'https' | 'mailto')[]?)`
+- `allowRelative` `(boolean)`
+- `maxUrlLength` `(number?)`
+
+```vue
+<TLinkifyText :x="2" :y="6" :w="80" value="build failed: see https://example.com/docs" />
+```
+
+## TBadge
+
+小型状态徽标，渲染为单行 `[value]` 文本。适合 tab badge、计数和短状态，不拥有交互或生命周期。
+
+## TTag
+
+小型标签，渲染为单行 `<label>` 文本。`tone` 只影响语义色，不表示稳定性或权限边界。
+
+## TDivider
+
+单行分隔符，可选 `title`。只负责绘制，不拥有折叠、分组或焦点行为。
+
+## TCode
+
+单行 code 文本，用于命令、路径或短 token。它只做 cell 截断和样式渲染，不执行命令、不复制内容。
+
+## TMermaid / TMermaidText
+
+Mermaid 组件详见下方 [TMermaidText](#tmermaidtext)。这里仅作为 Text / Action 分类索引：基础组件从 `@simon_he/vue-tui/vue` 或 `@simon_he/vue-tui/agent` 导入并显式传 `renderer`；内置 `beautiful-mermaid` bridge 从 `@simon_he/vue-tui/mermaid` 或 `@simon_he/vue-tui/agent/mermaid` 导入，使用前需要安装 `beautiful-mermaid`。
+
+## TAgentTerminalGraphic
+
+Agent terminal graphics 组件，从 `@simon_he/vue-tui/agent` 引入。它面向真实 stdout terminal：组件在 TUI buffer 中占用指定 cell rect，并通过 `createStdoutRenderer()` 注册的 terminal graphics output 在帧末尾写入 Kitty / iTerm2 / Sixel 等 raw escape payload。DOM/headless 或不支持图像协议时自动显示 `fallback` 文本；未传 `fallback` 时，`kind="image"` 默认为空文本，`kind="math"` 使用 `content`。
+
+组件本身不 import KaTeX、不读取图片文件、不执行外部命令。宿主传入 `renderer(content, context)`，根据 `context.protocol` 或 `context.capabilities.preferredProtocol` 返回 `{ type: "sequence", protocol, sequence, fallback?, clearSequence?, rows?, cols? }` 作为可信 terminal image escape，或返回 `{ type: "text", text }` 作为 Unicode/ANSI fallback。返回 `null` / `undefined` 会使用组件 `fallback`，不会进入错误态；renderer 抛错时同样显示 fallback，但会使用 `errorStyle`。为了避免 terminal escape injection，bare string 只会按普通文本 fallback 处理，不会作为 raw escape 写入 stdout。`h` 省略时会优先使用 renderer result 的 `rows` 推导占用高度，仍建议宿主显式传入最终 cell 高度。`kind="math"` 可用于 KaTeX/LaTeX，`kind="image"` 可用于普通图片。
+
+虚拟滚动或重内容场景建议使用 `deferRenderUntilVisible`、`suspendRenderWhileScrolling` / `suspended` 和 `createTerminalGraphicRenderQueue()` 控制懒渲染、取消、缓存与并发。PNG 渲染链路可用 `createPngTerminalGraphicRenderer()` 组合 Kitty / iTerm2 序列；Sixel 需要宿主提供 `toSixel` encoder，例如 libsixel binding、`img2sixel` 包装或自定义 renderer。传给 PNG/Sixel renderer 的转换函数应观察 `context.signal` 并及时 settle；queue 会在 caller abort 后 reject，但并发 slot 会等实际转换 settle 后释放。默认 PNG cache key 覆盖 `kind`、尺寸、`final`、content/组件 `cacheKey` 和 renderer `cacheSalt`，不包含 protocol，因此使用默认 key 时 `toPngBase64()` 应保持协议无关；随 PNG frame 返回的 `fallback` 也会进入同一缓存，如果它依赖 protocol、主题、字体、DPR、KaTeX macro 或 renderer options，应传 `cacheSalt`、自行提供完整 `cacheKey()`，或改用 renderer 的 `fallback()` option。terminal 不支持图像、raw 不可见、组件不可见或缺少 Sixel encoder 时只会走 renderer-level `fallback()` 或组件 `fallback`，不会为了读取 PNG frame `fallback` 而执行 `toPngBase64()`。Kitty 支持显式 delete sequence；组件级自定义 Kitty `clearSequence` 只接受 `context.imageId` / `context.placementId` 对应的 `d=i` / `d=I` delete，current-cell `d=c` / `d=C` 不会作为组件 clear 使用。iTerm2 inline image 和 Sixel clear 是 best-effort，通过重绘占用的 cell rect 清理。自定义 Kitty renderer 如果依赖组件默认 clear，应使用 `context.imageId` / `context.placementId` 创建 draw sequence；否则应返回同一组 id/placement 的可靠 `clearSequence`。
+
+真实终端 smoke checklist：
+
+- [ ] Kitty native
+- [ ] iTerm2 inline image
+- [ ] tmux passthrough
+- [ ] Sixel-capable terminal
+- [ ] unsupported / CI / non-TTY fallback
+
+```vue
+<TAgentTerminalGraphic
+  :x="0"
+  :y="2"
+  :w="72"
+  :h="12"
+  kind="math"
+  content="\\frac{a}{b}"
+  fallback="a / b"
+  :renderer="terminalMathRenderer"
+/>
+```
+
+## TVideo
+
+`TVideo` 是实验性的 terminal video 组件。组件本身保持 browser-safe；Node 侧 FFmpeg 和 yt-dlp adapter 从 `@simon_he/vue-tui/experimental/video/node` 单独导入，并在真正开始播放时才动态加载 `node:child_process`。系统需要能执行 `ffmpeg`；解析 YouTube 等视频页面时还需要 `yt-dlp`。两者都可以通过对应的 path option 指定可执行文件，不会在安装包时下载二进制。按照当前 [yt-dlp EJS 安装说明](https://github.com/yt-dlp/yt-dlp/wiki/EJS)，完整 YouTube 支持还需要 `yt-dlp-ejs` 和受支持的 JavaScript runtime；Demo 推荐安装默认启用的 Deno 2.3+。
+
+`src` 可以是本地路径、`file:` URL 或 `http(s)` 视频链接。FFmpeg 先按 `maxFps` 降帧，再用 fast bilinear 缩放并 pad 到受控尺寸。Kitty / iTerm2 使用 PNG `image2pipe`，默认 12fps，自动像素尺寸会保持 cell 区域比例并限制在 640×360；普通 Unicode terminal 使用 `gray8` raw frame，最高 10fps，并映射为纯 ASCII 文本，不执行 PNG 压缩、base64 转换或图形 escape sequence。ASCII 路径按 terminal cell 约 1:2 的宽高比采样：每行请求约一半 cell 数的灰度样本，再将每个亮度 glyph 横向绘制两次，从而保持视频比例。帧泵只保留 latest frame，被覆盖的帧不会进入渲染阶段；连续重复帧也会在转换前去重。暂停、隐藏、离开 viewport、滚动期间和卸载都会 abort decoder；恢复时 adapter 使用最后一帧的近似时间戳继续 seek。
+
+开启 `controls` 后，点击视频画面会切换暂停/继续。`controlsLayout` 支持 `"compact" | "cinema"`，默认为 `"compact"`：`compact` 把播放/暂停、进度条和 1×/2×/3× 倍速放在底部 1 cell 的单行控制栏，`cinema` 使用底部 2 cells 的双行布局。鼠标可以拖动进度条；聚焦视频区域后可用 Enter 播放/暂停、Up/Down 切换倍速，CLI 下也支持 Space 和数字 1/2/3。进度拖动期间只更新预览并停止旧 decoder，松手后才按目标时间启动一次新 decoder；暂停状态 seek 只解码一帧作为预览。`paused` 和 `playbackRate` 不绑定时由组件内部维护，使用 `v-model:paused` / `v-model:playback-rate` 时则由父组件控制。
+
+可 seek 的进度条需要 `durationMs`，或由 frame source 在帧上提供 `durationMs`。`TVideoFrameSourceContext` 同时包含 `startAtMs`、`playbackRate` 和 `loop`；自定义 source 应据此定位媒体时间和控制播放速度。FFmpeg 在 2×/3× 时仍按墙钟限制到 `maxFps`，不会成倍增加 PNG/ASCII 转换；yt-dlp adapter 会短期复用已经成功解析的媒体直链，暂停、seek 和换速不会重复启动 yt-dlp。
+
+`TVideoFrameSourceContext.preferredFormat` 会请求 `png` 或 `gray8`，自定义 frame source 应按请求返回对应帧。Kitty 使用固定 image/placement id，并由 stdout renderer 在同一 terminal frame 内完成旧帧清理和新帧绘制；没有图形协议时自动显示动态 ASCII 视频，Sixel video encoder 尚未接入。普通 HTTP MP4 需要服务端支持 Range，或使用把 `moov` 放在文件头的 faststart 文件。
+
+```ts
+import { TVideo } from "@simon_he/vue-tui/experimental";
+import { createFfmpegVideoFrameSource } from "@simon_he/vue-tui/experimental/video/node";
+
+const videoFrames = createFfmpegVideoFrameSource();
+
+h(TVideo, {
+  x: 0,
+  y: 0,
+  w: 60,
+  h: 18,
+  src: "https://example.com/video.mp4",
+  frameSource: videoFrames,
+  maxFps: 12,
+  controls: true,
+  controlsLayout: "compact",
+  durationMs: 60_000,
+});
+```
+
+直播源应使用 `createFfmpegVideoFrameSource({ live: true })`，避免 FFmpeg 的 input readrate 对实时流产生丢包。adapter 只允许本地 `file` 或 `http(s)` 输入协议，且始终使用 `shell: false` 把 `src` 作为单独 argv 传递。
+
+YouTube `watch` URL 是网页而不是媒体流，不能直接交给 FFmpeg。`createYtDlpVideoFrameSource` 会先让 `yt-dlp` 解析一个 video-only HTTP(S) 流，再把临时 URL 和必要的 HTTP headers 交给同一 FFmpeg 管线。默认会根据 `TVideo` 的实际解码尺寸和 `maxFps` 自适应选择 source；常见终端区域通常选择 360p、至多 30fps 的源，再由 FFmpeg 降到最终 PNG/ASCII 尺寸和播放帧率。`maxSourceHeight` 只是可选上限。暂停、滚动或卸载时，解析进程与 FFmpeg 都会被终止。只应播放你有权访问和再利用的内容。
+
+```ts
+import { createYtDlpVideoFrameSource } from "@simon_he/vue-tui/experimental/video/node";
+
+const youtubeFrames = createYtDlpVideoFrameSource({
+  ytDlpPath: "yt-dlp",
+});
+
+h(TVideo, {
+  x: 0,
+  y: 0,
+  w: 60,
+  h: 18,
+  src: "https://www.youtube.com/watch?v=aqz-KE-bpKQ",
+  frameSource: youtubeFrames,
+  maxFps: 12,
+  controls: true,
+  controlsLayout: "cinema",
+});
+```
+
+`pnpm run showcase` 的 Video Tab 使用带 CC BY 3.0 署名的 Big Buck Bunny 短片和原生 `HTMLVideoElement + Canvas 2D`；`pnpm run showcase:terminal` 默认使用同一离线短片。准备好上面的 yt-dlp、EJS 和 runtime 后，可运行 `VUE_TUI_YOUTUBE_DEMO=1 pnpm run showcase:terminal`，直接解析 Blender 官方 YouTube 4K60 页面。三种路径都只在切入 Video Tab 后开始解码，离开 Tab 即取消并释放媒体资源。
+
+## TCommandPalette
+
+命令面板组件，组合 `TDialog`、`TInput` 和列表行渲染。默认按 `label` / `detail` / `keywords` 做 substring 过滤，也支持 `v-model:query`、custom matcher、async `itemsProvider`、group/separator 行和 `closeOnSelect`。`select` payload 包含 `{ item, index, sourceIndex, query, source }`，其中 `index` 是过滤/渲染后的 row index，`sourceIndex` 是原始 `items` 或 provider result index；默认选择命令不会自动关闭面板，宿主可在 `@select` 中更新 `v-model`，或显式开启 `closeOnSelect`。`itemsProvider` rejection 会渲染错误行并 emit `loadError`。
+
+```vue
+<TCommandPalette
+  v-model="paletteOpen"
+  :items="commands"
+  title="Command"
+  placeholder="Search commands"
+  @select="runCommand"
+/>
+```
+
+## TTable
+
+`TTable` 是多列静态表格，负责列宽、表头、可选边框和 row click。它只从 `rows` 顶部按当前高度取可见行，不内置 `scrollTop`、分页或 virtualization；大数据浏览应组合外部分页/offset，或使用 `TVirtualList` 一类窗口化视图。
+
+## TDataTable
+
+`TDataTable` 在 `TTable` 上增加受控排序、过滤、行选择和受控 viewport offset；点击表头会 emit `sortChange` / `update:sortBy` / `update:sortDirection`。`scrollTop` 表示过滤/排序后结果集里的顶部可见行。`rowSelect` payload 里的 `index` 是当前 viewport 内的 visible row index，`dataIndex` 是过滤/排序后结果集里的绝对 index，`originalIndex` 是输入 `rows` 数组里的 index。`rowKey` 函数收到的 `index` 是原始 rows index，排序/过滤后仍保持行 identity。列 `format(value, row, index)` 里的 `index` 也是原始 rows index，过滤和渲染阶段保持一致。列 `format` 会影响显示和过滤匹配，排序使用 `row[sortBy]` 的原始值。键盘移动的 active row 使用 `activeStyle`，已提交选择继续使用 `selectedStyle`。它仍然是 non-virtual：rows 会在内存中排序/过滤，然后只把当前 visible slice 传给 `TTable`。
+
+```vue
+<TDataTable
+  :x="0"
+  :y="0"
+  :w="80"
+  :h="12"
+  :columns="columns"
+  :rows="rows"
+  row-key="id"
+  sortable
+  filterable
+  selectable
+/>
+```
+
+## TContributionGraph
+
+贡献热力图组件，按列优先顺序把 `values` 映射到固定行数的 cell 网格。默认是 7 行、列间留 1 cell 间隔，适合 GitHub contributions 风格、agent token usage、每日/每轮计数密度这类紧凑历史视图。
+
+```vue
+<TContributionGraph :x="0" :y="0" :values="dailyTokens" :rows="7" />
+```
+
+## TLineChart
+
+单色终端折线图组件，把 `values` 采样到给定 `w`/`h` 区域内，用 box-drawing glyph 绘制阶梯折线。适合 token 总量、延迟、吞吐等小型 dashboard 曲线。
+
+```vue
+<TLineChart :x="0" :y="8" :w="40" :h="8" :values="tokenTotals" />
+```
+
+## TCandlestickChart
+
+K 线图组件，接收 `{ open, high, low, close }` 数组并在宽度不足时保留最新 candles。默认上涨为绿色、下跌为红色，可通过 `upStyle`、`downStyle`、`wickStyle` 覆盖。
+
+```vue
+<TCandlestickChart :x="0" :y="17" :w="50" :h="10" :candles="prices" />
+```
+
+## TPieChart
+
+终端饼图组件，按 `values` 从顶部开始顺时针分段，用 segment styles 给不同区域着色。适合展示 token 分类、状态占比或简单资源分布。
+
+```vue
+<TPieChart :x="44" :y="8" :w="16" :h="8" :values="[prompt, completion]" />
+```
+
+## TTree
+
+`TTree` 渲染层级节点，`expandedIds` 和 `selectedId` 都是受控状态。默认点击或 Space/Enter 可展开节点会 toggle；开启 `selectableParents` 后，点击 marker toggle，点击 label 或按 Enter select 父节点，Space 继续 toggle。
+
+## TCheckbox
+
+checkbox 控件，使用 `modelValue` / `update:modelValue`，Space / Enter / click 切换。
+
+## TRadioGroup
+
+radio group 控件，使用 `options` 和受控 `modelValue` 渲染单选列表。
+
+## TSwitch
+
+switch 控件，适合二元配置开关。
+
+## TSlider
+
+slider 控件，使用 `min` / `max` / `step` 和 ArrowLeft / ArrowRight 调整数值。
+
+## TFormField
+
+`TFormField` 统一 label、help、error、required、disabled 的展示边界，不内置验证系统。
+`style` 会作为 label、help、error 的基础样式；`disabled` 只让 label 变暗，slot 内容是否禁用由宿主组件控制。
+
+```vue
+<TFormField :x="0" :y="0" :w="44" :h="3" label="Token" help="Paste your API token" :error="error">
+  <TPasswordInput v-model="token" :x="0" :y="0" :w="40" />
+</TFormField>
+```
+
+## TPasswordInput
+
+`TPasswordInput` 是 `TInput secret` 的轻量包装，输入值仍由宿主通过 `v-model` 控制，渲染时隐藏明文。
+
+## TAutocompleteInput
+
+`TAutocompleteInput` 组合 `TInput` 和 suggestions 列表。静态 `suggestions` 保持宿主受控，也可以用 `suggestionProvider(query, { signal })` 走异步路径；provider rejection 会渲染错误行并 emit `loadError`。选择 suggestion 时 emit `update:modelValue`、`change` 和包含 `{ value, index, sourceIndex, option, query, source }` 的 `select`，不 emit `input`。
+
+## TForm
+
+Advanced 表单上下文组件，从 `@simon_he/vue-tui/vue` 引入。它提供 validation/error context：`model`、同步 `rules`、`submit`、`validation`，以及 `TFormField name` 对错误文本的读取。自定义字段可以通过 `/vue` 的 `useTForm()` 或 `TFormContextKey` 消费上下文。`validate()` 会在 submit 或宿主显式调用时更新 errors，不会在 `model` / `rules` 变化时自动重新校验。`TForm` 通过 template ref 暴露 `validate()`、`submit()`、`clearValidation()` 和 `setFieldError()`。`disabled` 会通过 form context 禁用当前已接入的内置表单控件（`TCheckbox`、`TSwitch`、`TRadioGroup`、`TSlider`）；`TInput`、`TPasswordInput`、`TAutocompleteInput` 仍需要宿主显式处理禁用语义。`readOnly` 目前只是通过 form context 提供给自定义字段消费者的提示，不会自动让后代输入控件只读。它不规定 schema 格式，也不拥有远程提交。
+
+## TContextMenu
+
+`TContextMenu` 是轻量菜单 overlay，基于现有 `TBox` / `TText` / `TView` 渲染。默认会在外部点击时关闭；如需保持 non-modal 行为，可设置 `closeOnOutside=false`。`x` / `y` / `w` 是 caller-owned placement，组件不会自动贴边 clamp 或 flip。它不会直接操作系统 clipboard 或浏览器窗口；菜单项动作通过 `select` 交给宿主处理。
+
+```vue
+<TContextMenu
+  v-model="open"
+  :x="cursor.x"
+  :y="cursor.y"
+  :items="[{ id: 'open', label: 'Open Link' }]"
+  @select="handleMenuSelect"
+/>
+```
+
+## TPopover
+
+`TPopover` 是带边框的轻量内容浮层，可以传 `content`，也可以用 default slot 自定义内容。`x` / `y` / `w` / `h` 是 caller-owned placement，组件不会自动贴边 clamp 或 flip。
+
+## TTooltip
+
+`TTooltip` 是单行提示文本，适合说明 unfamiliar controls 或链接打开条件。
+
+## TToastViewport
+
+Advanced toast 视口，从 `@simon_he/vue-tui/vue` 引入。它只渲染传入的 `items`，不会创建全局 singleton，也不会自己启动计时器；宿主负责 duration、dismiss 和队列状态。
+
+`placement` 基于当前 layout / clipRect 放置 toast stack；`offsetX` / `offsetY` 是相对所选角的 cell inset，因此组件可以放在 `TView`、`TBox` 或 split pane 子树里。`w` 是单个 toast item 的宽度；当父 layout 没有 clipRect 时，用 `viewportW` / `viewportH` 指定用于 placement 的 viewport 尺寸。
+
+## TProgress
+
+Advanced determinate progress，渲染 `value / max`、可选 label 和百分比。它不启动动画，适合 stdout/headless 快照。
+
+## TSpinner
+
+Advanced indeterminate spinner，通过 `frameIndex` 选择帧。组件不会无条件开启 interval；宿主按自己的 scheduler 或 tick 更新 `frameIndex`。
+
+## TStatusBar
+
+`TStatusBar` 用于 terminal app 的底部状态栏。它是纯渲染组件，不注册全局快捷键。
+
+```vue
+<TStatusBar :x="0" :y="23" :w="80" left="Ready" center="main" right="Ctrl+K" />
+```
+
+## TBreadcrumb
+
+`TBreadcrumb` 渲染路径导航，点击 item 只 emit `select`。
+
+```vue
+<TBreadcrumb :x="0" :y="0" :w="60" :items="pathSegments" @select="goToPath" />
+```
+
+## TKeyHint
+
+`TKeyHint` 渲染快捷键提示，不绑定或监听快捷键。
+
+```vue
+<TKeyHint :x="62" :y="0" combo="Esc" label="Close" />
+```
+
+## TTabs
+
+Advanced tab header，从 `@simon_he/vue-tui/vue` 引入。它只管理 header 选择和 `activeKey`，不拥有 pane 内容。
+
+## TSplitPane
+
+Advanced pane group，从 `@simon_he/vue-tui/vue` 引入。`sizes` 是受控的 cell size；空间不足时按 `minSizes` 压缩，空间有剩余时补到最后一个 pane。separator 支持键盘微调；default slot 接收 `{ panes }`，pane 内容由宿主按返回 rect 渲染。
+
+## Theme Tokens
+
+`createTheme()` 生成完整主题对象；`TerminalProvider.theme` 通常直接接收 partial overrides，例如 `{ colors: { link: "cyanBright" } }`，provider 会自行归一化。主题 token 只提供默认样式；组件局部传入的 `style`、`hoverStyle`、`focusStyle` 等 props 会覆盖主题。
+
+```ts
+const theme = createTheme({
+  colors: {
+    link: "cyanBright",
+    linkVisited: "magentaBright",
+    danger: "redBright",
+  },
+  components: {
+    TLink: {
+      underline: true,
+      hoverUnderline: true,
+    },
+  },
+});
+```
+
+## TAnchor
+
+类似 `TView`，但用「定位约束」描述矩形：`left/top/right/bottom/w/h`。用于做相对定位（例如贴右/贴底的浮层）。
+
+### Props
+
+- `left`/`top`/`right`/`bottom` `(number?)`
+- `w`/`h` `(number?)`
+- `zIndex` `(number)`
+- `focusable` `(boolean)`
+- `selectable` `(boolean?)`
+
+### Events
+
+`@click`/`@dblclick`/`@pointerdown`/`@pointerup`/`@pointermove`/`@wheel`/`@keydown`/`@keyup`/`@focus`/`@blur`
+
+> 同时支持对应的 `Capture` 版本（例如 `@clickCapture`）。
+>
+> 注：`TAnchor` 当前不提供 `@pointerenter/@pointerleave`（需要 hover 事件时请用 `TView`）。
+
+## TFlow
+
+按方向把 `items` 映射成若干子视口（每个子项一个 `TView`），用于列表式布局（更偏 layout 工具）。
+
+### Props
+
+- `x`/`y`/`w`/`h` `(number, required)`
+- `items` `(unknown[], required)`
+- `direction` `('vertical'|'horizontal')`（默认 `vertical`）
+- `gap` `(number)`：子项间隔（cell）
+- `itemSize` `(number)`：子项主轴尺寸（cell）
+- `zIndex` `(number)`
+
+### Slots
+
+- `item`: `({ item, index }) => VNode`
+
+## TFlex / TFlexItem
+
+用 Flexbox 风格约束声明 row/column 布局，最终仍生成 `TView` 子视口。适合 header/content/footer、左右栏和需要在 resize 后按 grow/shrink 重新分配 cell 的布局。
+
+`TFlexItem` 的 `width`/`height`、`w`/`h`、`basis`、`minWidth`/`minHeight`、`maxWidth`/`maxHeight` 支持 cell 数值或百分比字符串。百分比会先扣除 `TFlex` padding；main-axis 百分比再扣除 gap 后计算，cross-axis 百分比按 content box 交叉轴计算。
+
+`wrap` 会按 item 的显式主轴尺寸、`basis` 和 min/max 约束分行或分列；当前不读取 slot 内容固有尺寸。
+
+`rowGap`/`columnGap` 可覆盖 `gap` 在对应轴上的值。`alignContent` 只影响 wrap 后的多行/多列交叉轴分布。
+
+`paddingX`/`paddingY`/`paddingTop`/`paddingRight`/`paddingBottom`/`paddingLeft` 可覆盖 `padding`。`TFlexItem` 支持 `margin`、`marginX`/`marginY` 和四个方向的 margin；margin 参与主轴分配和 wrap 判断，最终子内容仍渲染在 margin 内侧。
+
+`TFlexItem.order` 控制视觉排列顺序；相同 order 的 item 保持原 slot 顺序。
+
+需要内容固有尺寸时，可以在 `TFlexItem.measure` 中返回 preferred `width`/`height`。`measure` 会收到扣除 padding 后的 `maxWidth`/`maxHeight` 和当前 `direction`，返回值会在没有显式尺寸或 `basis` 时参与布局。
+
+### Props
+
+- `TFlex`: `x`/`y`/`w`/`h`、`direction`、`gap`、`rowGap`、`columnGap`、`padding`、`paddingX`/`paddingY`、`paddingTop`/`paddingRight`/`paddingBottom`/`paddingLeft`、`wrap`、`alignItems`、`justifyContent`、`alignContent`、`zIndex`
+- `TFlexItem`: `grow`、`shrink`、`basis`、`width`/`height`、`w`/`h`、`minWidth`/`minHeight`、`maxWidth`/`maxHeight`、`measure`、`order`、`zIndex`、`margin`、`marginX`/`marginY`、`marginTop`/`marginRight`/`marginBottom`/`marginLeft`、`alignSelf`
+
+### Slots
+
+- `TFlexItem.default`: `({ rect }) => VNode`
+
+## TInput
+
+单行文本输入框（含光标、选择、剪贴板、IME 组合输入、快捷键），通过 `v-model` 管理值。
+
+### Props（常用）
+
+- `x`/`y`/`w` `(number, required)`
+- `h` `(number)`：高度（默认 `1`）
+- `modelValue` `(string)` + `update:modelValue`
+- `placeholder` `(string?)`
+- `placeholderWhenFocused` `(boolean)`：聚焦时是否显示 placeholder（默认 `false`）
+- `autoFocus` `(boolean)`
+- `cursorBlink` `(boolean)`
+- `cursorShape` `('block'|'underline'|'bar')`
+- `style` `(Style?)`
+- `secret` `(boolean)` / `maskChar` `(string)`：密码模式
+- `plugins` `(TInputPlugin[])`：输入增强插件（见下方）；init-only，修改后需重新挂载 `TInput`
+
+> `TInput` 功能较多，完整参数以源码为准：`src/vue/components/TInput.ts`。
+>
+> 跨宿主注意：`TInput` 本体已经开始把 terminal clipboard、TTY 判定、路径 href 这类宿主行为往 plugin 边界迁移。现在更推荐通过 `TerminalProvider.inputPlugins`、`createTerminalApp({ inputPlugins })` 或局部 `plugins` 注入宿主能力，而不是继续把平台差异写死到组件里。像 copy toast 这种 UI 反馈也应由宿主显式提供，不再依赖默认全局 hook。
+
+### Events（补充）
+
+- `input` / `change` / `keydown` / `focus` / `blur`
+- `update:mentions` / `mentionClick`：`collectMentions=true` 时（见 `createPromptMentionPlugin()`）
+- `update:multilineTexts` / `multilineClick`：多行 token 相关
+- `validationError`：文本过滤/校验插件上报
+
+## TInput Plugins
+
+用于扩展 `TInput` 的输入体验：通过 `:plugins="[...]"` 注入。插件列表是 init-only；如果需要切换宿主插件、path provider 或 prompt plugin，请重新挂载对应的 `TInput`。
+
+宿主级插件也可以统一从上层注入：
+
+- `TerminalProvider.inputPlugins`
+- `createTerminalApp({ inputPlugins })`
+- `createTerminalApp({ clipboard })`：只需要接入 clipboard 时的简化入口；传入 `inputPlugins` 时仍由宿主完全控制插件组合
+
+`TerminalProvider.inputPlugins` 也是 init-only；已经挂载的 `TInput` 不会重新安装插件列表。
+
+### `createTInputHostPlugin()`
+
+把宿主能力封装成 `TInput` 插件。适合注入：
+
+- `readClipboardText` / `writeClipboardText`
+- `showToast`
+- `resolvePath` / `pathToHref`
+- `isTerminalLike`
+
+`@simon_he/vue-tui` 导出 browser-safe 的 `createTInputHostPlugin()`。CLI 侧的 `defaultTInputHostPlugin` 和 `createDefaultTInputHostAdapter()` 从 `@simon_he/vue-tui/cli` 导出，负责 Node-like 的 clipboard / path 行为，不会自动附带 UI toast。如果宿主希望保留 `Copied` / `Copy failed` 这类提示，需要显式提供 `showToast`。
+
+`createOsc52ClipboardProvider()` 可作为 terminal clipboard 写入 provider 显式传给 `createTerminalApp({ clipboard })`。它不会默认执行系统剪贴板命令。
+
+一个最小宿主接线示例：
+
+```ts
+import { createTInputHostPlugin } from "@simon_he/vue-tui";
+import { createDefaultTInputHostAdapter } from "@simon_he/vue-tui/cli";
+import { createTerminalApp } from "@simon_he/vue-tui/cli";
+
+const baseHost = createDefaultTInputHostAdapter();
+
+const app = createTerminalApp({
+  cols: 80,
+  rows: 24,
+  component: App,
+  inputPlugins: [
+    createTInputHostPlugin({
+      ...baseHost,
+      showToast(message) {
+        toastStore.show(message);
+      },
+    }),
+  ],
+});
+```
+
+### `createPromptMentionPlugin()`
+
+提供 prompt/mention 的浮层补全：
+
+- prompt：基于 `promptSuggestions` + `promptTrigger`（默认 `/`）匹配并弹出列表
+- mention：基于 `mentionTrigger`（默认 `@`）匹配；配合 `collectMentions=true` 会把选择结果写入 `mentions`（通过 `update:mentions`）
+- mention 数据源既可以来自 `mentionSuggestions` / `mentionSuggestionProviders`，也可以通过 `mentionPathProvider` 注入路径补全能力
+- 如果宿主就是 Node / 本地文件系统语义，可以直接用 `createNodeMentionPathProvider()`
+- 键盘：`↑/↓` 选择，`Tab`/`Enter` 接受，`Esc` 关闭浮层
+
+### `createTextRestrictionPlugin({ rules })`
+
+注册输入过滤规则（allow/deny/replace/filter），用于限制字符集、替换非法字符或做整体校验。
+
+- 命中过滤/拒绝时会触发 `TInput` 的 `validationError` 事件（payload 含 `originalText/acceptedText` 等）
+
+### `TInputPluginsContextKey`
+
+高级宿主如果希望按子树组合/覆盖输入插件，可以直接用公开导出的 `TInputPluginsContextKey` 做 `provide/inject`。
+
+- 适合像 reference app 那样，在某个页面根节点统一补一个局部 host plugin
+- 比起给每个 `TInput` 单独传 `plugins`，更适合做“页面级宿主接线”
+
+## TInputBox
+
+带边框的输入框组合组件（内部是 `TBox` + `TInput`）。
+
+### Props（常用）
+
+- `x`/`y`/`w`/`h` `(number, required)`
+- `modelValue` `(string)` + `update:modelValue`
+- `title` `(string?)`
+- `placeholder` `(string?)`
+- `autoFocus` `(boolean)`
+- `plugins` `(TInputPlugin[])`
+
+## TList
+
+可滚动列表（单选）：支持点击/双击、键盘导航、滚轮滚动，`v-model` 维护选中 index。
+
+`TList` 适合小数据选择器。大数据选择/浏览场景请使用 `TVirtualList`，日志、streaming transcript、append-only output 场景请使用 experimental `TLogView`，避免把大数组直接传进 Vue deep reactivity。
+
+> Limitation: TList wheel optimization coalesces bursts and repaints viewport rows; it does not reuse shifted rows or repaint only exposed rows. Large datasets should use `TVirtualList` / `TLogView`.
+
+### Props
+
+- `x`/`y`/`w`/`h` `(number, required)`
+- `items` `(string[], required)`
+- `itemVersion` `(number)`：同长度内容更新时可递增，触发 repaint
+- `modelValue` `(number)` + `update:modelValue`
+- `style` `(Style?)`
+- `autoFocus` `(boolean)`
+- `closeOnBlur` `(boolean)`
+
+### Events
+
+- `change`: `{ index, value }`
+- `scroll`: `scrollTop`（number）
+- `close` / `focus` / `blur` / `keydown`
+
+### Wheel scrolling and selection
+
+Behavior change for the wheel-mailbox release:
+
+- `TList` wheel is viewport-only.
+- `TList` wheel no longer updates `modelValue`.
+- `TList` wheel no longer moves the active selection.
+- `TList` wheel burst applies only the final `scrollTop` in the next frame and
+  emits `scroll` at most once per frame.
+- `TList` treats `update:modelValue` as selection-change, not selection-confirm.
+- Enter and double click emit `change`; they do not emit `update:modelValue`
+  when committing the already-active item.
+- Keyboard-driven and external-model-driven viewport changes no longer emit
+  `scroll`.
+- `TList` `scroll` now represents viewport-driven scroll changes, especially
+  wheel scrolling and programmatic clamp.
+- `onScroll` is a result notification, not a veto/cancel hook.
+- Same-length item text changes require replacing the `items` array reference or
+  bumping `itemVersion`.
+
+`TList` treats wheel scrolling as viewport-only. Wheel scrolling emits `scroll`,
+but it does not update `modelValue` and does not move the active selection.
+Keyboard navigation, click, double click, and Enter reattach selection to the
+visible viewport.
+Each applied `TList` wheel scroll still repaints the visible viewport; exposed
+row-only slow scrolling remains a `TVirtualList` / `TLogView` / renderer follow-up.
+If existing code depended on wheel scrolling to update `modelValue`, listen to
+`scroll` instead. If selection should follow scroll, synchronize that explicitly
+from `onScroll`; `onScroll` is a result notification, not a veto/cancel hook.
+
+Migration example:
+
+```vue
+<TList
+  :items="items"
+  :model-value="selectedIndex"
+  @update:model-value="selectedIndex = $event"
+  @scroll="viewportTop = $event"
+  @change="confirmItem"
+/>
+```
+
+Before this release, wheel scrolling could move `selectedIndex`. After this
+release, wheel scrolling only updates `viewportTop`; keyboard navigation and
+click still update `selectedIndex`, while Enter and double click call
+`confirmItem`.
+
+`TList` uses the same full-rect clipping model as `TText`/`TVirtualList`: when
+the list is clipped from the top or left, paint and hit testing keep the source
+row/column offset instead of rebasing the clipped area to a new viewport origin.
+x/y/w/h are cell coordinates. Fractional geometry is normalized by flooring the
+start and end cell edges; pass integers for deterministic layout.
+When changing styles, replace the style object instead of mutating it in place.
+Replace the `items` array reference when item text changes without changing
+length, or bump `itemVersion`. For large mutable data sources, prefer
+`TVirtualList` with `itemVersion`.
+
+`scroll(top)` represents viewport-driven scroll changes, not every internal
+viewport-top mutation.
+
+`scroll(top)` is emitted when:
+
+- wheel scrolling changes the viewport top
+- item-count or clipped-viewport changes programmatically clamp the viewport top
+
+Hidden `v-show=false` lists still emit `scroll(top)` when item-count changes
+force a real internal `scrollTop` clamp, but they do not dirty terminal rows or
+commit visible output. A fully clipped viewport keeps detached `scrollTop`
+without clamping to `0` until a finite viewport height is restored. If a wheel
+frame is still pending when the viewport becomes hidden or fully clipped, that
+pending wheel is canceled and does not emit `scroll`.
+
+`scroll(top)` is not emitted when:
+
+- keyboard selection calls `ensureActiveVisible()`
+- external `modelValue` synchronization calls `ensureActiveVisible()`
+- click / double click selection calls `ensureActiveVisible()`
+
+Terminal-level DOM wheel handling may still prevent browser page scrolling even
+when `TList` itself does not consume an edge wheel event. Handler-level
+`preventDefault()` here only describes whether the list consumes the wheel
+internally.
+
+### Selection event semantics
+
+`TList` treats `update:modelValue` as a selection-change event, not a
+selection-confirm event.
+
+- Arrow / Home / End / PageUp / PageDown emit `update:modelValue` only when the
+  active index changes.
+- Click emits `update:modelValue` only when the clicked index differs from the
+  current active index.
+- Enter and double click emit `change`.
+- Enter and double click do not emit `update:modelValue` when they commit the
+  already-active index.
+
+`scroll` is emitted synchronously after internal viewport state changes. If an
+`onScroll` handler synchronously mutates `modelValue` or replaces `items`,
+`TList` may render the viewport change first and reconcile controlled props on
+the next Vue tick; `onScroll` is not a synchronous veto point for wheel
+scrolling.
+
+Mutating `style` in place does not schedule repaint by itself. Replace the
+style object, or rely on a later repaint-triggering interaction if you choose
+to mutate it in place. Derived active/dim style caching only applies to stable
+frozen style objects and the internal empty-style cache; mutable non-empty
+style objects favor correctness over allocation reuse.
+
+Detached wheel state is reattached only when selection changes, external
+`modelValue` changes, click/double-click/Enter/keyboard navigation happens, or
+data/geometry clamps require it. A parent re-render with the same `modelValue`
+does not reset the viewport. Reattaching detached state by itself does not
+request repaint; repaint only happens when active rows or `scrollTop` change.
+
+## TVirtualList
+
+大数据选择/浏览列表：使用 `itemCount` / `itemVersion` / `getItem` 从外部数据源读取可见行，避免把大数组本体放进 Vue deep reactivity。它不是日志/streaming 组件；append-only 输出请使用 `TLogView`。
+
+> Phase 1 experimental API：当前从 `@simon_he/vue-tui/experimental` 导出，暂不进入 root 入口。API 仍可能在 overscan、TLogView 等后续能力落地前调整。
+
+### Props
+
+- `x`/`y`/`w`/`h` `(number, required)`
+- `itemCount` `(number, required)`
+- `itemVersion` `(number, required)`：数据变更版本号
+- `getItem` `((index: number) => unknown, required)`
+- `renderItem` `((item, index) => unknown)`
+- `modelValue` `(number)` + `update:modelValue`
+- `scrollTop` `(number?)` + `update:scrollTop`：受控 viewport scrollTop；省略时由组件内部维护
+- `style` / `activeStyle` `(Style?)`
+- `autoFocus` `(boolean)`
+- `rowScrollMode` `("off" | "unsafe-full-row")`：实验性 unsafe wheel 优化；当前 `TVirtualList` 仅在 terminal/headless（非 DOM rows）路径、组件占满整行、未被裁剪、renderer 支持 `scrollOperations`、且调用方确认组件独占这些 plane rows 时使用 exposed-row row-scroll；DOM 路径仍保持 viewport repaint，否则保持默认 `"off"`
+
+### Data source
+
+`getItem` 和 `renderItem` 应保持稳定引用，数据变化用 `itemVersion` 通知组件。`style` / `activeStyle` 对象也应按 immutable 方式使用；样式变化时替换对象 identity。
+
+```ts
+const items = markRaw(bigArray);
+const itemVersion = ref(0);
+const getItem = (index: number) => items[index];
+const renderItem = (item: Row) => item.title;
+```
+
+避免在模板里传 inline function：
+
+```vue
+<TVirtualList :get-item="(index) => items[index]" />
+```
+
+### Wheel Scroll
+
+Wheel burst 通过 frame mailbox 合并；同一帧只应用最后的 `scrollTop`。滚动 repaint 只调用 `markDirtyRows(viewportRows)`，dirty rows 不超过可见 viewport 高度，也不会走 exposed-row fast path 或提交 `scrollOperations`。组件 hidden、fully clipped、unmount 或受控 `scrollTop` 在 RAF 前变化时，会取消 pending wheel，不会让旧 wheel 覆盖新的受控位置。
+
+### Selection model
+
+`modelValue` 使用 optimistic controlled 语义：键盘和点击会先更新组件内部 active row 并 emit `update:modelValue`。如果父组件稍后接受、延迟应用或改成其它 `modelValue`，组件会在 prop 同步时跟随；如果父组件完全忽略 update，组件会保留本地 optimistic active state。
+
+### Events
+
+- `change`: `{ index, value }`
+- `update:scrollTop`: `scrollTop`（number）
+- `scroll`: `scrollTop`（number）
+- `focus` / `blur` / `keydown`
+
+## TTranscriptView
+
+Transcript row viewport：渲染 message / action / tool-call / approval rows，支持 row-scoped action/link hit regions、focus navigation、cell selection copy 和 wrapped visual rows。
+
+> Experimental prototype：当前从 `@simon_he/vue-tui/experimental` 导出，暂不进入 root 入口。它会在当前 layout state 中 flatten source rows 到 visual rows；适合小到中等 transcript 和交互原型，建议控制在 few thousand visual rows 量级，不适合作为几十万 visual rows 的高吞吐 retained transcript 视图。大规模 append-only output 继续使用 `TLogView`。
+
+### Props
+
+- `x`/`y`/`w`/`h` `(number, required)`
+- `source` `(TTranscriptDataSource, required)`：提供 `rowCount()`、`getRow(index)`，可选提供 `getRowKey(index)`、`getRowVersion(index)`、`firstRowIndex()`
+- `version` `(number, required)`：数据变化版本号
+- `scrollTop` `(number?)` + `update:scrollTop`
+- `defaultScrollTop` `(number?)`
+- `autoStickToBottom` `(boolean)`
+- `selectable` `(boolean)`
+- `wrap` `(boolean)`
+- `style` / `hoverStyle` / `focusStyle` `(Style?)`
+- `autoFocus` / `focusable` / `wheelScroll` `(boolean)`
+- `keyboardRegions` `(boolean)`：默认 `true`，获得焦点时 `Tab` / `Shift+Tab` 在当前 viewport 的 hit regions 间循环 focus，`Enter` 激活 focused region，`Escape` 清除 focus
+
+### Events
+
+- `actionClick` / `linkClick` / `foldToggle` / `toolClick`: `{ region, row, rowIndex, absoluteRowIndex, event }`
+- `rowClick`: `{ row, rowIndex, absoluteRowIndex, event }`
+- `hoverRegion`: region event or `null`
+- `scroll`: scroll metrics
+- `update:scrollTop`: `scrollTop`（number）
+
+`TTranscriptSegment.text` 是 inline-only 文本；显式 `\n` / `\r` / `\t` 会按 inline cell 文本规整。需要保留显式换行时，请在 source 层拆成多个 transcript rows，或拆成独立 visual row blocks。
+
+## TMarkdownText
+
+Markdown renderer for static or streaming text content。它走独立的 `parser -> block -> visual row -> paint` 链路，不会把 Markdown AST 直接交给 `TText`。
+
+> Markdown import: `@simon_he/vue-tui/markdown`
+>
+ 行内公式在图形终端混排进文字行（≤2 行高），超高公式（矩阵等）与无图形环境保持原始文本，格式错误的公式也会回退为原始文本。需要安装可选 peer `mathjax-full` + `@resvg/resvg-js` 才会启用图片路径。详见 [Markdown 数学公式渲染](/guide/markdown-math)。
 >
 > `content` string 路径仍然只做 **per-frame coalescing**：一帧内多次 append 会合并成一次 rebuild，但 rebuild 本身仍然会从当前 full markdown string parse。长文档 streaming transcript 场景可以使用 `createMarkdownBlockSource()`，在消息、tool fence 或代码块完成时 `finalizeBlock()`，再把 `blocks` 传给 `TVirtualMarkdown`，避免反复重 parse 已 finalize 的历史。
 

--- a/docs/generated/api-manifest.json
+++ b/docs/generated/api-manifest.json
@@ -673,11 +673,19 @@
         "TVirtualMarkdown",
         "buildMarkdownBlocks",
         "buildMarkdownVisualRows",
+        "clearMarkdownMathImageCache",
         "createMarkdownBlockSource",
         "createTuiMarkdownParser",
+        "enqueueMarkdownMathImages",
+        "getCachedMarkdownMathImage",
+        "getMarkdownMathImage",
+        "isMarkdownMathImageRendererReady",
         "isSafeMarkdownLink",
         "layoutMarkdownBlocks",
-        "loadMarkdownMathRenderer"
+        "loadMarkdownMathImageRenderer",
+        "loadMarkdownMathRenderer",
+        "setMarkdownMathRasterizer",
+        "subscribeMarkdownMathImage"
       ],
       "typeExports": [
         "TuiMarkdownBlock",
@@ -693,6 +701,11 @@
         "TuiMarkdownLayoutOptions",
         "TuiMarkdownLinkActionPayload",
         "TuiMarkdownMathActionPayload",
+        "TuiMarkdownMathImageCells",
+        "TuiMarkdownMathImageOptions",
+        "TuiMarkdownMathMode",
+        "TuiMarkdownMathOptions",
+        "TuiMarkdownMathRasterizer",
         "TuiMarkdownMathSegment",
         "TuiMarkdownNode",
         "TuiMarkdownParseConfig",
@@ -6835,6 +6848,62 @@
           "descriptionSource": "component-default"
         },
         {
+          "name": "mathImages",
+          "type": "boolean",
+          "required": false,
+          "defaultValue": "true",
+          "description": "Renders markdown math as terminal graphics images when the terminal supports it.",
+          "descriptionSource": "component-default"
+        },
+        {
+          "name": "mathCellWidthPx",
+          "type": "number",
+          "required": false,
+          "defaultValue": "undefined",
+          "description": "Terminal cell width in pixels used to map rendered formulas to cells.",
+          "descriptionSource": "component-default"
+        },
+        {
+          "name": "mathCellHeightPx",
+          "type": "number",
+          "required": false,
+          "defaultValue": "undefined",
+          "description": "Terminal cell height in pixels used to map rendered formulas to cells.",
+          "descriptionSource": "component-default"
+        },
+        {
+          "name": "mathScale",
+          "type": "number",
+          "required": false,
+          "defaultValue": "undefined",
+          "description": "Rasterization DPI scale for rendered formulas (does not change cell size).",
+          "descriptionSource": "component-default"
+        },
+        {
+          "name": "mathColor",
+          "type": "string",
+          "required": false,
+          "defaultValue": "undefined",
+          "description": "Hex color used for rendered formula glyphs; defaults to the text foreground.",
+          "descriptionSource": "component-default"
+        },
+        {
+          "name": "mathMaxWidthCells",
+          "type": "number",
+          "required": false,
+          "defaultValue": "undefined",
+          "description": "Maximum width in terminal cells for block-level formulas before they are scaled down.",
+          "descriptionSource": "component-default"
+        },
+        {
+          "name": "mathBaselineRatio",
+          "type": "number",
+          "required": false,
+          "defaultValue": "undefined",
+          "description": "Inline formula baseline position as a fraction of cell height, used to align formulas with text.",
+          "descriptionSource": "component-default"
+        },
+        {
           "name": "imageActions",
           "type": "boolean",
           "required": false,
@@ -10830,6 +10899,62 @@
           "required": false,
           "defaultValue": "true",
           "description": "Preserves markdown image aspect ratio while fitting width and height bounds.",
+          "descriptionSource": "component-default"
+        },
+        {
+          "name": "mathImages",
+          "type": "boolean",
+          "required": false,
+          "defaultValue": "true",
+          "description": "Renders markdown math as terminal graphics images when the terminal supports it.",
+          "descriptionSource": "component-default"
+        },
+        {
+          "name": "mathCellWidthPx",
+          "type": "number",
+          "required": false,
+          "defaultValue": "undefined",
+          "description": "Terminal cell width in pixels used to map rendered formulas to cells.",
+          "descriptionSource": "component-default"
+        },
+        {
+          "name": "mathCellHeightPx",
+          "type": "number",
+          "required": false,
+          "defaultValue": "undefined",
+          "description": "Terminal cell height in pixels used to map rendered formulas to cells.",
+          "descriptionSource": "component-default"
+        },
+        {
+          "name": "mathScale",
+          "type": "number",
+          "required": false,
+          "defaultValue": "undefined",
+          "description": "Rasterization DPI scale for rendered formulas (does not change cell size).",
+          "descriptionSource": "component-default"
+        },
+        {
+          "name": "mathColor",
+          "type": "string",
+          "required": false,
+          "defaultValue": "undefined",
+          "description": "Hex color used for rendered formula glyphs; defaults to the text foreground.",
+          "descriptionSource": "component-default"
+        },
+        {
+          "name": "mathMaxWidthCells",
+          "type": "number",
+          "required": false,
+          "defaultValue": "undefined",
+          "description": "Maximum width in terminal cells for block-level formulas before they are scaled down.",
+          "descriptionSource": "component-default"
+        },
+        {
+          "name": "mathBaselineRatio",
+          "type": "number",
+          "required": false,
+          "defaultValue": "undefined",
+          "description": "Inline formula baseline position as a fraction of cell height, used to align formulas with text.",
           "descriptionSource": "component-default"
         },
         {

--- a/docs/generated/components-api.md
+++ b/docs/generated/components-api.md
@@ -1703,30 +1703,37 @@ Import: `@simon_he/vue-tui/markdown`
 
 ### Props
 
-| 名称                                  | 类型                                   | 默认值                 | 必填 | 说明                                                                                         |
-| ------------------------------------- | -------------------------------------- | ---------------------- | ---- | -------------------------------------------------------------------------------------------- |
-| <code>x</code>                        | <code>number</code>                    | —                      | 是   | Left position in terminal cells.                                                             |
-| <code>y</code>                        | <code>number</code>                    | —                      | 是   | Top position in terminal cells.                                                              |
-| <code>zIndex</code>                   | <code>number</code>                    | <code>0</code>         | 否   | Render and event ordering within the current plane.                                          |
-| <code>content</code>                  | <code>string</code>                    | —                      | 是   | Markdown source rendered into terminal visual rows.                                          |
-| <code>w</code>                        | <code>number</code>                    | —                      | 是   | Width in terminal cells.                                                                     |
-| <code>h</code>                        | <code>number</code>                    | <code>undefined</code> | 否   | Height in terminal cells.                                                                    |
-| <code>style</code>                    | <code>Style</code>                     | <code>undefined</code> | 否   | Base terminal cell style override.                                                           |
-| <code>final</code>                    | <code>boolean</code>                   | <code>true</code>      | 否   | Parses the markdown as a complete document when enabled.                                     |
-| <code>streaming</code>                | <code>boolean</code>                   | <code>false</code>     | 否   | Coalesces rapid content updates into frame-scheduled markdown rebuilds.                      |
-| <code>clear</code>                    | <code>boolean</code>                   | <code>true</code>      | 否   | Clears the component rectangle before drawing content.                                       |
-| <code>customHtmlTags</code>           | <code>readonly string[]</code>         | <code>undefined</code> | 否   | Additional HTML tag names accepted by the markdown parser.                                   |
-| <code>theme</code>                    | <code>TuiMarkdownThemeOverrides</code> | <code>undefined</code> | 否   | Markdown theme token overrides for parsed blocks and inline segments.                        |
-| <code>imageRenderer</code>            | <code>TuiMarkdownImageResolver</code>  | <code>undefined</code> | 否   | Optional resolver for markdown image payloads before terminal graphics rendering.            |
-| <code>imageMinWidth</code>            | <code>number</code>                    | <code>undefined</code> | 否   | Minimum markdown image render width in terminal cells.                                       |
-| <code>imageMaxWidth</code>            | <code>number</code>                    | <code>undefined</code> | 否   | Maximum markdown image render width in terminal cells.                                       |
-| <code>imageMinHeight</code>           | <code>number</code>                    | <code>undefined</code> | 否   | Minimum markdown image render height in terminal cells.                                      |
-| <code>imageMaxHeight</code>           | <code>number</code>                    | <code>undefined</code> | 否   | Maximum markdown image render height in terminal cells.                                      |
-| <code>imagePreserveAspectRatio</code> | <code>boolean</code>                   | <code>true</code>      | 否   | Preserves markdown image aspect ratio while fitting width and height bounds.                 |
-| <code>imageActions</code>             | <code>boolean</code>                   | <code>false</code>     | 否   | Enables pointer actions for rendered markdown images.                                        |
-| <code>mathActions</code>              | <code>boolean</code>                   | <code>false</code>     | 否   | Enables pointer actions for rendered or raw markdown math syntax.                            |
-| <code>linkActions</code>              | <code>boolean</code>                   | <code>false</code>     | 否   | Enables pointer actions for rendered markdown links.                                         |
-| <code>imageOcclusionRects</code>      | <code>readonly Rect[]</code>           | <code>undefined</code> | 否   | Terminal rectangles that markdown image layout treats as unavailable for graphics placement. |
+| 名称                                  | 类型                                   | 默认值                 | 必填 | 说明                                                                                             |
+| ------------------------------------- | -------------------------------------- | ---------------------- | ---- | ------------------------------------------------------------------------------------------------ |
+| <code>x</code>                        | <code>number</code>                    | —                      | 是   | Left position in terminal cells.                                                                 |
+| <code>y</code>                        | <code>number</code>                    | —                      | 是   | Top position in terminal cells.                                                                  |
+| <code>zIndex</code>                   | <code>number</code>                    | <code>0</code>         | 否   | Render and event ordering within the current plane.                                              |
+| <code>content</code>                  | <code>string</code>                    | —                      | 是   | Markdown source rendered into terminal visual rows.                                              |
+| <code>w</code>                        | <code>number</code>                    | —                      | 是   | Width in terminal cells.                                                                         |
+| <code>h</code>                        | <code>number</code>                    | <code>undefined</code> | 否   | Height in terminal cells.                                                                        |
+| <code>style</code>                    | <code>Style</code>                     | <code>undefined</code> | 否   | Base terminal cell style override.                                                               |
+| <code>final</code>                    | <code>boolean</code>                   | <code>true</code>      | 否   | Parses the markdown as a complete document when enabled.                                         |
+| <code>streaming</code>                | <code>boolean</code>                   | <code>false</code>     | 否   | Coalesces rapid content updates into frame-scheduled markdown rebuilds.                          |
+| <code>clear</code>                    | <code>boolean</code>                   | <code>true</code>      | 否   | Clears the component rectangle before drawing content.                                           |
+| <code>customHtmlTags</code>           | <code>readonly string[]</code>         | <code>undefined</code> | 否   | Additional HTML tag names accepted by the markdown parser.                                       |
+| <code>theme</code>                    | <code>TuiMarkdownThemeOverrides</code> | <code>undefined</code> | 否   | Markdown theme token overrides for parsed blocks and inline segments.                            |
+| <code>imageRenderer</code>            | <code>TuiMarkdownImageResolver</code>  | <code>undefined</code> | 否   | Optional resolver for markdown image payloads before terminal graphics rendering.                |
+| <code>imageMinWidth</code>            | <code>number</code>                    | <code>undefined</code> | 否   | Minimum markdown image render width in terminal cells.                                           |
+| <code>imageMaxWidth</code>            | <code>number</code>                    | <code>undefined</code> | 否   | Maximum markdown image render width in terminal cells.                                           |
+| <code>imageMinHeight</code>           | <code>number</code>                    | <code>undefined</code> | 否   | Minimum markdown image render height in terminal cells.                                          |
+| <code>imageMaxHeight</code>           | <code>number</code>                    | <code>undefined</code> | 否   | Maximum markdown image render height in terminal cells.                                          |
+| <code>imagePreserveAspectRatio</code> | <code>boolean</code>                   | <code>true</code>      | 否   | Preserves markdown image aspect ratio while fitting width and height bounds.                     |
+| <code>mathImages</code>               | <code>boolean</code>                   | <code>true</code>      | 否   | Renders markdown math as terminal graphics images when the terminal supports it.                 |
+| <code>mathCellWidthPx</code>          | <code>number</code>                    | <code>undefined</code> | 否   | Terminal cell width in pixels used to map rendered formulas to cells.                            |
+| <code>mathCellHeightPx</code>         | <code>number</code>                    | <code>undefined</code> | 否   | Terminal cell height in pixels used to map rendered formulas to cells.                           |
+| <code>mathScale</code>                | <code>number</code>                    | <code>undefined</code> | 否   | Rasterization DPI scale for rendered formulas (does not change cell size).                       |
+| <code>mathColor</code>                | <code>string</code>                    | <code>undefined</code> | 否   | Hex color used for rendered formula glyphs; defaults to the text foreground.                     |
+| <code>mathMaxWidthCells</code>        | <code>number</code>                    | <code>undefined</code> | 否   | Maximum width in terminal cells for block-level formulas before they are scaled down.            |
+| <code>mathBaselineRatio</code>        | <code>number</code>                    | <code>undefined</code> | 否   | Inline formula baseline position as a fraction of cell height, used to align formulas with text. |
+| <code>imageActions</code>             | <code>boolean</code>                   | <code>false</code>     | 否   | Enables pointer actions for rendered markdown images.                                            |
+| <code>mathActions</code>              | <code>boolean</code>                   | <code>false</code>     | 否   | Enables pointer actions for rendered or raw markdown math syntax.                                |
+| <code>linkActions</code>              | <code>boolean</code>                   | <code>false</code>     | 否   | Enables pointer actions for rendered markdown links.                                             |
+| <code>imageOcclusionRects</code>      | <code>readonly Rect[]</code>           | <code>undefined</code> | 否   | Terminal rectangles that markdown image layout treats as unavailable for graphics placement.     |
 
 ### Events
 
@@ -2931,33 +2938,40 @@ Import: `@simon_he/vue-tui/markdown`
 
 ### Props
 
-| 名称                                  | 类型                                     | 默认值                    | 必填 | 说明                                                                                         |
-| ------------------------------------- | ---------------------------------------- | ------------------------- | ---- | -------------------------------------------------------------------------------------------- |
-| <code>x</code>                        | <code>number</code>                      | —                         | 是   | Left position in terminal cells.                                                             |
-| <code>y</code>                        | <code>number</code>                      | —                         | 是   | Top position in terminal cells.                                                              |
-| <code>w</code>                        | <code>number</code>                      | —                         | 是   | Width in terminal cells.                                                                     |
-| <code>h</code>                        | <code>number</code>                      | —                         | 是   | Height in terminal cells.                                                                    |
-| <code>zIndex</code>                   | <code>number</code>                      | <code>0</code>            | 否   | Render and event ordering within the current plane.                                          |
-| <code>content</code>                  | <code>string</code>                      | <code>&quot;&quot;</code> | 否   | Markdown source rendered when external blocks are not provided.                              |
-| <code>blocks</code>                   | <code>readonly TuiMarkdownBlock[]</code> | <code>undefined</code>    | 否   | Prebuilt markdown blocks used instead of parsing content.                                    |
-| <code>scrollTop</code>                | <code>number</code>                      | <code>0</code>            | 否   | Controlled top visual-row offset within the markdown viewport.                               |
-| <code>style</code>                    | <code>Style</code>                       | <code>undefined</code>    | 否   | Base terminal cell style override.                                                           |
-| <code>final</code>                    | <code>boolean</code>                     | <code>true</code>         | 否   | Parses the markdown as a complete document when enabled.                                     |
-| <code>streaming</code>                | <code>boolean</code>                     | <code>false</code>        | 否   | Coalesces rapid content updates into frame-scheduled markdown rebuilds.                      |
-| <code>autoFocus</code>                | <code>boolean</code>                     | <code>false</code>        | 否   | Requests focus when the component becomes visible.                                           |
-| <code>selectable</code>               | <code>boolean</code>                     | <code>true</code>         | 否   | Controls whether native terminal text selection may start inside the markdown viewport.      |
-| <code>customHtmlTags</code>           | <code>readonly string[]</code>           | <code>undefined</code>    | 否   | Additional HTML tag names accepted by the markdown parser.                                   |
-| <code>theme</code>                    | <code>TuiMarkdownThemeOverrides</code>   | <code>undefined</code>    | 否   | Markdown theme token overrides for parsed blocks and inline segments.                        |
-| <code>imageRenderer</code>            | <code>TuiMarkdownImageResolver</code>    | <code>undefined</code>    | 否   | Optional resolver for markdown image payloads before terminal graphics rendering.            |
-| <code>imageMinWidth</code>            | <code>number</code>                      | <code>undefined</code>    | 否   | Minimum markdown image render width in terminal cells.                                       |
-| <code>imageMaxWidth</code>            | <code>number</code>                      | <code>undefined</code>    | 否   | Maximum markdown image render width in terminal cells.                                       |
-| <code>imageMinHeight</code>           | <code>number</code>                      | <code>undefined</code>    | 否   | Minimum markdown image render height in terminal cells.                                      |
-| <code>imageMaxHeight</code>           | <code>number</code>                      | <code>undefined</code>    | 否   | Maximum markdown image render height in terminal cells.                                      |
-| <code>imagePreserveAspectRatio</code> | <code>boolean</code>                     | <code>true</code>         | 否   | Preserves markdown image aspect ratio while fitting width and height bounds.                 |
-| <code>imageActions</code>             | <code>boolean</code>                     | <code>false</code>        | 否   | Enables pointer actions for rendered markdown images.                                        |
-| <code>mathActions</code>              | <code>boolean</code>                     | <code>false</code>        | 否   | Enables pointer actions for rendered or raw markdown math syntax.                            |
-| <code>linkActions</code>              | <code>boolean</code>                     | <code>false</code>        | 否   | Enables pointer actions for rendered markdown links.                                         |
-| <code>imageOcclusionRects</code>      | <code>readonly Rect[]</code>             | <code>undefined</code>    | 否   | Terminal rectangles that markdown image layout treats as unavailable for graphics placement. |
+| 名称                                  | 类型                                     | 默认值                    | 必填 | 说明                                                                                             |
+| ------------------------------------- | ---------------------------------------- | ------------------------- | ---- | ------------------------------------------------------------------------------------------------ |
+| <code>x</code>                        | <code>number</code>                      | —                         | 是   | Left position in terminal cells.                                                                 |
+| <code>y</code>                        | <code>number</code>                      | —                         | 是   | Top position in terminal cells.                                                                  |
+| <code>w</code>                        | <code>number</code>                      | —                         | 是   | Width in terminal cells.                                                                         |
+| <code>h</code>                        | <code>number</code>                      | —                         | 是   | Height in terminal cells.                                                                        |
+| <code>zIndex</code>                   | <code>number</code>                      | <code>0</code>            | 否   | Render and event ordering within the current plane.                                              |
+| <code>content</code>                  | <code>string</code>                      | <code>&quot;&quot;</code> | 否   | Markdown source rendered when external blocks are not provided.                                  |
+| <code>blocks</code>                   | <code>readonly TuiMarkdownBlock[]</code> | <code>undefined</code>    | 否   | Prebuilt markdown blocks used instead of parsing content.                                        |
+| <code>scrollTop</code>                | <code>number</code>                      | <code>0</code>            | 否   | Controlled top visual-row offset within the markdown viewport.                                   |
+| <code>style</code>                    | <code>Style</code>                       | <code>undefined</code>    | 否   | Base terminal cell style override.                                                               |
+| <code>final</code>                    | <code>boolean</code>                     | <code>true</code>         | 否   | Parses the markdown as a complete document when enabled.                                         |
+| <code>streaming</code>                | <code>boolean</code>                     | <code>false</code>        | 否   | Coalesces rapid content updates into frame-scheduled markdown rebuilds.                          |
+| <code>autoFocus</code>                | <code>boolean</code>                     | <code>false</code>        | 否   | Requests focus when the component becomes visible.                                               |
+| <code>selectable</code>               | <code>boolean</code>                     | <code>true</code>         | 否   | Controls whether native terminal text selection may start inside the markdown viewport.          |
+| <code>customHtmlTags</code>           | <code>readonly string[]</code>           | <code>undefined</code>    | 否   | Additional HTML tag names accepted by the markdown parser.                                       |
+| <code>theme</code>                    | <code>TuiMarkdownThemeOverrides</code>   | <code>undefined</code>    | 否   | Markdown theme token overrides for parsed blocks and inline segments.                            |
+| <code>imageRenderer</code>            | <code>TuiMarkdownImageResolver</code>    | <code>undefined</code>    | 否   | Optional resolver for markdown image payloads before terminal graphics rendering.                |
+| <code>imageMinWidth</code>            | <code>number</code>                      | <code>undefined</code>    | 否   | Minimum markdown image render width in terminal cells.                                           |
+| <code>imageMaxWidth</code>            | <code>number</code>                      | <code>undefined</code>    | 否   | Maximum markdown image render width in terminal cells.                                           |
+| <code>imageMinHeight</code>           | <code>number</code>                      | <code>undefined</code>    | 否   | Minimum markdown image render height in terminal cells.                                          |
+| <code>imageMaxHeight</code>           | <code>number</code>                      | <code>undefined</code>    | 否   | Maximum markdown image render height in terminal cells.                                          |
+| <code>imagePreserveAspectRatio</code> | <code>boolean</code>                     | <code>true</code>         | 否   | Preserves markdown image aspect ratio while fitting width and height bounds.                     |
+| <code>mathImages</code>               | <code>boolean</code>                     | <code>true</code>         | 否   | Renders markdown math as terminal graphics images when the terminal supports it.                 |
+| <code>mathCellWidthPx</code>          | <code>number</code>                      | <code>undefined</code>    | 否   | Terminal cell width in pixels used to map rendered formulas to cells.                            |
+| <code>mathCellHeightPx</code>         | <code>number</code>                      | <code>undefined</code>    | 否   | Terminal cell height in pixels used to map rendered formulas to cells.                           |
+| <code>mathScale</code>                | <code>number</code>                      | <code>undefined</code>    | 否   | Rasterization DPI scale for rendered formulas (does not change cell size).                       |
+| <code>mathColor</code>                | <code>string</code>                      | <code>undefined</code>    | 否   | Hex color used for rendered formula glyphs; defaults to the text foreground.                     |
+| <code>mathMaxWidthCells</code>        | <code>number</code>                      | <code>undefined</code>    | 否   | Maximum width in terminal cells for block-level formulas before they are scaled down.            |
+| <code>mathBaselineRatio</code>        | <code>number</code>                      | <code>undefined</code>    | 否   | Inline formula baseline position as a fraction of cell height, used to align formulas with text. |
+| <code>imageActions</code>             | <code>boolean</code>                     | <code>false</code>        | 否   | Enables pointer actions for rendered markdown images.                                            |
+| <code>mathActions</code>              | <code>boolean</code>                     | <code>false</code>        | 否   | Enables pointer actions for rendered or raw markdown math syntax.                                |
+| <code>linkActions</code>              | <code>boolean</code>                     | <code>false</code>        | 否   | Enables pointer actions for rendered markdown links.                                             |
+| <code>imageOcclusionRects</code>      | <code>readonly Rect[]</code>             | <code>undefined</code>    | 否   | Terminal rectangles that markdown image layout treats as unavailable for graphics placement.     |
 
 ### Events
 

--- a/docs/guide/markdown-math.md
+++ b/docs/guide/markdown-math.md
@@ -9,12 +9,14 @@ Vue TUI 的 markdown 渲染器支持 `$...$` 行内公式和 `$$...$$` 块级公
 
 ## 渲染策略
 
-| 公式 | 有图形能力 + 渲染栈 | 无图形能力 / 渲染栈缺失 |
-| ---- | ------------------ | ----------------------- |
-| 块级 `$$...$$` | Kitty/iTerm2 图片（替换 box） | box 包裹原始 TeX |
+| 公式           | 有图形能力 + 渲染栈           | 无图形能力 / 渲染栈缺失 |
+| -------------- | ----------------------------- | ----------------------- |
+| 块级 `$$...$$` | Kitty/iTerm2 图片（替换 box） | box 包裹原始 TeX        |
+
 | 行内 `$...---
 title: Markdown 数学公式渲染
 description: 在终端里渲染 LaTeX/KaTeX 数学公式：块级公式输出为 Kitty 图形协议图片，行内公式混排进文字行，无图形能力时回退为 box 包裹或原始文本。
+
 ---
 
 # Markdown 数学公式渲染
@@ -23,12 +25,14 @@ Vue TUI 的 markdown 渲染器支持 `$...$` 行内公式和 `$$...$$` 块级公
 
 ## 渲染策略
 
-| 公式 | 有图形能力 + 渲染栈 | 无图形能力 / 渲染栈缺失 |
-| ---- | ------------------ | ----------------------- |
-| 块级 `$$...$$` | Kitty/iTerm2 图片（替换 box） | box 包裹原始 TeX |
-（≤2 行高） | 混排进文字行的 1 行图片 | 原始 `$...---
+| 公式           | 有图形能力 + 渲染栈           | 无图形能力 / 渲染栈缺失 |
+| -------------- | ----------------------------- | ----------------------- |
+| 块级 `$$...$$` | Kitty/iTerm2 图片（替换 box） | box 包裹原始 TeX        |
+| （≤2 行高）    | 混排进文字行的 1 行图片       | 原始 `$...---           |
+
 title: Markdown 数学公式渲染
 description: 在终端里渲染 LaTeX/KaTeX 数学公式：块级公式输出为 Kitty 图形协议图片，行内公式混排进文字行，无图形能力时回退为 box 包裹或原始文本。
+
 ---
 
 # Markdown 数学公式渲染
@@ -37,11 +41,11 @@ Vue TUI 的 markdown 渲染器支持 `$...$` 行内公式和 `$$...$$` 块级公
 
 ## 渲染策略
 
-| 公式 | 有图形能力 + 渲染栈 | 无图形能力 / 渲染栈缺失 |
-| ---- | ------------------ | ----------------------- |
-| 块级 `$$...$$` | Kitty/iTerm2 图片（替换 box） | box 包裹原始 TeX |
- 文本 |
-| 行内超高公式（矩阵等） | 保持原始 `$...$` 文本 | 原始 `$...$` 文本 |
+| 公式                   | 有图形能力 + 渲染栈           | 无图形能力 / 渲染栈缺失 |
+| ---------------------- | ----------------------------- | ----------------------- |
+| 块级 `$$...$$`         | Kitty/iTerm2 图片（替换 box） | box 包裹原始 TeX        |
+| 文本                   |
+| 行内超高公式（矩阵等） | 保持原始 `$...$` 文本         | 原始 `$...$` 文本       |
 
 任何形态的公式（图片或文本）都可以点击，触发 `mathAction` 事件，携带原始 TeX 便于复制。
 
@@ -64,7 +68,7 @@ pnpm add mathjax-full @resvg/resvg-js
 
 ## 快速开始
 
-````vue
+```vue
 <script setup lang="ts">
 import { TVirtualMarkdown } from "@simon_he/vue-tui/markdown";
 
@@ -91,16 +95,14 @@ const content = [
     @math-action="onMathAction"
   />
 </template>
-````
+```
 
 ```ts
 import { createOsc52ClipboardProvider } from "@simon_he/vue-tui";
 
 const clipboard = createOsc52ClipboardProvider();
 
-async function onMathAction(payload: {
-  math: { raw: string };
-}): Promise<void> {
+async function onMathAction(payload: { math: { raw: string } }): Promise<void> {
   await clipboard.writeText(payload.math.raw);
 }
 ```
@@ -111,15 +113,15 @@ async function onMathAction(payload: {
 
 `TMarkdownText` 与 `TVirtualMarkdown` 共用以下数学相关 props：
 
-| Prop | 类型 | 默认 | 说明 |
-| ---- | ---- | ---- | ---- |
-| `mathImages` | `boolean` | `true` | 是否尝试把公式渲染为图片。`false` 时始终显示文本/bx |
-| `mathCellWidthPx` | `number` | `8` | 终端单元格宽度（px），用于公式像素 → 格子换算 |
-| `mathCellHeightPx` | `number` | `16` | 终端单元格高度（px） |
-| `mathScale` | `number` | `2` | 光栅化 DPI 倍率（不影响格子大小，越高越清晰） |
-| `mathColor` | `string` | 跟随文字前景色 | 公式颜色（hex）。默认取 `defaultStyle.fg`，浅色主题自动用深色字 |
-| `mathMaxWidthCells` | `number` | 容器宽度 | 块级公式最大宽度（格子），超宽会等比缩小 |
-| `mathBaselineRatio` | `number` | `0.78` | 行内公式基线在格高中的位置（0~1），用于和文字基线对齐 |
+| Prop                | 类型      | 默认           | 说明                                                            |
+| ------------------- | --------- | -------------- | --------------------------------------------------------------- |
+| `mathImages`        | `boolean` | `true`         | 是否尝试把公式渲染为图片。`false` 时始终显示文本/bx             |
+| `mathCellWidthPx`   | `number`  | `8`            | 终端单元格宽度（px），用于公式像素 → 格子换算                   |
+| `mathCellHeightPx`  | `number`  | `16`           | 终端单元格高度（px）                                            |
+| `mathScale`         | `number`  | `2`            | 光栅化 DPI 倍率（不影响格子大小，越高越清晰）                   |
+| `mathColor`         | `string`  | 跟随文字前景色 | 公式颜色（hex）。默认取 `defaultStyle.fg`，浅色主题自动用深色字 |
+| `mathMaxWidthCells` | `number`  | 容器宽度       | 块级公式最大宽度（格子），超宽会等比缩小                        |
+| `mathBaselineRatio` | `number`  | `0.78`         | 行内公式基线在格高中的位置（0~1），用于和文字基线对齐           |
 
 `mathScale` 只影响 PNG 分辨率；`mathCellWidthPx` / `mathCellHeightPx` 影响公式映射到多少个格子。字体偏大/偏小时先调这两个。
 

--- a/docs/guide/markdown-math.md
+++ b/docs/guide/markdown-math.md
@@ -1,0 +1,182 @@
+---
+title: Markdown 数学公式渲染
+description: 在终端里渲染 LaTeX/KaTeX 数学公式：块级公式输出为 Kitty 图形协议图片，行内公式混排进文字行，无图形能力时回退为 box 包裹或原始文本。
+---
+
+# Markdown 数学公式渲染
+
+Vue TUI 的 markdown 渲染器支持 `$...$` 行内公式和 `$$...$$` 块级公式。在支持图形协议的终端（Kitty / Ghostty / WezTerm / iTerm2）里，公式会**渲染成图片**显示；在不支持的终端里自动回退为文本。
+
+## 渲染策略
+
+| 公式 | 有图形能力 + 渲染栈 | 无图形能力 / 渲染栈缺失 |
+| ---- | ------------------ | ----------------------- |
+| 块级 `$$...$$` | Kitty/iTerm2 图片（替换 box） | box 包裹原始 TeX |
+| 行内 `$...---
+title: Markdown 数学公式渲染
+description: 在终端里渲染 LaTeX/KaTeX 数学公式：块级公式输出为 Kitty 图形协议图片，行内公式混排进文字行，无图形能力时回退为 box 包裹或原始文本。
+---
+
+# Markdown 数学公式渲染
+
+Vue TUI 的 markdown 渲染器支持 `$...$` 行内公式和 `$$...$$` 块级公式。在支持图形协议的终端（Kitty / Ghostty / WezTerm / iTerm2）里，公式会**渲染成图片**显示；在不支持的终端里自动回退为文本。
+
+## 渲染策略
+
+| 公式 | 有图形能力 + 渲染栈 | 无图形能力 / 渲染栈缺失 |
+| ---- | ------------------ | ----------------------- |
+| 块级 `$$...$$` | Kitty/iTerm2 图片（替换 box） | box 包裹原始 TeX |
+（≤2 行高） | 混排进文字行的 1 行图片 | 原始 `$...---
+title: Markdown 数学公式渲染
+description: 在终端里渲染 LaTeX/KaTeX 数学公式：块级公式输出为 Kitty 图形协议图片，行内公式混排进文字行，无图形能力时回退为 box 包裹或原始文本。
+---
+
+# Markdown 数学公式渲染
+
+Vue TUI 的 markdown 渲染器支持 `$...$` 行内公式和 `$$...$$` 块级公式。在支持图形协议的终端（Kitty / Ghostty / WezTerm / iTerm2）里，公式会**渲染成图片**显示；在不支持的终端里自动回退为文本。
+
+## 渲染策略
+
+| 公式 | 有图形能力 + 渲染栈 | 无图形能力 / 渲染栈缺失 |
+| ---- | ------------------ | ----------------------- |
+| 块级 `$$...$$` | Kitty/iTerm2 图片（替换 box） | box 包裹原始 TeX |
+ 文本 |
+| 行内超高公式（矩阵等） | 保持原始 `$...$` 文本 | 原始 `$...$` 文本 |
+
+任何形态的公式（图片或文本）都可以点击，触发 `mathAction` 事件，携带原始 TeX 便于复制。
+
+## 安装依赖
+
+公式转图片依赖两个**可选 peer**（不装也能用，只是公式以文本/bx 形式显示）：
+
+```bash
+# 核心库
+pnpm add @simon_he/vue-tui vue
+
+# 可选：数学公式图片渲染栈（懒加载，按需安装）
+pnpm add mathjax-full @resvg/resvg-js
+```
+
+- `mathjax-full`：TeX → SVG（纯 JS，字形路径内嵌，无需任何字体文件）。
+- `@resvg/resvg-js`：SVG → PNG 光栅化。
+
+> 说明：`katex` 仍是可选 peer，但只用于旧的文本预览路径；公式图片渲染使用上面的 `mathjax-full` + `@resvg/resvg-js`（KaTeX 只能输出 HTML/MathML，无法直接生成 SVG）。
+
+## 快速开始
+
+````vue
+<script setup lang="ts">
+import { TVirtualMarkdown } from "@simon_he/vue-tui/markdown";
+
+const content = [
+  "欧拉公式：$e^{i\\pi}+1=0$",
+  "",
+  "块级积分：",
+  "$$",
+  "\\int_0^1 x^2\\,dx + \\frac{1}{2}\\sum_{n=1}^{\\infty} \\frac{1}{n^2} = \\frac{\\pi^2}{12}",
+  "$$",
+  "",
+  "点击公式复制 TeX：$\\frac{a}{b}$",
+].join("\n");
+</script>
+
+<template>
+  <TVirtualMarkdown
+    :x="0"
+    :y="0"
+    :w="100"
+    :h="28"
+    :content="content"
+    :math-actions="true"
+    @math-action="onMathAction"
+  />
+</template>
+````
+
+```ts
+import { createOsc52ClipboardProvider } from "@simon_he/vue-tui";
+
+const clipboard = createOsc52ClipboardProvider();
+
+async function onMathAction(payload: {
+  math: { raw: string };
+}): Promise<void> {
+  await clipboard.writeText(payload.math.raw);
+}
+```
+
+> 终端必须是 TTY 且被识别为支持图形协议，图片路径才会启用；否则自动显示文本/bx 回退，无需改代码。
+
+## Props
+
+`TMarkdownText` 与 `TVirtualMarkdown` 共用以下数学相关 props：
+
+| Prop | 类型 | 默认 | 说明 |
+| ---- | ---- | ---- | ---- |
+| `mathImages` | `boolean` | `true` | 是否尝试把公式渲染为图片。`false` 时始终显示文本/bx |
+| `mathCellWidthPx` | `number` | `8` | 终端单元格宽度（px），用于公式像素 → 格子换算 |
+| `mathCellHeightPx` | `number` | `16` | 终端单元格高度（px） |
+| `mathScale` | `number` | `2` | 光栅化 DPI 倍率（不影响格子大小，越高越清晰） |
+| `mathColor` | `string` | 跟随文字前景色 | 公式颜色（hex）。默认取 `defaultStyle.fg`，浅色主题自动用深色字 |
+| `mathMaxWidthCells` | `number` | 容器宽度 | 块级公式最大宽度（格子），超宽会等比缩小 |
+| `mathBaselineRatio` | `number` | `0.78` | 行内公式基线在格高中的位置（0~1），用于和文字基线对齐 |
+
+`mathScale` 只影响 PNG 分辨率；`mathCellWidthPx` / `mathCellHeightPx` 影响公式映射到多少个格子。字体偏大/偏小时先调这两个。
+
+## 主题
+
+公式文本与 box 的样式通过 markdown 主题的 `math` token 控制：
+
+```ts
+{
+  theme: {
+    math: { fg: "cyanBright" }, // 公式 box 与 raw 文本颜色
+  },
+}
+```
+
+## 编程接口
+
+`@simon_he/vue-tui/markdown` 也导出底层 API，便于自建渲染管线或排查问题：
+
+- `loadMarkdownMathImageRenderer(): Promise<boolean>` — 确保光栅化栈加载完成，返回是否可用。
+- `isMarkdownMathImageRendererReady(): boolean` — 同步查询渲染栈是否就绪。
+- `getMarkdownMathImage(tex, mode, options)` — 解析单个公式为 `{ base64, widthCells, heightCells }`（带缓存）。
+- `setMarkdownMathRasterizer(fn)` — 注入自定义 TeX→PNG 光栅化器（已有自家管线的消费者可零依赖接入）。
+- `clearMarkdownMathImageCache()` — 清空公式图片缓存。
+- `resolveMarkdownMathColor(fg)` — 把终端前景色映射为 hex（供自定义渲染器复用）。
+
+## 常见问题
+
+### 终端里只显示 box / 原始文本，没有图片
+
+按优先级检查：
+
+1. **终端不支持图形协议**：Kitty、Ghostty、WezTerm、iTerm2 支持；纯 xterm、CI 输出不支持。
+2. **在 tmux / screen / zellij 里运行**：多路复用器下图形协议默认关闭。退出复用器直接运行，或开启 passthrough：`VUE_TUI_GRAPHICS_TMUX_PASSTHROUGH=1`（需要终端支持转发）。
+3. **渲染栈未安装**：确认安装了 `mathjax-full` 与 `@resvg/resvg-js`。
+4. **stdout 不是 TTY**：管道/重定向/CI 下不会启用图片。
+
+运行诊断脚本，一条命令输出全部状态：
+
+```bash
+npx tsx scripts/check-math-graphics.ts
+```
+
+它会打印检测到的协议、原因、渲染栈状态和一个示例公式的渲染结果。也可运行示例 `bun run run:katex-showcase:terminal`，底部的黄色状态栏会显示 `graphics=kitty supported=yes raster=ready` 之类的诊断信息。
+
+### 图片有但看不清楚 / 位置不对
+
+- 公式颜色和背景接近：设置 `mathColor`，或确认 `defaultStyle.fg` 正确（默认会跟随文字前景色）。
+- 行内公式偏高/偏低：调 `mathBaselineRatio`（0.65~0.9 之间试）。
+- 公式太大/太小：调 `mathCellWidthPx` / `mathCellHeightPx`；DPI 不够清晰调 `mathScale`。
+
+### 块级公式宽了 / 换行被截断
+
+块级公式默认限制在容器宽度内（`mathMaxWidthCells`），超宽会等比缩小。超长表达式建议拆行或改用行内展示。
+
+## Related Pages
+
+- [Markdown Transcript](/guide/markdown-transcript)
+- [Components](/components)
+- [Terminal Compatibility](/terminal-compatibility)

--- a/docs/guide/markdown-transcript.md
+++ b/docs/guide/markdown-transcript.md
@@ -101,6 +101,7 @@ This keeps token streaming from repainting the input or overlay regions.
 
 ## Related Pages
 
+- [Markdown Math](/guide/markdown-math)
 - [Agent Console](/agent-console)
 - [Terminal Log Viewer](/guide/terminal-log-viewer)
 - [Vue Terminal UI](/guide/vue-terminal-ui)

--- a/docs/perf/agent-console-profile-baseline.json
+++ b/docs/perf/agent-console-profile-baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 5,
-  "measurementRef": "61336a43aa96150bcf73831b43c8543a3fbc1817",
+  "measurementRef": "7ab61b37cffa2d7660d26aa02e614aafd0060757",
   "measurementInputs": {
     "examples/agent-console/src/AgentConsoleSurface.ts": "af637520b7323160fe433ddbfb4a41d965c62d92654c8014d279ff55291aa129",
     "examples/agent-console/src/App.vue": "0ac4ae6fb1279e8ed98e6a82f6eb0e98feacb85b67a0544ae8005cf70f583d8f",
@@ -17,10 +17,10 @@
     "examples/agent-console/index.html": "8bfed1c6b6b5edb0b90a0056f9743cdb797edec540d55c619ceee23266727f2d",
     "examples/agent-console/package.json": "dff2a7a501e3f86ed2ba845562218dc7d93f2b7e03a84faad93cfcd4a4424bad",
     "examples/agent-console/vite.config.ts": "4ec8b8e26c88a1b77c82414e9b69b95e532a11a2b042503b88c11abb733c1870",
-    "package.json": "ae71f677900af41b9d306408a38682507ae92aa873f8622528852a8f04cc8bdf",
-    "pnpm-lock.yaml": "d9ea5bc3800494ae6b81e8499a3122f9388f9015541ccef25954eca7349b2f56",
-    "tsdown.config.mjs": "415fa32f8c9984559606f69fa5e8de2404cd9766ab4e749cd7e00cc098af0518",
-    "scripts/build-cjs.mjs": "e65f25aabe3a077e5d95fc53ab8f1df9e64c4915fe734c81ab7350ca9d05c4e0",
+    "package.json": "66506a513df5911c7959586e09e59f568683e35bafac492b238ccd5659e3bae1",
+    "pnpm-lock.yaml": "e23a17c99e80c9881aad8fb625e9ed47f64ca41b27f36a8379b4f12f8d03a710",
+    "tsdown.config.mjs": "c173fcfe3e77c789bb0863960ae312e0657c5e8656723beead96c8a92e676416",
+    "scripts/build-cjs.mjs": "cfefe2a44d1aceb33ea51dd213ac85b8d875219a1f7c70eb5e83953cc4cfc9bc",
     "scripts/run-build-checked.mjs": "94ba7210a715891d28fe40bb4cb02694e9d0b7d7861a35d81d3457a6940d2afd",
     "scripts/check-build-warnings.mjs": "d09f9bc01718e15e1f36b70f5bcf6357183674971b23eeedd3188550016a0701",
     "scripts/profile-agent-console-abc.ts": "cedda9ba248d08d641a618b203d2ccd26f34f5bfc3ef82a08e7fdeb0c9f638ce",
@@ -29,7 +29,7 @@
     "scripts/profile-agent-console-cli.ts": "f990d7d144b6c8830c09339ebb8145624569eff85dbee9046ad122edbaa01544",
     "scripts/tsconfig.agent-console-profile-dist.json": "43f8b7a5af20c2c15bd025e0e0ee6e6dc35f6bd09a64e07fb6324fdbdfcb10f6"
   },
-  "verificationRef": "61336a43aa96150bcf73831b43c8543a3fbc1817",
+  "verificationRef": "7ab61b37cffa2d7660d26aa02e614aafd0060757",
   "verificationInputs": {
     "scripts/agent-console-cpu-profile.ts": "20330b5fae6506344a36c5d2703f745a7ac3376f996d50ce54653c41e488de1f",
     "scripts/agent-console-profile-environment.ts": "5b2df314bfe1afeab5e7c5af9c457212a366c76e56d4fa9fa584fa016fcc9504",
@@ -19264,7 +19264,7 @@
           }
         }
       },
-      "productionRef": "61336a43aa96150bcf73831b43c8543a3fbc1817"
+      "productionRef": "7ab61b37cffa2d7660d26aa02e614aafd0060757"
     },
     "B": {
       "schemaVersion": 2,
@@ -38465,7 +38465,7 @@
           }
         }
       },
-      "productionRef": "61336a43aa96150bcf73831b43c8543a3fbc1817"
+      "productionRef": "7ab61b37cffa2d7660d26aa02e614aafd0060757"
     },
     "C": {
       "schemaVersion": 2,
@@ -57689,7 +57689,7 @@
           }
         }
       },
-      "productionRef": "61336a43aa96150bcf73831b43c8543a3fbc1817"
+      "productionRef": "7ab61b37cffa2d7660d26aa02e614aafd0060757"
     }
   },
   "comparisons": {

--- a/examples/chat-cli.ts
+++ b/examples/chat-cli.ts
@@ -150,6 +150,7 @@ const out = createStdoutRenderer(
         anchor: "bottom",
         barGap: CHAT_CLI_BAR_GAP,
         screenRows: () => SMOKE_ROWS,
+        getImeAnchor: () => app.getImeAnchor(),
       }
     : {
         output: process.stdout,
@@ -160,6 +161,7 @@ const out = createStdoutRenderer(
         anchor: "bottom",
         barGap: CHAT_CLI_BAR_GAP,
         screenRows: () => liveRows(),
+        getImeAnchor: () => app.getImeAnchor(),
       },
 );
 

--- a/examples/chat-cli.ts
+++ b/examples/chat-cli.ts
@@ -19,11 +19,7 @@ import {
   type TerminalCleanupHandle,
 } from "../src/cli.js";
 import { nextTick } from "vue";
-import {
-  CHAT_CLI_BAR_GAP,
-  CHAT_CLI_BAR_ROWS,
-  createChatCliApp,
-} from "./chat-cli/App.js";
+import { CHAT_CLI_BAR_GAP, CHAT_CLI_BAR_ROWS, createChatCliApp } from "./chat-cli/App.js";
 
 const interactive = process.env.VT_INTERACTIVE === "1";
 const smoke = process.env.VT_SMOKE === "1" || !interactive;

--- a/examples/chat-cli.ts
+++ b/examples/chat-cli.ts
@@ -1,0 +1,258 @@
+/**
+ * vue-tui REPL-style CLI example runner.
+ *
+ * Only the bottom input bar is TUI-owned and refreshed (`anchor: "bottom"`).
+ * Everything above the bar is NATIVE terminal output:
+ * - messages and replies are written to the terminal scroll region, scroll
+ *   natively (mouse wheel / scrollback), and survive into history;
+ * - right-click paste / native selection keep working because the mouse is not
+ *   captured and the alternate screen is never entered.
+ *
+ * Interactive: VT_INTERACTIVE=1 tsx examples/chat-cli.ts
+ * Smoke:       VT_SMOKE=1 tsx examples/chat-cli.ts
+ */
+import {
+  createStdinDriver,
+  createStdoutRenderer,
+  createTerminalApp,
+  installTerminalCleanup,
+  type TerminalCleanupHandle,
+} from "../src/cli.js";
+import { nextTick } from "vue";
+import {
+  CHAT_CLI_BAR_GAP,
+  CHAT_CLI_BAR_ROWS,
+  createChatCliApp,
+} from "./chat-cli/App.js";
+
+const interactive = process.env.VT_INTERACTIVE === "1";
+const smoke = process.env.VT_SMOKE === "1" || !interactive;
+const DEFAULT_COLS = 110;
+
+function liveCols(): number {
+  const v = Number(process.stdout.columns);
+  return Number.isFinite(v) && v > 0 ? v : DEFAULT_COLS;
+}
+function liveRows(): number {
+  const v = Number(process.stdout.rows);
+  return Number.isFinite(v) && v > 0 ? v : 24;
+}
+/** Simulated screen height used by smoke mode (30 rows, 3-row bar). */
+const SMOKE_ROWS = 30;
+
+/**
+ * Writes native output above the pinned bar, inside the scroll region the
+ * renderer establishes (rows 1..screenRows-barRows). Tracks its own cursor row
+ * within the region so successive messages append instead of overwriting; at
+ * the region bottom a newline scrolls the region natively (top lines enter the
+ * terminal's scrollback history).
+ */
+class ScrollbackWriter {
+  private row = -1;
+  private col = 0;
+
+  constructor(
+    private opts: {
+      write: (chunk: string) => void;
+      screenRows: () => number;
+      screenCols: () => number;
+      barRows: number;
+      barGap: number;
+    },
+  ) {}
+
+  /** Rows available for native output above the bar's reserved gap. */
+  private regionRows(): number {
+    return Math.max(1, Math.floor(this.opts.screenRows()) - this.opts.barRows - this.opts.barGap);
+  }
+
+  private ensureReady(): void {
+    if (this.row < 0) {
+      this.row = this.regionRows() - 1;
+      this.col = 0;
+    }
+    if (this.row > this.regionRows() - 1) this.row = this.regionRows() - 1;
+  }
+
+  private position(): void {
+    this.opts.write(`\u001B[${this.row + 1};${this.col + 1}H`);
+  }
+
+  /** Emit a newline, scrolling the region natively when at its bottom margin. */
+  newline(): void {
+    this.opts.write("\n");
+    this.col = 0;
+    // At the region bottom margin a newline scrolls the region; the cursor
+    // stays on the fresh bottom row. Otherwise advance to the next row.
+    if (this.row < this.regionRows() - 1) this.row++;
+  }
+
+  write(text: string): void {
+    this.ensureReady();
+    this.position();
+    const cols = Math.max(1, Math.floor(this.opts.screenCols()));
+    for (const ch of text) {
+      if (ch === "\n") {
+        this.newline();
+        continue;
+      }
+      this.opts.write(ch);
+      this.col++;
+      if (this.col >= cols) {
+        this.newline();
+        this.position();
+      }
+    }
+  }
+
+  line(text: string): void {
+    this.write(`${text}\n`);
+  }
+}
+
+const writer = new ScrollbackWriter({
+  write: (chunk) => {
+    if (smoke) smokeChunks.push(chunk);
+    else process.stdout.write(chunk);
+  },
+  screenRows: () => (smoke ? SMOKE_ROWS : liveRows()),
+  screenCols: () => (smoke ? DEFAULT_COLS : liveCols()),
+  barRows: CHAT_CLI_BAR_ROWS,
+  barGap: CHAT_CLI_BAR_GAP,
+});
+const smokeChunks: string[] = [];
+
+const { handlers, component } = createChatCliApp({ onSubmit: handleSubmit });
+
+const app = createTerminalApp({
+  cols: smoke ? DEFAULT_COLS : Math.max(DEFAULT_COLS, liveCols()),
+  rows: CHAT_CLI_BAR_ROWS,
+  component,
+  defaultStyle: { fg: "whiteBright" },
+});
+app.mount();
+
+const rendererChunks: string[] = [];
+const out = createStdoutRenderer(
+  app.terminal,
+  smoke
+    ? {
+        output: {
+          isTTY: false,
+          write(chunk: string) {
+            rendererChunks.push(chunk);
+          },
+        },
+        clear: false,
+        hideCursor: false,
+        altScreen: false,
+        trackResize: false,
+        anchor: "bottom",
+        barGap: CHAT_CLI_BAR_GAP,
+        screenRows: () => SMOKE_ROWS,
+      }
+    : {
+        output: process.stdout,
+        hideCursor: true,
+        altScreen: false,
+        clear: false,
+        trackResize: false,
+        anchor: "bottom",
+        barGap: CHAT_CLI_BAR_GAP,
+        screenRows: () => liveRows(),
+      },
+);
+
+app.scheduler.flush();
+
+function handleSubmit(text: string): void {
+  writer.line(`❯ ${text}`);
+  const reply = `echo: ${text}`;
+  if (smoke) {
+    writer.write(reply);
+    writer.newline();
+    return;
+  }
+  void streamReply(reply);
+}
+
+async function streamReply(reply: string): Promise<void> {
+  for (const ch of reply) {
+    await sleep(25);
+    writer.write(ch);
+  }
+  writer.newline();
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+let driver: ReturnType<typeof createStdinDriver> | null = null;
+let cleanupHandle: TerminalCleanupHandle | null = null;
+let exiting = false;
+
+const onResize = () => {
+  app.terminal.resize(Math.max(DEFAULT_COLS, liveCols()), CHAT_CLI_BAR_ROWS);
+  app.scheduler.flush();
+  // Re-anchor the bar and re-establish the scroll region for the new size.
+  out.forceRender();
+};
+
+const cleanup = () => {
+  if (exiting) return;
+  exiting = true;
+  if (process.stdout.isTTY) process.stdout.off("resize", onResize);
+  cleanupHandle?.uninstall();
+  cleanupHandle = null;
+  driver?.dispose();
+  out.dispose(); // restores the full-screen scroll region (ESC[r)
+  app.dispose();
+};
+
+const exit = () => {
+  cleanup();
+  process.exit(0);
+};
+
+if (process.stdout.isTTY) {
+  process.stdout.on("resize", onResize);
+}
+
+if (smoke) {
+  handlers.onSubmit?.("hello vue-tui");
+  await nextTick();
+  app.scheduler.flushNow();
+
+  const rendererOut = rendererChunks.join("");
+  const writerOut = smokeChunks.join("");
+  const output = {
+    cols: DEFAULT_COLS,
+    rows: SMOKE_ROWS,
+    inputBorder: app.terminal
+      .getRow(0)
+      .map((cell) => cell.ch)
+      .join("")
+      .startsWith("┌"),
+    // Bar buffer row 0 is addressed at 1-based row 28 of a 30-row screen.
+    barAnchored: rendererOut.includes("\u001B[28;1H"),
+    // Output starts at the last scroll-region row (1-based 25: 30 rows minus
+    // the 3-row bar minus the 2-row reserved gap), above the gap.
+    outputAboveBar: writerOut.includes("\u001B[25;1H❯ hello vue-tui"),
+    hasEcho: writerOut.includes("echo: hello vue-tui"),
+  };
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+  exit();
+} else {
+  cleanupHandle = installTerminalCleanup(cleanup, { signalPolicy: "exit" });
+  driver = createStdinDriver({
+    dispatch: (event) => {
+      const prevented = app.events.dispatch(event);
+      app.scheduler.flush();
+      return prevented;
+    },
+    // No mouse capture: right-click paste and native selection stay untouched.
+    enableMouse: false,
+    onExit: exit,
+  });
+}

--- a/examples/chat-cli/App.ts
+++ b/examples/chat-cli/App.ts
@@ -1,0 +1,65 @@
+import type { PropType } from "vue";
+import { defineComponent, h, onBeforeUnmount, ref } from "vue";
+import { TInputBox, useTerminal } from "../../src/vue.js";
+
+/**
+ * Height of the pinned REPL bar (TInputBox border box) in rows.
+ * The TUI terminal buffer is exactly this tall — it owns nothing else.
+ */
+export const CHAT_CLI_BAR_ROWS = 3;
+
+/**
+ * Rows of blank space kept between the native output region and the pinned
+ * input bar, so the bar never sits flush against the content above it.
+ */
+export const CHAT_CLI_BAR_GAP = 2;
+
+export type ChatCliHandlers = Readonly<{
+  /** Called when the user submits a message (Enter in the bar). */
+  onSubmit?: (text: string) => void;
+}>;
+
+/**
+ * The only TUI-owned region in REPL mode: a border-boxed input pinned to the
+ * bottom of the screen by the stdout renderer (`anchor: "bottom"`). Everything
+ * above is native terminal output owned by the caller.
+ */
+export function createChatCliApp(handlers: ChatCliHandlers = {}) {
+  return {
+    handlers,
+    component: defineComponent({
+      name: "ChatCliBar",
+      setup() {
+        const { terminal, scheduler } = useTerminal();
+        const size = ref(terminal.size());
+        const offResize = terminal.on("resize", () => {
+          size.value = terminal.size();
+          scheduler.invalidate();
+        });
+        onBeforeUnmount(offResize);
+
+        const input = ref("");
+
+        return () =>
+          h(TInputBox, {
+            x: 0,
+            y: 0,
+            w: size.value.cols,
+            h: size.value.rows,
+            title: "chat · Enter 发送 · Ctrl+C 退出",
+            modelValue: input.value,
+            "onUpdate:modelValue": (v: string) => {
+              input.value = v;
+            },
+            onChange: (v: string) => {
+              const trimmed = String(v ?? "").trim();
+              if (!trimmed) return;
+              input.value = "";
+              handlers.onSubmit?.(trimmed);
+            },
+            autoFocus: true,
+          });
+      },
+    }),
+  };
+}

--- a/examples/katex-showcase.ts
+++ b/examples/katex-showcase.ts
@@ -11,23 +11,31 @@ import {
   createTerminalApp,
   installTerminalCleanup,
 } from "../src/cli.js";
-import { TMarkdownText, type TuiMarkdownMathActionPayload } from "../src/markdown.js";
+import {
+  TMarkdownText,
+  loadMarkdownMathImageRenderer,
+  type TuiMarkdownMathActionPayload,
+} from "../src/markdown.js";
+import { detectTerminalGraphicsCapabilities } from "../src/renderer/terminal-graphics.js";
 import { TText, useLayout, useTerminal } from "../src/vue.js";
 
 const CONTENT = [
-  "Optional KaTeX terminal text rendering",
+  "Markdown math: block images, inline images, boxed/raw fallbacks",
   "",
-  "Rendered after the optional KaTeX peer loads:",
-  "Euler: $e^{i\\pi}+1=0$",
-  "Fraction: $\\frac{a}{b}+\\sqrt{x}$",
-  "Operators: $\\int_0^1 x^2 dx + \\sum_{n=1}^{10} n$",
+  "Block math renders as an image when the terminal supports",
+  "graphics and the raster stack (mathjax-full + @resvg/resvg-js) is loaded,",
+  "otherwise it stays inside a box:",
   "",
-  "Unsupported formulas stay raw:",
-  "Matrix: $\\begin{bmatrix}1&2\\\\3&4\\end{bmatrix}$",
-  "Cases: $\\begin{cases}x&x>0\\\\-x&x<0\\end{cases}$",
-  "Unsupported command: $\\operatorname{softmax}(x)$",
+  "$$",
+  "\\int_0^1 x^2\\,dx + \\frac{1}{2}\\sum_{n=1}^{\\infty} \\frac{1}{n^2} = \\frac{\\pi^2}{12}",
+  "$$",
   "",
-  "Click any formula to copy its original KaTeX text.",
+  "Inline math is rendered into the text row: Euler $e^{i\\pi}+1=0$ and a",
+  "fraction $\\frac{a}{b}$ plus $x^{2}+\\sqrt{y}$.",
+  "",
+  "Tall inline (matrices) stays raw: $\\begin{bmatrix}1&2\\\\3&4\\end{bmatrix}$",
+  "",
+  "Click any formula (image or raw text) to copy its original TeX.",
   "Press q / Escape / Ctrl+C to exit.",
 ].join("\n");
 
@@ -41,6 +49,18 @@ const App = defineComponent({
     const cols = computed(() => Math.max(1, layout.clipRect?.w ?? 80));
     const rows = computed(() => Math.max(1, layout.clipRect?.h ?? 24));
     const status = ref("");
+    const diag = ref("");
+
+    // Self-diagnostic: show which gate decided the rendering path.
+    void (async () => {
+      const caps = detectTerminalGraphicsCapabilities();
+      const raster = await loadMarkdownMathImageRenderer();
+      diag.value =
+        `graphics=${caps.protocol} supported=${caps.supported ? "yes" : "NO"} ` +
+        `(reason: ${caps.reason ?? "auto-detected"}) ` +
+        `raster=${raster ? "ready" : "missing (install mathjax-full + @resvg/resvg-js)"}`;
+      scheduler.flushNow();
+    })();
 
     async function copyMath(payload: TuiMarkdownMathActionPayload): Promise<void> {
       try {
@@ -71,6 +91,15 @@ const App = defineComponent({
             w: Math.max(1, cols.value - 2),
             value: status.value,
             style: { fg: "cyan" },
+          })
+        : null,
+      diag.value
+        ? h(TText, {
+            x: 1,
+            y: Math.max(1, rows.value - 1),
+            w: Math.max(1, cols.value - 2),
+            value: diag.value,
+            style: { fg: "yellow" },
           })
         : null,
     ];

--- a/package.json
+++ b/package.json
@@ -268,6 +268,8 @@
     "profile:agent-console:abc": "tsx scripts/profile-agent-console-abc.ts",
     "profile:agent-console:abc:smoke": "AGENT_CONSOLE_PROFILE_SMOKE=1 tsx scripts/profile-agent-console-abc.ts",
     "example:tlog-view-lab": "pnpm run build && VT_SMOKE=1 tsx examples/tlog-view-lab.ts",
+    "example:chat-cli:smoke": "VT_SMOKE=1 tsx examples/chat-cli.ts",
+    "run:chat-cli:terminal": "pnpm run build && VT_INTERACTIVE=1 tsx examples/chat-cli.ts",
     "run:basic:terminal": "pnpm run build && pnpm -C examples/basic terminal",
     "run:agent-console:terminal": "pnpm run build && pnpm -C examples/agent-console terminal",
     "run:basic:multi-select:terminal": "pnpm run build && pnpm -C examples/basic build:terminal:multi-select && pnpm -C examples/basic terminal:multi-select",

--- a/package.json
+++ b/package.json
@@ -370,6 +370,7 @@
   "devDependencies": {
     "@arethetypeswrong/core": "^0.18.3",
     "@playwright/test": "^1.61.0",
+    "@resvg/resvg-js": "^2.6.2",
     "@types/node": "^18.19.130",
     "@vitest/coverage-v8": "^4.1.9",
     "beautiful-mermaid": "^1.1.3",
@@ -379,6 +380,7 @@
     "happy-dom": "^17.6.3",
     "katex": "^0.16.47",
     "lint-staged": "^13.3.0",
+    "mathjax-full": "^3.2.2",
     "oxfmt": "^0.47.0",
     "oxlint": "^1.70.0",
     "picocolors": "^1.1.1",
@@ -394,9 +396,11 @@
     "vue": "^3.5.38"
   },
   "peerDependencies": {
+    "@resvg/resvg-js": "^2.6.2",
     "beautiful-mermaid": "^1.1.3",
     "bun-webgpu": "^0.1.7",
     "katex": "^0.16.47",
+    "mathjax-full": "^3.2.2",
     "vue": ">=3.3.0 <4"
   },
   "peerDependenciesMeta": {
@@ -407,6 +411,12 @@
       "optional": true
     },
     "katex": {
+      "optional": true
+    },
+    "mathjax-full": {
+      "optional": true
+    },
+    "@resvg/resvg-js": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@playwright/test':
         specifier: ^1.61.0
         version: 1.61.0
+      '@resvg/resvg-js':
+        specifier: ^2.6.2
+        version: 2.6.2
       '@types/node':
         specifier: ^18.19.130
         version: 18.19.130
@@ -48,6 +51,9 @@ importers:
       lint-staged:
         specifier: ^13.3.0
         version: 13.3.0
+      mathjax-full:
+        specifier: ^3.2.2
+        version: 3.2.2
       oxfmt:
         specifier: ^0.47.0
         version: 0.47.0
@@ -1286,6 +1292,86 @@ packages:
     resolution: {integrity: sha512-ezIadUb1aFhwJLd++WVqVpi9rnlX8vnd4ju7saPhwLHJN1mJgOv0puePTGV+FbtSnWtwoHDT8lAm4kagDZmpCg==}
     engines: {node: '>=20.0.0'}
 
+  '@resvg/resvg-js-android-arm-eabi@2.6.2':
+    resolution: {integrity: sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@resvg/resvg-js-android-arm64@2.6.2':
+    resolution: {integrity: sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@resvg/resvg-js-darwin-arm64@2.6.2':
+    resolution: {integrity: sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@resvg/resvg-js-darwin-x64@2.6.2':
+    resolution: {integrity: sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
+    resolution: {integrity: sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
+    resolution: {integrity: sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@resvg/resvg-js-linux-arm64-musl@2.6.2':
+    resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@resvg/resvg-js-linux-x64-gnu@2.6.2':
+    resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@resvg/resvg-js-linux-x64-musl@2.6.2':
+    resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
+    resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
+    resolution: {integrity: sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@resvg/resvg-js-win32-x64-msvc@2.6.2':
+    resolution: {integrity: sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@resvg/resvg-js@2.6.2':
+    resolution: {integrity: sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==}
+    engines: {node: '>= 10'}
+
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1799,6 +1885,10 @@ packages:
   '@webgpu/types@0.1.71':
     resolution: {integrity: sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==}
 
+  '@xmldom/xmldom@0.9.10':
+    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+    engines: {node: '>=14.6'}
+
   acorn@8.14.1:
     resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
     engines: {node: '>=0.4.0'}
@@ -1957,6 +2047,10 @@ packages:
     resolution: {integrity: sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==}
     engines: {node: '>=16'}
 
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
@@ -2073,6 +2167,10 @@ packages:
     resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  esm@3.2.25:
+    resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
+    engines: {node: '>=6'}
 
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
@@ -2485,6 +2583,10 @@ packages:
     resolution: {integrity: sha512-gGDZxv51QgitJhdoTHU/JtgpquCbmTRdhH8nsRG7BknLh69jCuE3ism28i5EUY+7BQRj6evZA8YSNK+CcM2/sA==}
     engines: {node: '>=20.19'}
 
+  mathjax-full@3.2.2:
+    resolution: {integrity: sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==}
+    deprecated: Version 4 replaces this package with the scoped package @mathjax/src
+
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
@@ -2497,6 +2599,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  mhchemparser@4.2.1:
+    resolution: {integrity: sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==}
 
   micromark-util-character@2.1.0:
     resolution: {integrity: sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==}
@@ -2537,6 +2642,9 @@ packages:
 
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
+  mj-context-menu@0.6.1:
+    resolution: {integrity: sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -2849,6 +2957,10 @@ packages:
   speakingurl@14.0.1:
     resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
     engines: {node: '>=0.10.0'}
+
+  speech-rule-engine@4.1.4:
+    resolution: {integrity: sha512-i/VCLG1fvRc95pMHRqG4aQNscv+9aIsqA2oI7ZQS51sTdUcDHYX6cpT8/tqZ+enjs1tKVwbRBWgxut9SWn+f9g==}
+    hasBin: true
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -3193,6 +3305,9 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wicked-good-xpath@1.3.0:
+    resolution: {integrity: sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -3942,6 +4057,57 @@ snapshots:
     dependencies:
       quansync: 0.2.10
 
+  '@resvg/resvg-js-android-arm-eabi@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-android-arm64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-darwin-arm64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-darwin-x64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm64-musl@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-x64-gnu@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-x64-musl@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-x64-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js@2.6.2':
+    optionalDependencies:
+      '@resvg/resvg-js-android-arm-eabi': 2.6.2
+      '@resvg/resvg-js-android-arm64': 2.6.2
+      '@resvg/resvg-js-darwin-arm64': 2.6.2
+      '@resvg/resvg-js-darwin-x64': 2.6.2
+      '@resvg/resvg-js-linux-arm-gnueabihf': 2.6.2
+      '@resvg/resvg-js-linux-arm64-gnu': 2.6.2
+      '@resvg/resvg-js-linux-arm64-musl': 2.6.2
+      '@resvg/resvg-js-linux-x64-gnu': 2.6.2
+      '@resvg/resvg-js-linux-x64-musl': 2.6.2
+      '@resvg/resvg-js-win32-arm64-msvc': 2.6.2
+      '@resvg/resvg-js-win32-ia32-msvc': 2.6.2
+      '@resvg/resvg-js-win32-x64-msvc': 2.6.2
+
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
 
@@ -4374,6 +4540,8 @@ snapshots:
 
   '@webgpu/types@0.1.71': {}
 
+  '@xmldom/xmldom@0.9.10': {}
+
   acorn@8.14.1: {}
 
   algoliasearch@5.52.0:
@@ -4530,6 +4698,8 @@ snapshots:
 
   commander@11.0.0: {}
 
+  commander@13.1.0: {}
+
   commander@8.3.0: {}
 
   concat-map@0.0.1: {}
@@ -4680,6 +4850,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.28.0
       '@esbuild/win32-ia32': 0.28.0
       '@esbuild/win32-x64': 0.28.0
+
+  esm@3.2.25: {}
 
   estree-walker@2.0.2: {}
 
@@ -5046,6 +5218,13 @@ snapshots:
       mdurl: 2.0.0
       punycode.js: 2.3.1
 
+  mathjax-full@3.2.2:
+    dependencies:
+      esm: 3.2.25
+      mhchemparser: 4.2.1
+      mj-context-menu: 0.6.1
+      speech-rule-engine: 4.1.4
+
   mdast-util-to-hast@13.2.1:
     dependencies:
       '@types/hast': 3.0.4
@@ -5063,6 +5242,8 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  mhchemparser@4.2.1: {}
 
   micromark-util-character@2.1.0:
     dependencies:
@@ -5102,6 +5283,8 @@ snapshots:
   minisearch@7.2.0: {}
 
   mitt@3.0.1: {}
+
+  mj-context-menu@0.6.1: {}
 
   mri@1.2.0: {}
 
@@ -5482,6 +5665,12 @@ snapshots:
 
   speakingurl@14.0.1: {}
 
+  speech-rule-engine@4.1.4:
+    dependencies:
+      '@xmldom/xmldom': 0.9.10
+      commander: 13.1.0
+      wicked-good-xpath: 1.3.0
+
   stackback@0.0.2: {}
 
   std-env@4.1.0: {}
@@ -5818,6 +6007,8 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wicked-good-xpath@1.3.0: {}
 
   wrap-ansi@6.2.0:
     dependencies:

--- a/scripts/api-doc-metadata.ts
+++ b/scripts/api-doc-metadata.ts
@@ -89,6 +89,16 @@ export const sharedPublicPropDescriptions: Record<string, string> = {
   imageActions: "Enables pointer actions for rendered markdown images.",
   mathActions: "Enables pointer actions for rendered or raw markdown math syntax.",
   linkActions: "Enables pointer actions for rendered markdown links.",
+  mathImages:
+    "Renders markdown math as terminal graphics images when the terminal supports it.",
+  mathCellWidthPx: "Terminal cell width in pixels used to map rendered formulas to cells.",
+  mathCellHeightPx: "Terminal cell height in pixels used to map rendered formulas to cells.",
+  mathScale: "Rasterization DPI scale for rendered formulas (does not change cell size).",
+  mathColor: "Hex color used for rendered formula glyphs; defaults to the text foreground.",
+  mathMaxWidthCells:
+    "Maximum width in terminal cells for block-level formulas before they are scaled down.",
+  mathBaselineRatio:
+    "Inline formula baseline position as a fraction of cell height, used to align formulas with text.",
   imageOcclusionRects:
     "Terminal rectangles that markdown image layout treats as unavailable for graphics placement.",
   columns: "Table column definitions.",
@@ -384,6 +394,13 @@ export const componentPublicPropDescriptions: Record<string, Record<string, stri
       "mathActions",
       "linkActions",
       "imageOcclusionRects",
+      "mathImages",
+      "mathCellWidthPx",
+      "mathCellHeightPx",
+      "mathScale",
+      "mathColor",
+      "mathMaxWidthCells",
+      "mathBaselineRatio",
     ),
   },
   TList: {
@@ -495,6 +512,13 @@ export const componentPublicPropDescriptions: Record<string, Record<string, stri
       "mathActions",
       "linkActions",
       "imageOcclusionRects",
+      "mathImages",
+      "mathCellWidthPx",
+      "mathCellHeightPx",
+      "mathScale",
+      "mathColor",
+      "mathMaxWidthCells",
+      "mathBaselineRatio",
     ),
   },
 };

--- a/scripts/api-doc-metadata.ts
+++ b/scripts/api-doc-metadata.ts
@@ -89,8 +89,7 @@ export const sharedPublicPropDescriptions: Record<string, string> = {
   imageActions: "Enables pointer actions for rendered markdown images.",
   mathActions: "Enables pointer actions for rendered or raw markdown math syntax.",
   linkActions: "Enables pointer actions for rendered markdown links.",
-  mathImages:
-    "Renders markdown math as terminal graphics images when the terminal supports it.",
+  mathImages: "Renders markdown math as terminal graphics images when the terminal supports it.",
   mathCellWidthPx: "Terminal cell width in pixels used to map rendered formulas to cells.",
   mathCellHeightPx: "Terminal cell height in pixels used to map rendered formulas to cells.",
   mathScale: "Rasterization DPI scale for rendered formulas (does not change cell size).",

--- a/scripts/build-cjs.mjs
+++ b/scripts/build-cjs.mjs
@@ -95,7 +95,7 @@ const cjsBrowserResult = await build({
   // CJS intentionally bundles stream-markdown-parser because it only exposes
   // ESM entrypoints. Keep optional peers external so they can be loaded
   // through dynamic import at render time.
-  external: ["vue", "beautiful-mermaid", "katex"],
+  external: ["vue", "beautiful-mermaid", "katex", "mathjax-full", "@resvg/resvg-js"],
   plugins: [forbidNodeBuiltinsPlugin, instrumentationStripPlugin],
   define: productionDefine,
 });
@@ -133,7 +133,7 @@ const cjsCliResult = await build({
   minifySyntax: true,
   metafile: true,
   supported: { "dynamic-import": true },
-  external: ["vue", "bun-webgpu", "katex"],
+  external: ["vue", "bun-webgpu", "katex", "mathjax-full", "@resvg/resvg-js"],
   define: productionDefine,
   plugins: [instrumentationStripPlugin],
 });

--- a/scripts/check-math-graphics.ts
+++ b/scripts/check-math-graphics.ts
@@ -1,0 +1,94 @@
+/**
+ * Terminal graphics / math image diagnostics.
+ *
+ * Run inside the terminal you want to debug:
+ *   bun run tsx scripts/check-math-graphics.ts
+ *
+ * Prints the detected graphics protocol, the math rasterizer status, and a
+ * sample rasterized formula so you can tell exactly which gate blocked the
+ * Kitty image path.
+ */
+import { detectTerminalGraphicsCapabilities } from "../src/renderer/terminal-graphics.js";
+import { getMarkdownMathImage, loadMarkdownMathImageRenderer } from "../src/markdown.js";
+
+function env(key: string): string | undefined {
+  const processLike = globalThis as { process?: { env?: Record<string, unknown> } };
+  const value = processLike.process?.env?.[key];
+  return value == null ? undefined : String(value);
+}
+
+async function main(): Promise<void> {
+  console.log("=== environment ===");
+  for (const key of [
+    "TERM",
+    "TERM_PROGRAM",
+    "TERM_PROGRAM_VERSION",
+    "COLORTERM",
+    "GHOSTTY_RESOURCES_DIR",
+    "KITTY_WINDOW_ID",
+    "TMUX",
+    "STY",
+    "ZELLIJ",
+    "CI",
+  ]) {
+    console.log(`  ${key}=${env(key) ?? "(unset)"}`);
+  }
+
+  console.log("\n=== graphics capability detection ===");
+  const caps = detectTerminalGraphicsCapabilities();
+  console.log("  protocol      :", caps.protocol);
+  console.log("  supported     :", caps.supported);
+  console.log("  preferred     :", caps.preferredProtocol);
+  console.log("  candidates    :", caps.candidates.join(", ") || "(none)");
+  console.log("  reason        :", caps.reason ?? "auto-detected");
+  console.log("  stdoutIsTTY   :", caps.stdoutIsTTY);
+  if (caps.multiplexer) {
+    console.log("  multiplexer   :", caps.multiplexer);
+    console.log("  passthrough   :", caps.passthrough);
+    console.log(
+      "  NOTE          : inside a multiplexer the graphics protocol is disabled",
+      "unless passthrough is enabled (VUE_TUI_GRAPHICS_TMUX_PASSTHROUGH=1) or forced.",
+    );
+  }
+
+  console.log("\n=== math rasterizer ===");
+  const ready = await loadMarkdownMathImageRenderer();
+  console.log("  rasterizer    :", ready ? "ready" : "NOT AVAILABLE");
+  if (!ready) {
+    console.log(
+      "  install       : pnpm add mathjax-full @resvg/resvg-js  (optional peers of @simon_he/vue-tui)",
+    );
+    return;
+  }
+
+  const tex = "\\frac{a}{b}+\\int_0^1 x^2\\,dx";
+  const result = await getMarkdownMathImage(tex, "display", {
+    cellWidthPx: 8,
+    cellHeightPx: 16,
+    scale: 2,
+    color: "#ffffff",
+    maxWidthCells: 60,
+  });
+  if (!result) {
+    console.log("  sample render : FAILED (returned null)");
+    return;
+  }
+  console.log(
+    `  sample render : ${result.widthCells}x${result.heightCells} cells, PNG ${result.base64.length} chars base64`,
+  );
+  if (caps.supported && caps.preferredProtocol === "kitty") {
+    console.log(
+      "\n  Everything is ready — the showcase should render a Kitty image.",
+      "If it does not, the terminal may not be applying the graphics protocol",
+      "(e.g. running under tmux, or a terminal that ignores kitty APC frames).",
+    );
+  } else if (caps.supported) {
+    console.log(
+      `\n  Graphics use ${caps.protocol}; the showcase will emit ${caps.protocol} frames.`,
+    );
+  } else {
+    console.log("\n  Graphics are NOT supported here — the showcase will show boxed raw formulas.");
+  }
+}
+
+void main();

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -4,6 +4,23 @@ export { createMarkdownBlockSource } from "./vue/markdown/block-source.js";
 export { buildMarkdownBlocks, buildMarkdownVisualRows } from "./vue/markdown/document.js";
 export { layoutMarkdownBlocks } from "./vue/markdown/layout.js";
 export { loadMarkdownMathRenderer } from "./vue/markdown/math.js";
+export {
+  clearMarkdownMathImageCache,
+  enqueueMarkdownMathImages,
+  getCachedMarkdownMathImage,
+  getMarkdownMathImage,
+  isMarkdownMathImageRendererReady,
+  loadMarkdownMathImageRenderer,
+  setMarkdownMathRasterizer,
+  subscribeMarkdownMathImage,
+} from "./vue/markdown/math-image.js";
+export type {
+  TuiMarkdownMathImageCells,
+  TuiMarkdownMathImageOptions,
+  TuiMarkdownMathMode,
+  TuiMarkdownMathRasterizer,
+} from "./vue/markdown/math-image.js";
+export type { TuiMarkdownMathOptions } from "./vue/markdown/ast.js";
 export { createTuiMarkdownParser, isSafeMarkdownLink } from "./vue/markdown/parser.js";
 export type {
   TuiMarkdownBlockSource,

--- a/src/renderer/cli/stdout-renderer.ts
+++ b/src/renderer/cli/stdout-renderer.ts
@@ -111,6 +111,13 @@ export type StdoutRenderer = Readonly<{
   capabilities: RendererCapabilities;
   graphicsCapabilities?: TerminalGraphicsCapabilities;
   render: () => void;
+  /**
+   * Force an immediate full repaint of the renderer's rows, bypassing frame
+   * throttling. For `anchor: "bottom"` (REPL bar) callers this re-anchors the
+   * bar and re-establishes the scroll region after the terminal resized or
+   * after native output was written above the bar.
+   */
+  forceRender: () => void;
   dispose: () => void;
   /** Move terminal cursor to specified cell position for IME input */
   setCursor: (x: number, y: number) => void;
@@ -136,6 +143,41 @@ export type StdoutRendererOptions = Readonly<{
   clear?: boolean;
   hideCursor?: boolean;
   altScreen?: boolean;
+  /**
+   * How the TUI buffer is anchored on the terminal screen.
+   *
+   * - `"top"` (default): buffer row 0 maps to screen row 1 — the renderer owns
+   *   the whole terminal screen (full-screen TUIs).
+   * - `"bottom"`: the buffer is pinned to the bottom `rows` of the terminal
+   *   screen (a REPL-style prompt bar). Everything above the buffer is native
+   *   terminal output owned by the caller (scrollback, right-click paste,
+   *   native scrolling) — the renderer only ever writes to its own pinned rows
+   *   and never clears or repaints the area above.
+   *
+   * In bottom mode the renderer:
+   * - repaints the full (small) buffer every frame, so an externally scrolled
+   *   screen can never leave stale bar rows behind;
+   * - never emits scroll-region operations that would disturb the caller's
+   *   scroll region above the bar;
+   * - skips the whole-screen clear even when `clear` is true;
+   * - establishes a scroll region that excludes the bar (`ESC[1;<screenRows-rows>r`)
+   *   so output written by the caller scrolls natively above the bar, and
+   *   restores it on dispose.
+   */
+  anchor?: "top" | "bottom";
+  /**
+   * Rows of blank space reserved between the native output region and the
+   * pinned bar in `anchor: "bottom"` mode. The bar stays at the very bottom;
+   * the scroll region the renderer establishes shrinks by `barGap` rows so
+   * caller output scrolls above a persistent blank gap. Default 0.
+   */
+  barGap?: number;
+  /**
+   * Live provider of the terminal screen height in rows (cells). Used only for
+   * `anchor: "bottom"` to compute the bar's pinned offset. Falls back to
+   * `output.rows` and then `process.stdout.rows` when omitted.
+   */
+  screenRows?: () => number;
   /** Fallback background color when a cell has no explicit bg. `null` = terminal default. */
   defaultBg?: string | null;
   /** Optional ANSI-name palette used when emitting ansi256/truecolor sequences. */
@@ -261,6 +303,36 @@ export function createStdoutRenderer(
   let palette: ThemePalette | null = options?.palette ?? null;
   const trackResize = options?.trackResize ?? true;
   const getImeAnchor = options?.getImeAnchor;
+  const anchorMode = options?.anchor === "bottom" ? "bottom" : "top";
+  const screenRowsFn = typeof options?.screenRows === "function" ? options.screenRows : undefined;
+  // Blank rows reserved between the output scroll region and the pinned bar.
+  const barGap = Math.max(0, Math.floor(Number(options?.barGap ?? 0)));
+  // Absolute screen-row offset for bottom-anchored (REPL bar) mode.
+  // Buffer row 0 maps to screen row `rowOffset` (0-based); 0 in top mode.
+  let rowOffset = 0;
+  // 1-based bottom row of the output scroll region (`ESC[1;<n>r`).
+  let scrollRegionBottom = 0;
+  const resolveScreenRows = (): number => {
+    let rows = 0;
+    if (screenRowsFn) {
+      const v = Math.floor(Number(screenRowsFn()));
+      if (Number.isFinite(v) && v > 0) rows = v;
+    }
+    if (!rows) {
+      const v = Math.floor(Number((out as any).rows));
+      if (Number.isFinite(v) && v > 0) rows = v;
+    }
+    if (!rows) {
+      const v = Math.floor(Number((process as any).stdout?.rows));
+      if (Number.isFinite(v) && v > 0) rows = v;
+    }
+    return rows;
+  };
+  const computeRowOffset = (bufferRows: number): number => {
+    if (anchorMode !== "bottom") return 0;
+    const offset = resolveScreenRows() - bufferRows;
+    return Number.isFinite(offset) && offset > 0 ? offset : 0;
+  };
   const allowFileUrls = options?.allowFileUrls ?? false;
   const cliLatency = getCliLatencyProfiler();
   const profiler = createTuiProfiler("stdout-renderer", {
@@ -1272,7 +1344,7 @@ export function createStdoutRenderer(
     let out = "";
 
     for (let row = 0; row < rect.h; row++) {
-      out += `\u001B[${rect.y + row + 1};${rect.x + 1}H${blank}`;
+      out += `\u001B[${rect.y + row + 1 + rowOffset};${rect.x + 1}H${blank}`;
     }
 
     return out;
@@ -2350,8 +2422,8 @@ export function createStdoutRenderer(
     rowCursorToCol1.length = rows;
     rowClearToEol.length = rows;
     for (let y = start; y < rows; y++) {
-      rowCursorToCol1[y] = `\u001B[${y + 1};1H`;
-      rowClearToEol[y] = `\u001B[${y + 1};1H\u001B[K`;
+      rowCursorToCol1[y] = `\u001B[${y + 1 + rowOffset};1H`;
+      rowClearToEol[y] = `\u001B[${y + 1 + rowOffset};1H\u001B[K`;
     }
   };
 
@@ -2818,6 +2890,26 @@ export function createStdoutRenderer(
       );
     }
     let terminalGraphicsBlockScrollRegions = false;
+    // Bottom-anchored REPL mode: the TUI owns only the last `size.rows` screen rows
+    // (the pinned bar). Repaint the whole (small) bar every frame so an externally
+    // scrolled screen can never leave stale bar rows, and drop scroll-region ops so
+    // the caller's scroll region above the bar is never disturbed. When the live
+    // screen height or bar gap changed, re-anchor and re-establish the region.
+    if (anchorMode === "bottom") {
+      dirtyRows = null;
+      scrollOperations = null;
+      const nextRowOffset = computeRowOffset(size.rows);
+      if (nextRowOffset !== rowOffset) {
+        rowOffset = nextRowOffset;
+        rowCursorToCol1.length = 0;
+        rowClearToEol.length = 0;
+      }
+      const nextRegionBottom = Math.max(1, nextRowOffset - barGap);
+      if (outputIsTTY && nextRegionBottom !== scrollRegionBottom) {
+        scrollRegionBottom = nextRegionBottom;
+        out.write(`\u001B[1;${nextRegionBottom}r`);
+      }
+    }
     ensureRowEscapes(Math.max(size.rows, lastRenderedRows));
     ensureFingerprints(size.cols, size.rows);
     const bgSeq = openBg(defaultBg);
@@ -3150,7 +3242,9 @@ export function createStdoutRenderer(
     frameParts.push(allowGraphicsOnlyWithoutBaseline || keepLineWrapDisabled ? "" : "\u001B[?7l");
     // Reset once at the start so we can avoid repeated resets for common style changes.
     frameParts.push(SGR_RESET, bgSeq);
-    if (hideCursor && !getImeAnchor) frameParts.push(CURSOR_HOME);
+    if (hideCursor && !getImeAnchor) {
+      frameParts.push(rowOffset > 0 ? `\u001B[${rowOffset + 1}H` : CURSOR_HOME);
+    }
 
     // Track consecutive row cursor optimization state
     let lastRenderedY = -1;
@@ -3263,7 +3357,7 @@ export function createStdoutRenderer(
 
         if (afterX >= size.cols) return;
 
-        parts.push(`\u001B[${y + 1};${afterX + 1}H`);
+        parts.push(`\u001B[${y + 1 + rowOffset};${afterX + 1}H`);
       };
 
       // Skip cursor positioning if disabled (ghostty workaround)
@@ -3274,7 +3368,7 @@ export function createStdoutRenderer(
           frameParts.push("\r\n");
         } else {
           frameParts.push(
-            spanStart === 0 ? rowCursorToCol1[y]! : `\u001B[${y + 1};${spanStart + 1}H`,
+            spanStart === 0 ? rowCursorToCol1[y]! : `\u001B[${y + 1 + rowOffset};${spanStart + 1}H`,
           );
         }
       }
@@ -3965,7 +4059,13 @@ export function createStdoutRenderer(
     // If rendered content shrank, clear the old extra rows.
     // But instead of using \u001B[J which causes flash, we fill with empty lines.
     // Do not write below the viewport during a rows-only terminal resize.
-    if (!rowsToRender && lastRenderedRows > size.rows && !rowsOnlyResizeBaseline) {
+    // Bottom-anchored bars never have rows below the buffer to clear.
+    if (
+      !rowsToRender &&
+      lastRenderedRows > size.rows &&
+      !rowsOnlyResizeBaseline &&
+      anchorMode !== "bottom"
+    ) {
       const extraRows = lastRenderedRows - size.rows;
       if (activeStyleKey !== bgKey) {
         frameParts.push(SGR_RESET, bgSeq);
@@ -4033,7 +4133,7 @@ export function createStdoutRenderer(
           !overlayTouchedRowSet?.has(y) &&
           Boolean(spans?.some((span) => span.start < rect.x + rect.w && span.end > rect.x));
         if ((!rowsToRender || rowWasPaintedByTextRenderer(y)) && !preservedGraphicSpan) continue;
-        out += `\u001B[${y + 1};${rect.x + 1}H${clearStyle}${erase}${SGR_RESET}`;
+        out += `\u001B[${y + 1 + rowOffset};${rect.x + 1}H${clearStyle}${erase}${SGR_RESET}`;
       }
 
       return out;
@@ -4092,7 +4192,7 @@ export function createStdoutRenderer(
 
         const cell = rect ? { x: rect.x, y: rect.y } : clampCellToViewport(fallbackCell, size);
         frameParts.push(
-          countGraphicsBytes(`\u001B[${cell.y + 1};${cell.x + 1}H`),
+          countGraphicsBytes(`\u001B[${cell.y + 1 + rowOffset};${cell.x + 1}H`),
           countGraphicsBytes(maybeWrapTerminalGraphic(sequence)),
           countGraphicsBytes(SGR_RESET),
         );
@@ -4373,7 +4473,9 @@ export function createStdoutRenderer(
     // Reset style at end to leave terminal in clean state
     if (enableOsc8Links && activeStyle.href) frameParts.push(OSC8_CLOSE);
     frameParts.push(SGR_RESET);
-    if (hideCursor && !getImeAnchor) frameParts.push(CURSOR_HOME);
+    if (hideCursor && !getImeAnchor) {
+      frameParts.push(rowOffset > 0 ? `\u001B[${rowOffset + 1}H` : CURSOR_HOME);
+    }
     // Re-enable line wrap and end synchronized output when this frame used it.
     // Alt-screen TUI sessions keep autowrap disabled between frames so terminal
     // window resizes clip existing content instead of reflowing it.
@@ -4980,7 +5082,7 @@ export function createStdoutRenderer(
   if (altScreen && outputIsTTY) out.write("\u001B[?1049h");
   if (keepLineWrapDisabled) out.write("\u001B[?7l");
   if (hideCursor) out.write("\u001B[?25l");
-  if (clear) {
+  if (clear && anchorMode !== "bottom") {
     out.write(`${SGR_RESET}${openBg(defaultBg)}\u001B[2J\u001B[H${SGR_RESET}`);
   }
 
@@ -5089,7 +5191,7 @@ export function createStdoutRenderer(
       { cols: size.cols, rows: size.rows },
     );
     // ANSI cursor position is 1-based: ESC [ row ; col H
-    out.write(`\u001B[${cy + 1};${cx + 1}H`);
+    out.write(`\u001B[${cy + 1 + rowOffset};${cx + 1}H`);
     lastCursorX = cx;
     lastCursorY = cy;
   }
@@ -5145,7 +5247,7 @@ export function createStdoutRenderer(
               ? { x: visibleRect.x, y: visibleRect.y }
               : clampCellToViewport({ cellX: active.x, cellY: active.y }, size);
             clearParts.push(
-              `\u001B[${cell.y + 1};${cell.x + 1}H`,
+              `\u001B[${cell.y + 1 + rowOffset};${cell.x + 1}H`,
               maybeWrapTerminalGraphic(active.clearSequence),
             );
             wroteClear = true;
@@ -5192,6 +5294,8 @@ export function createStdoutRenderer(
       if (keepLineWrapDisabled) out.write("\u001B[?7h");
       if (hideCursor) out.write("\u001B[?25h");
       if (altScreen && outputIsTTY) out.write("\u001B[?1049l");
+      // Restore the full-screen scroll region the REPL bar narrowed.
+      if (anchorMode === "bottom" && outputIsTTY && scrollRegionBottom > 0) out.write("\u001B[r");
     } catch (err) {
       if (disposeError == null) disposeError = err;
     }
@@ -5230,6 +5334,7 @@ export function createStdoutRenderer(
     capabilities: STDOUT_RENDERER_CAPABILITIES,
     graphicsCapabilities,
     render,
+    forceRender: () => render(undefined, true),
     dispose,
     setCursor,
     showCursor,

--- a/src/renderer/cli/stdout-renderer.ts
+++ b/src/renderer/cli/stdout-renderer.ts
@@ -155,9 +155,11 @@ export type StdoutRendererOptions = Readonly<{
    *   and never clears or repaints the area above.
    *
    * In bottom mode the renderer:
+   * - initially scrolls existing terminal contents upward to reserve the bar
+   *   rows and one fresh native-output row without overwriting prior history;
    * - repaints the full (small) buffer every frame, so an externally scrolled
    *   screen can never leave stale bar rows behind;
-   * - never emits scroll-region operations that would disturb the caller's
+   * - never emits buffer scroll operations that would disturb the caller's
    *   scroll region above the bar;
    * - skips the whole-screen clear even when `clear` is true;
    * - establishes a scroll region that excludes the bar (`ESC[1;<screenRows-rows>r`)
@@ -306,12 +308,17 @@ export function createStdoutRenderer(
   const anchorMode = options?.anchor === "bottom" ? "bottom" : "top";
   const screenRowsFn = typeof options?.screenRows === "function" ? options.screenRows : undefined;
   // Blank rows reserved between the output scroll region and the pinned bar.
-  const barGap = Math.max(0, Math.floor(Number(options?.barGap ?? 0)));
+  const rawBarGap = Math.floor(Number(options?.barGap ?? 0));
+  const barGap = Number.isFinite(rawBarGap) ? Math.max(0, rawBarGap) : 0;
   // Absolute screen-row offset for bottom-anchored (REPL bar) mode.
   // Buffer row 0 maps to screen row `rowOffset` (0-based); 0 in top mode.
   let rowOffset = 0;
   // 1-based bottom row of the output scroll region (`ESC[1;<n>r`).
   let scrollRegionBottom = 0;
+  // Existing terminal contents must be moved above the rows claimed by the bar
+  // exactly once, before narrowing the scroll region. Otherwise pre-existing
+  // output gets frozen in the gap or overwritten by the first native message.
+  let bottomRegionInitialized = false;
   const resolveScreenRows = (): number => {
     let rows = 0;
     if (screenRowsFn) {
@@ -2905,6 +2912,19 @@ export function createStdoutRenderer(
         rowClearToEol.length = 0;
       }
       const nextRegionBottom = Math.max(1, nextRowOffset - barGap);
+      if (outputIsTTY && !bottomRegionInitialized) {
+        const screenRows = resolveScreenRows();
+        if (screenRows > 0 && nextRowOffset > 0) {
+          // Make physical room before narrowing the scroll region. Merely setting
+          // DECSTBM would freeze pre-existing output in the gap/bar rows, and the
+          // caller's first native line would overwrite the old region-bottom row.
+          // One extra scroll leaves that region-bottom row fresh for the caller.
+          const reservedRows = Math.max(0, screenRows - nextRegionBottom);
+          const scrollCount = Math.min(screenRows, reservedRows + 1);
+          out.write(`\u001B[r\u001B[${screenRows};1H${"\n".repeat(scrollCount)}`);
+          bottomRegionInitialized = true;
+        }
+      }
       if (outputIsTTY && nextRegionBottom !== scrollRegionBottom) {
         scrollRegionBottom = nextRegionBottom;
         out.write(`\u001B[1;${nextRegionBottom}r`);
@@ -4456,9 +4476,10 @@ export function createStdoutRenderer(
         if (hasFrameOutput || x !== lastCursorX || y !== lastCursorY) {
           hasFrameOutput = true;
           emittedCursorPos = { x, y };
-          // ANSI cursor position is 1-based: ESC [ row ; col H
+          // ANSI cursor position is 1-based. Bottom-anchored buffers use local
+          // row coordinates, so map the IME anchor to its absolute screen row.
           closeActiveHrefBeforeCursorMove();
-          frameParts.push(`\u001B[${y + 1};${x + 1}H`);
+          frameParts.push(`\u001B[${y + 1 + rowOffset};${x + 1}H`);
         }
       }
     }

--- a/src/renderer/terminal-graphics.ts
+++ b/src/renderer/terminal-graphics.ts
@@ -1199,3 +1199,170 @@ export function wrapTerminalGraphicsForMultiplexer(
 
   return sequence;
 }
+
+export type TerminalGraphicPngViewport = Readonly<{
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}>;
+
+export type CreateTerminalGraphicPngSequenceOptions = Readonly<{
+  protocol: "kitty" | "iterm2";
+  base64: string;
+  imageId: number;
+  placementId: number;
+  cols?: number;
+  rows?: number;
+  sourceWidth?: number;
+  sourceHeight?: number;
+  placementColumns?: number;
+  placementRows?: number;
+  rect?: TerminalGraphicPngViewport;
+  fullRect?: TerminalGraphicPngViewport;
+  zIndex?: number;
+  freeImageData?: boolean;
+  fallback?: string;
+}>;
+
+export type TerminalGraphicPngSequenceResult = Readonly<{
+  type: "sequence";
+  protocol: "kitty" | "iterm2";
+  sequence: string;
+  resizeSequence?: string;
+  clearSequence?: string;
+  fallback?: string;
+  cols?: number;
+  rows?: number;
+  sourceWidth?: number;
+  sourceHeight?: number;
+  zIndex?: number;
+}>;
+
+function resolveKittyPngSourceCrop(
+  rect: TerminalGraphicPngViewport,
+  fullRect: TerminalGraphicPngViewport,
+  sourceWidth: number,
+  sourceHeight: number,
+): Readonly<{
+  sourceX: number;
+  sourceY: number;
+  sourceWidth: number;
+  sourceHeight: number;
+}> | null {
+  if (fullRect.w <= 0 || fullRect.h <= 0) return null;
+
+  const offsetX = Math.max(0, rect.x - fullRect.x);
+  const offsetY = Math.max(0, rect.y - fullRect.y);
+  const visibleW = Math.max(0, Math.min(rect.w, fullRect.w - offsetX));
+  const visibleH = Math.max(0, Math.min(rect.h, fullRect.h - offsetY));
+  if (offsetX <= 0 && offsetY <= 0 && visibleW >= fullRect.w && visibleH >= fullRect.h) {
+    return null;
+  }
+
+  const sourceX = Math.max(
+    0,
+    Math.min(sourceWidth - 1, Math.floor((offsetX * sourceWidth) / fullRect.w)),
+  );
+  const sourceY = Math.max(
+    0,
+    Math.min(sourceHeight - 1, Math.floor((offsetY * sourceHeight) / fullRect.h)),
+  );
+  const sourceRight = Math.max(
+    sourceX + 1,
+    Math.min(sourceWidth, Math.ceil(((offsetX + visibleW) * sourceWidth) / fullRect.w)),
+  );
+  const sourceBottom = Math.max(
+    sourceY + 1,
+    Math.min(sourceHeight, Math.ceil(((offsetY + visibleH) * sourceHeight) / fullRect.h)),
+  );
+  return {
+    sourceX,
+    sourceY,
+    sourceWidth: sourceRight - sourceX,
+    sourceHeight: sourceBottom - sourceY,
+  };
+}
+
+/**
+ * Build a kitty/iTerm2 graphics sequence that renders one PNG. Shared by the
+ * image renderer factory (`createPngTerminalGraphicRenderer`) and the video
+ * frame renderer (`TVideo`) so both emit the same terminal sequences.
+ *
+ * Returns null for protocols this helper does not handle (callers fall back).
+ */
+export function createTerminalGraphicPngSequence(
+  options: CreateTerminalGraphicPngSequenceOptions,
+): TerminalGraphicPngSequenceResult | null {
+  if (options.protocol === "kitty") {
+    let placement: Readonly<{
+      columns: number | undefined;
+      rows?: number;
+      sourceX?: number;
+      sourceY?: number;
+      sourceWidth?: number;
+      sourceHeight?: number;
+    }> = {
+      columns: options.placementColumns,
+      rows: options.placementRows,
+    };
+
+    if (options.rect && options.fullRect && options.sourceWidth && options.sourceHeight) {
+      const crop = resolveKittyPngSourceCrop(
+        options.rect,
+        options.fullRect,
+        options.sourceWidth,
+        options.sourceHeight,
+      );
+      if (crop) placement = { ...placement, ...crop };
+    }
+
+    return {
+      type: "sequence",
+      protocol: "kitty",
+      sequence: createKittyGraphicsSequence(options.base64, {
+        imageId: options.imageId,
+        placementId: options.placementId,
+        zIndex: options.zIndex,
+        ...placement,
+      }),
+      resizeSequence: createKittyPlacementSequence({
+        imageId: options.imageId,
+        placementId: options.placementId,
+        zIndex: options.zIndex,
+        ...placement,
+      }),
+      clearSequence: createKittyDeleteGraphicsSequence({
+        imageId: options.imageId,
+        placementId: options.placementId,
+        freeImageData: options.freeImageData,
+      }),
+      ...(options.fallback != null ? { fallback: options.fallback } : {}),
+      ...(options.cols != null ? { cols: options.cols } : {}),
+      ...(options.rows != null ? { rows: options.rows } : {}),
+      ...(options.sourceWidth != null ? { sourceWidth: options.sourceWidth } : {}),
+      ...(options.sourceHeight != null ? { sourceHeight: options.sourceHeight } : {}),
+      ...(options.zIndex != null ? { zIndex: options.zIndex } : {}),
+    };
+  }
+
+  if (options.protocol === "iterm2") {
+    return {
+      type: "sequence",
+      protocol: "iterm2",
+      sequence: createIterm2InlineImageSequence(options.base64, {
+        width: options.cols,
+        height: options.rows,
+        preserveAspectRatio: true,
+        doNotMoveCursor: true,
+      }),
+      ...(options.fallback != null ? { fallback: options.fallback } : {}),
+      ...(options.cols != null ? { cols: options.cols } : {}),
+      ...(options.rows != null ? { rows: options.rows } : {}),
+      ...(options.sourceWidth != null ? { sourceWidth: options.sourceWidth } : {}),
+      ...(options.sourceHeight != null ? { sourceHeight: options.sourceHeight } : {}),
+    };
+  }
+
+  return null;
+}

--- a/src/vue/agent/create-png-terminal-graphic-renderer.ts
+++ b/src/vue/agent/create-png-terminal-graphic-renderer.ts
@@ -4,10 +4,7 @@ import type {
 } from "../components/TAgentTerminalGraphic.js";
 import type { TerminalGraphicRenderQueue } from "../../renderer/terminal-graphic-render-queue.js";
 import {
-  createIterm2InlineImageSequence,
-  createKittyDeleteGraphicsSequence,
-  createKittyGraphicsSequence,
-  createKittyPlacementSequence,
+  createTerminalGraphicPngSequence,
   hashTerminalGraphicsString,
   isSafeTerminalGraphicsSequence,
   normalizeTerminalGraphicSize,
@@ -160,57 +157,6 @@ function normalizeCachedPngFrame(
   };
 }
 
-function resolveKittyViewportPlacement(
-  png: CachedPngTerminalGraphicFrame,
-  context: TAgentTerminalGraphicRendererContext,
-): Readonly<{
-  columns: number;
-  rows?: number;
-  sourceX?: number;
-  sourceY?: number;
-  sourceWidth?: number;
-  sourceHeight?: number;
-}> {
-  const rect = context.viewport.rect;
-  const full = context.viewport.fullRect;
-  const columns = positiveInt(rect.w) ?? png.cols;
-  const rows = positiveInt(rect.h) ?? png.rows;
-  const sourceWidth = positiveInt(png.sourceWidth);
-  const sourceHeight = positiveInt(png.sourceHeight);
-
-  if (!sourceWidth || !sourceHeight || full.w <= 0 || full.h <= 0) {
-    return { columns, rows };
-  }
-
-  const offsetX = Math.max(0, rect.x - full.x);
-  const offsetY = Math.max(0, rect.y - full.y);
-  const visibleW = Math.max(0, Math.min(rect.w, full.w - offsetX));
-  const visibleH = Math.max(0, Math.min(rect.h, full.h - offsetY));
-  if (offsetX <= 0 && offsetY <= 0 && visibleW >= full.w && visibleH >= full.h) {
-    return { columns, rows };
-  }
-
-  const x0 = Math.max(0, Math.min(sourceWidth - 1, Math.floor((offsetX * sourceWidth) / full.w)));
-  const y0 = Math.max(0, Math.min(sourceHeight - 1, Math.floor((offsetY * sourceHeight) / full.h)));
-  const x1 = Math.max(
-    x0 + 1,
-    Math.min(sourceWidth, Math.ceil(((offsetX + visibleW) * sourceWidth) / full.w)),
-  );
-  const y1 = Math.max(
-    y0 + 1,
-    Math.min(sourceHeight, Math.ceil(((offsetY + visibleH) * sourceHeight) / full.h)),
-  );
-
-  return {
-    columns,
-    rows,
-    sourceX: x0,
-    sourceY: y0,
-    sourceWidth: x1 - x0,
-    sourceHeight: y1 - y0,
-  };
-}
-
 function pngFrameBytes(frame: CachedPngTerminalGraphicFrame): number {
   return frame.base64.length + (frame.fallback?.length ?? 0);
 }
@@ -305,61 +251,30 @@ export function createPngTerminalGraphicRenderer(
       return textFallbackResult(await fallback());
     }
 
-    if (protocol === "kitty") {
-      const placement = resolveKittyViewportPlacement(png, context);
-      const sequence = createKittyGraphicsSequence(png.base64, {
+    if (protocol === "kitty" || protocol === "iterm2") {
+      const rect = context.viewport.rect;
+      const fullRect = context.viewport.fullRect;
+      const result = createTerminalGraphicPngSequence({
+        protocol,
+        base64: png.base64,
         imageId: context.imageId,
         placementId: context.placementId,
-        zIndex: options.zIndex,
-        ...placement,
-      });
-      const resizeSequence = createKittyPlacementSequence({
-        imageId: context.imageId,
-        placementId: context.placementId,
-        zIndex: options.zIndex,
-        ...placement,
-      });
-      if (!isSafeTerminalGraphicsSequence(sequence, "kitty", "draw")) {
-        return textFallbackResult(await fallback());
-      }
-
-      return {
-        type: "sequence",
-        protocol: "kitty",
-        sequence,
-        resizeSequence,
-        clearSequence: createKittyDeleteGraphicsSequence({
-          imageId: context.imageId,
-          placementId: context.placementId,
-        }),
-        ...(await sequenceFallback()),
         cols: png.cols,
         rows: png.rows,
         sourceWidth: png.sourceWidth,
         sourceHeight: png.sourceHeight,
+        placementColumns: positiveInt(rect.w) ?? png.cols,
+        placementRows: positiveInt(rect.h) ?? png.rows,
+        rect,
+        fullRect,
         zIndex: options.zIndex,
-      };
-    }
-
-    if (protocol === "iterm2") {
-      const sequence = createIterm2InlineImageSequence(png.base64, {
-        width: png.cols,
-        height: png.rows,
-        preserveAspectRatio: true,
-        doNotMoveCursor: true,
+        fallback: await fallback(),
       });
-      if (!isSafeTerminalGraphicsSequence(sequence, "iterm2", "draw")) {
+      if (!result) return textFallbackResult(await fallback());
+      if (!isSafeTerminalGraphicsSequence(result.sequence, protocol, "draw")) {
         return textFallbackResult(await fallback());
       }
-
-      return {
-        type: "sequence",
-        protocol: "iterm2",
-        sequence,
-        ...(await sequenceFallback()),
-        cols: png.cols,
-        rows: png.rows,
-      };
+      return result;
     }
 
     if (protocol === "sixel") {

--- a/src/vue/components/TMarkdownText.ts
+++ b/src/vue/components/TMarkdownText.ts
@@ -2,6 +2,7 @@ import type { PropType } from "vue";
 import type { Style } from "../../core/types.js";
 import type { Rect, TerminalPointerEvent } from "../../events/manager/types.js";
 import {
+  getTerminalGraphicsOutput,
   getTerminalGraphicsOutputVersion,
   subscribeTerminalGraphicsOutput,
 } from "../../renderer/terminal-graphics.js";
@@ -20,6 +21,14 @@ import { buildMarkdownVisualRows } from "../markdown/document.js";
 import { findMarkdownImageActionAt } from "../markdown/image-actions.js";
 import { findMarkdownLinkActionAt } from "../markdown/link-actions.js";
 import { findMarkdownMathActionAt } from "../markdown/math-actions.js";
+import {
+  enqueueMarkdownMathImages,
+  isMarkdownMathImageRendererReady,
+  loadMarkdownMathImageRenderer,
+  resolveMarkdownMathColor,
+  subscribeMarkdownMathImage,
+} from "../markdown/math-image.js";
+import { type TuiMarkdownMathOptions } from "../markdown/ast.js";
 import { subscribeMarkdownMathRenderer } from "../markdown/math.js";
 import { createTuiMarkdownParser } from "../markdown/parser.js";
 import {
@@ -74,6 +83,13 @@ export const TMarkdownText = defineComponent({
     imageMinHeight: { type: Number, default: undefined },
     imageMaxHeight: { type: Number, default: undefined },
     imagePreserveAspectRatio: { type: Boolean, default: true },
+    mathImages: { type: Boolean, default: true },
+    mathCellWidthPx: { type: Number, default: undefined },
+    mathCellHeightPx: { type: Number, default: undefined },
+    mathScale: { type: Number, default: undefined },
+    mathColor: { type: String, default: undefined },
+    mathMaxWidthCells: { type: Number, default: undefined },
+    mathBaselineRatio: { type: Number, default: undefined },
     imageActions: { type: Boolean, default: false },
     mathActions: { type: Boolean, default: false },
     linkActions: { type: Boolean, default: false },
@@ -110,8 +126,12 @@ export const TMarkdownText = defineComponent({
     const graphicsOutputVersion = shallowRef(getTerminalGraphicsOutputVersion(terminal));
     const unsubscribeGraphicsOutput = subscribeTerminalGraphicsOutput(terminal, () => {
       graphicsOutputVersion.value = getTerminalGraphicsOutputVersion(terminal);
+      enqueuePendingMathImages();
     });
     const unsubscribeMathRenderer = subscribeMarkdownMathRenderer(() => {
+      scheduleRebuild();
+    });
+    const unsubscribeMathImage = subscribeMarkdownMathImage(() => {
       scheduleRebuild();
     });
 
@@ -127,6 +147,32 @@ export const TMarkdownText = defineComponent({
       },
     );
 
+    function mathOptions(): TuiMarkdownMathOptions {
+      if (props.mathImages === false) return { enabled: false };
+      const resolvedColor = props.mathColor ?? resolveMarkdownMathColor(defaultStyle.value.fg);
+      return {
+        enabled: true,
+        ...(props.mathCellWidthPx != null ? { cellWidthPx: props.mathCellWidthPx } : {}),
+        ...(props.mathCellHeightPx != null ? { cellHeightPx: props.mathCellHeightPx } : {}),
+        ...(props.mathScale != null ? { scale: props.mathScale } : {}),
+        ...(resolvedColor != null ? { color: resolvedColor } : {}),
+        ...(props.mathBaselineRatio != null ? { baselineRatio: props.mathBaselineRatio } : {}),
+        maxWidthCells: props.mathMaxWidthCells ?? props.w,
+      };
+    }
+
+    function enqueuePendingMathImages(): void {
+      if (props.mathImages === false) return;
+      if (!getTerminalGraphicsOutput(terminal)?.capabilities.supported) return;
+      if (!isMarkdownMathImageRendererReady()) {
+        void loadMarkdownMathImageRenderer().then((ready) => {
+          if (ready && alive) scheduleRebuild();
+        });
+        return;
+      }
+      enqueueMarkdownMathImages(rows.value, mathOptions());
+    }
+
     function rebuildRows(): void {
       rows.value = markRaw(
         withTextWidthProvider(widthProvider, () =>
@@ -141,10 +187,12 @@ export const TMarkdownText = defineComponent({
               maxHeight: props.imageMaxHeight,
               preserveAspectRatio: props.imagePreserveAspectRatio,
             },
+            math: mathOptions(),
           }),
         ),
       );
       documentVersion.value++;
+      enqueuePendingMathImages();
     }
 
     function scheduleRebuild(): void {
@@ -183,6 +231,13 @@ export const TMarkdownText = defineComponent({
         () => props.imageMinHeight,
         () => props.imageMaxHeight,
         () => props.imagePreserveAspectRatio,
+        () => props.mathImages,
+        () => props.mathCellWidthPx,
+        () => props.mathCellHeightPx,
+        () => props.mathScale,
+        () => props.mathColor,
+        () => props.mathMaxWidthCells,
+        () => props.mathBaselineRatio,
       ],
       () => {
         scheduleRebuild();
@@ -195,6 +250,7 @@ export const TMarkdownText = defineComponent({
       rebuildVersion++;
       unsubscribeGraphicsOutput();
       unsubscribeMathRenderer();
+      unsubscribeMathImage();
       clearMarkdownImageGraphics(terminal, fullRect.value);
     });
 

--- a/src/vue/components/TVideo.ts
+++ b/src/vue/components/TVideo.ts
@@ -1,10 +1,7 @@
 import type { TerminalKeyboardEvent, TerminalPointerEvent } from "../../events/manager/types.js";
 import type { ExtractPublicPropTypes, PropType } from "vue";
 import type { Style } from "../../core/types.js";
-import type {
-  TAgentTerminalGraphicRenderer,
-  TAgentTerminalGraphicRendererContext,
-} from "./TAgentTerminalGraphic.js";
+import type { TAgentTerminalGraphicRenderer } from "./TAgentTerminalGraphic.js";
 import type {
   TVideoFrame,
   TVideoFrameEvent,
@@ -23,10 +20,7 @@ import {
   watch,
 } from "vue";
 import {
-  createIterm2InlineImageSequence,
-  createKittyDeleteGraphicsSequence,
-  createKittyGraphicsSequence,
-  createKittyPlacementSequence,
+  createTerminalGraphicPngSequence,
   getTerminalGraphicsOutput,
   getTerminalGraphicsOutputVersion,
   subscribeTerminalGraphicsOutput,
@@ -243,51 +237,6 @@ function bytesToBase64(bytes: Uint8Array): string {
   return chunks.join("");
 }
 
-function resolveKittyPlacement(
-  frame: NormalizedVideoFrame,
-  context: TAgentTerminalGraphicRendererContext,
-) {
-  const rect = context.viewport.rect;
-  const full = context.viewport.fullRect;
-  const columns = Math.max(1, Math.floor(rect.w));
-  const rows = Math.max(1, Math.floor(rect.h));
-  if (full.w <= 0 || full.h <= 0) return { columns, rows };
-
-  const offsetX = Math.max(0, rect.x - full.x);
-  const offsetY = Math.max(0, rect.y - full.y);
-  const visibleW = Math.max(0, Math.min(rect.w, full.w - offsetX));
-  const visibleH = Math.max(0, Math.min(rect.h, full.h - offsetY));
-  if (offsetX <= 0 && offsetY <= 0 && visibleW >= full.w && visibleH >= full.h) {
-    return { columns, rows };
-  }
-
-  const sourceX = Math.max(
-    0,
-    Math.min(frame.pixelWidth - 1, Math.floor((offsetX * frame.pixelWidth) / full.w)),
-  );
-  const sourceY = Math.max(
-    0,
-    Math.min(frame.pixelHeight - 1, Math.floor((offsetY * frame.pixelHeight) / full.h)),
-  );
-  const sourceRight = Math.max(
-    sourceX + 1,
-    Math.min(frame.pixelWidth, Math.ceil(((offsetX + visibleW) * frame.pixelWidth) / full.w)),
-  );
-  const sourceBottom = Math.max(
-    sourceY + 1,
-    Math.min(frame.pixelHeight, Math.ceil(((offsetY + visibleH) * frame.pixelHeight) / full.h)),
-  );
-
-  return {
-    columns,
-    rows,
-    sourceX,
-    sourceY,
-    sourceWidth: sourceRight - sourceX,
-    sourceHeight: sourceBottom - sourceY,
-  };
-}
-
 function createFrameRenderer(
   frame: NormalizedVideoFrame,
   cellWidth: number,
@@ -303,51 +252,24 @@ function createFrameRenderer(
     if (!context.visible || !context.rawVisible) return null;
     base64 ??= bytesToBase64(frame.png);
 
-    if (context.protocol === "kitty") {
-      const placement = resolveKittyPlacement(frame, context);
-      return {
-        type: "sequence",
-        protocol: "kitty",
-        sequence: createKittyGraphicsSequence(base64, {
-          imageId: context.imageId,
-          placementId: context.placementId,
-          ...placement,
-        }),
-        resizeSequence: createKittyPlacementSequence({
-          imageId: context.imageId,
-          placementId: context.placementId,
-          ...placement,
-        }),
-        clearSequence: createKittyDeleteGraphicsSequence({
-          imageId: context.imageId,
-          placementId: context.placementId,
-          freeImageData: true,
-        }),
-        cols: context.width,
-        rows: context.height,
-        sourceWidth: frame.pixelWidth,
-        sourceHeight: frame.pixelHeight,
-      };
-    }
+    const protocol = context.protocol;
+    if (protocol !== "kitty" && protocol !== "iterm2") return null;
 
-    if (context.protocol === "iterm2") {
-      return {
-        type: "sequence",
-        protocol: "iterm2",
-        sequence: createIterm2InlineImageSequence(base64, {
-          width: context.width,
-          height: context.height,
-          preserveAspectRatio: true,
-          doNotMoveCursor: true,
-        }),
-        cols: context.width,
-        rows: context.height,
-        sourceWidth: frame.pixelWidth,
-        sourceHeight: frame.pixelHeight,
-      };
-    }
-
-    return null;
+    return createTerminalGraphicPngSequence({
+      protocol,
+      base64,
+      imageId: context.imageId,
+      placementId: context.placementId,
+      cols: context.width,
+      rows: context.height,
+      sourceWidth: frame.pixelWidth,
+      sourceHeight: frame.pixelHeight,
+      placementColumns: Math.max(1, Math.floor(context.viewport.rect.w)),
+      placementRows: Math.max(1, Math.floor(context.viewport.rect.h)),
+      rect: context.viewport.rect,
+      fullRect: context.viewport.fullRect,
+      freeImageData: true,
+    });
   };
 }
 

--- a/src/vue/components/TVirtualMarkdown.ts
+++ b/src/vue/components/TVirtualMarkdown.ts
@@ -28,12 +28,21 @@ import { buildMarkdownBlocks } from "../markdown/document.js";
 import { findMarkdownImageActionAt } from "../markdown/image-actions.js";
 import { findMarkdownLinkActionAt } from "../markdown/link-actions.js";
 import { findMarkdownMathActionAt } from "../markdown/math-actions.js";
+import {
+  enqueueMarkdownMathImages,
+  isMarkdownMathImageRendererReady,
+  loadMarkdownMathImageRenderer,
+  resolveMarkdownMathColor,
+  subscribeMarkdownMathImage,
+} from "../markdown/math-image.js";
+import { type TuiMarkdownMathOptions } from "../markdown/ast.js";
 import { subscribeMarkdownMathRenderer } from "../markdown/math.js";
 import {
   terminalSelectionRowSpans,
   terminalSelectionVisibleRowSpans,
 } from "../../selection/terminal-selection.js";
 import {
+  getTerminalGraphicsOutput,
   getTerminalGraphicsOutputVersion,
   subscribeTerminalGraphicsOutput,
 } from "../../renderer/terminal-graphics.js";
@@ -166,6 +175,13 @@ export const TVirtualMarkdown = defineComponent({
     imageMinHeight: { type: Number, default: undefined },
     imageMaxHeight: { type: Number, default: undefined },
     imagePreserveAspectRatio: { type: Boolean, default: true },
+    mathImages: { type: Boolean, default: true },
+    mathCellWidthPx: { type: Number, default: undefined },
+    mathCellHeightPx: { type: Number, default: undefined },
+    mathScale: { type: Number, default: undefined },
+    mathColor: { type: String, default: undefined },
+    mathMaxWidthCells: { type: Number, default: undefined },
+    mathBaselineRatio: { type: Number, default: undefined },
     imageActions: { type: Boolean, default: false },
     mathActions: { type: Boolean, default: false },
     linkActions: { type: Boolean, default: false },
@@ -211,10 +227,44 @@ export const TVirtualMarkdown = defineComponent({
     const graphicsOutputVersion = shallowRef(getTerminalGraphicsOutputVersion(terminal));
     const unsubscribeGraphicsOutput = subscribeTerminalGraphicsOutput(terminal, () => {
       graphicsOutputVersion.value = getTerminalGraphicsOutputVersion(terminal);
+      enqueuePendingMathImages();
     });
     const unsubscribeMathRenderer = subscribeMarkdownMathRenderer(() => {
       scheduleRebuild();
     });
+    const unsubscribeMathImage = subscribeMarkdownMathImage(() => {
+      scheduleRebuild();
+    });
+
+    function mathOptions(): TuiMarkdownMathOptions {
+      if (props.mathImages === false) return { enabled: false };
+      const resolvedColor = props.mathColor ?? resolveMarkdownMathColor(defaultStyle.value.fg);
+      return {
+        enabled: true,
+        ...(props.mathCellWidthPx != null ? { cellWidthPx: props.mathCellWidthPx } : {}),
+        ...(props.mathCellHeightPx != null ? { cellHeightPx: props.mathCellHeightPx } : {}),
+        ...(props.mathScale != null ? { scale: props.mathScale } : {}),
+        ...(resolvedColor != null ? { color: resolvedColor } : {}),
+        ...(props.mathBaselineRatio != null ? { baselineRatio: props.mathBaselineRatio } : {}),
+        maxWidthCells: props.mathMaxWidthCells ?? props.w,
+      };
+    }
+
+    function enqueuePendingMathImages(): void {
+      if (props.mathImages === false) return;
+      if (!getTerminalGraphicsOutput(terminal)?.capabilities.supported) return;
+      if (!isMarkdownMathImageRendererReady()) {
+        void loadMarkdownMathImageRenderer().then((ready) => {
+          if (ready && alive) scheduleRebuild();
+        });
+        return;
+      }
+      const h = Math.max(0, Math.floor(props.h ?? absRect.value.h));
+      enqueueMarkdownMathImages(rows.value, mathOptions(), {
+        firstRow: internalScrollTop.value,
+        lastRow: internalScrollTop.value + h,
+      });
+    }
 
     watch(
       () => `${props.streaming ? 1 : 0}:${(props.customHtmlTags ?? []).join("\u0000")}`,
@@ -246,12 +296,14 @@ export const TVirtualMarkdown = defineComponent({
               maxHeight: props.imageMaxHeight,
               preserveAspectRatio: props.imagePreserveAspectRatio,
             },
+            math: mathOptions(),
           }).blocks;
         return layoutMarkdownBlocksCached(blocks, props.w, layoutCache);
       });
       layoutCache = markRaw(nextLayout.cache);
       const nextRows = nextLayout.rows;
       rows.value = markRaw(nextRows);
+      enqueuePendingMathImages();
       reconcileScrollTop();
       const nextScrollTop = internalScrollTop.value;
       const nextVisibleRows = visibleRowSignatures(nextRows, nextScrollTop);
@@ -432,6 +484,11 @@ export const TVirtualMarkdown = defineComponent({
       },
     );
 
+    // Rasterize formulas as they scroll into view (deduped by the cache).
+    watch(internalScrollTop, () => {
+      enqueuePendingMathImages();
+    });
+
     watch(
       [
         () => props.content,
@@ -446,6 +503,13 @@ export const TVirtualMarkdown = defineComponent({
         () => props.imageMinHeight,
         () => props.imageMaxHeight,
         () => props.imagePreserveAspectRatio,
+        () => props.mathImages,
+        () => props.mathCellWidthPx,
+        () => props.mathCellHeightPx,
+        () => props.mathScale,
+        () => props.mathColor,
+        () => props.mathMaxWidthCells,
+        () => props.mathBaselineRatio,
       ],
       () => {
         scheduleRebuild();
@@ -699,6 +763,7 @@ export const TVirtualMarkdown = defineComponent({
       rebuildVersion++;
       unsubscribeGraphicsOutput();
       unsubscribeMathRenderer();
+      unsubscribeMathImage();
       clearMarkdownImageGraphics(terminal, fullRect.value);
     });
 

--- a/src/vue/markdown/ast.ts
+++ b/src/vue/markdown/ast.ts
@@ -1,6 +1,6 @@
 import { sanitizeInlineText, sanitizeTextBlock, spaces, textCellWidth } from "../utils/text.js";
 import { readMarkdownImageDimensions, sanitizeMarkdownImageSource } from "./image.js";
-import { renderMarkdownInlineMathSegment } from "./math.js";
+import { getCachedMarkdownMathImage, type TuiMarkdownMathImageOptions } from "./math-image.js";
 import { sanitizeMarkdownLink } from "./parser.js";
 import { type TuiMarkdownTheme } from "./theme.js";
 import type {
@@ -15,11 +15,18 @@ import type {
   TuiMarkdownTableCellAlign,
 } from "./types.js";
 
+export type TuiMarkdownMathOptions = Readonly<
+  {
+    enabled?: boolean;
+  } & TuiMarkdownMathImageOptions
+>;
+
 type BlockContext = Readonly<{
   prefixSegments: readonly TuiMarkdownInlineSegment[];
   continuationPrefixSegments: readonly TuiMarkdownInlineSegment[];
   imageResolver?: TuiMarkdownImageResolver;
   imageSize?: TuiMarkdownImageSize;
+  math?: TuiMarkdownMathOptions;
 }>;
 
 const EMPTY_PREFIX: readonly TuiMarkdownInlineSegment[] = Object.freeze([]);
@@ -223,6 +230,7 @@ function inlineNodeSegments(
   options: Readonly<{
     imageResolver?: TuiMarkdownImageResolver;
     imageSize?: TuiMarkdownImageSize;
+    math?: TuiMarkdownMathOptions;
   }> = {},
 ): TuiMarkdownInlineSegment[] {
   const out: TuiMarkdownInlineSegment[] = [];
@@ -390,19 +398,39 @@ function inlineNodeSegments(
       case "math_inline":
         {
           const source = stringProp(node, "content");
-          const raw = stringProp(node, "raw") || `$${source}$`;
-          const rendered = renderMarkdownInlineMathSegment(source);
-          pushTextSegments(
-            out,
-            rendered.supported ? rendered.text : raw,
-            mergeStyle(inheritedStyle, theme.inlineCode),
-            undefined,
-            {
-              source,
+          const markup = stringProp(node, "markup") || "$";
+          const raw = stringProp(node, "raw") || `${markup}${source}${markup}`;
+          const mathStyle = mergeStyle(inheritedStyle, theme.inlineCode);
+          const tex = sanitizeInlineText(source);
+          const mathEnabled = options.math?.enabled !== false;
+          const cached =
+            tex && mathEnabled ? getCachedMarkdownMathImage(tex, "inline", options.math) : null;
+          if (cached) {
+            pushTextSegments(
+              out,
               raw,
-              rendered: rendered.supported,
-            },
-          );
+              mathStyle,
+              {
+                kind: "math",
+                tex,
+                raw,
+                base64: cached.base64,
+                displayWidth: cached.widthCells,
+                displayHeight: cached.heightCells,
+              },
+              { source: tex, raw, rendered: true },
+            );
+          } else {
+            pushTextSegments(
+              out,
+              raw,
+              mathStyle,
+              undefined,
+              tex && mathEnabled
+                ? { source: tex, raw, rendered: false, pendingImage: true, mode: "inline" }
+                : { source, raw, rendered: false },
+            );
+          }
         }
         break;
       case "reference":
@@ -453,6 +481,7 @@ function blockFromParagraph(
     inlineNodeSegments(nodeChildren(node), theme, undefined, {
       imageResolver: context.imageResolver,
       imageSize: context.imageSize,
+      math: context.math,
     }),
     context,
   );
@@ -470,6 +499,7 @@ function blockFromHeading(
     inlineNodeSegments(nodeChildren(node), theme, theme.heading[level - 1], {
       imageResolver: context.imageResolver,
       imageSize: context.imageSize,
+      math: context.math,
     }),
     context,
   );
@@ -510,7 +540,7 @@ function blockFromHtmlBlock(
       ],
       theme,
       undefined,
-      { imageResolver: context.imageResolver },
+      { imageResolver: context.imageResolver, math: context.math },
     ),
     context,
   );
@@ -545,6 +575,7 @@ function blockFromTable(
     segments: inlineNodeSegments(nodeChildren(cell), theme, theme.strong, {
       imageResolver: context.imageResolver,
       imageSize: context.imageSize,
+      math: context.math,
     }),
     align: tableCellAlign(cell),
   }));
@@ -553,6 +584,7 @@ function blockFromTable(
       segments: inlineNodeSegments(nodeChildren(cell), theme, undefined, {
         imageResolver: context.imageResolver,
         imageSize: context.imageSize,
+        math: context.math,
       }),
       align: tableCellAlign(cell),
     })),
@@ -609,10 +641,12 @@ function listItemBlocks(
   const firstContext: BlockContext = {
     prefixSegments: [...context.prefixSegments, markerSegment],
     continuationPrefixSegments: [...context.continuationPrefixSegments, indentSegment],
+    math: context.math,
   };
   const nestedContext: BlockContext = {
     prefixSegments: [...context.continuationPrefixSegments, indentSegment],
     continuationPrefixSegments: [...context.continuationPrefixSegments, indentSegment],
+    math: context.math,
   };
 
   const children = nodeChildren(item);
@@ -683,6 +717,58 @@ function listBlocks(
   return out;
 }
 
+/**
+ * Block-level display math (`$...$`). When a rasterized PNG is available this
+ * becomes a graphic segment rendered through the terminal graphics pipeline
+ * (Kitty/iTerm2/Sixel); otherwise it is wrapped in a box with the raw TeX text
+ * (also the permanent presentation when graphics/raster support is missing).
+ * Clicking either form emits `mathAction` so consumers can copy the raw content.
+ */
+function blockMathSegments(
+  source: string,
+  raw: string,
+  math: TuiMarkdownMathOptions,
+  theme: TuiMarkdownTheme,
+): TuiMarkdownInlineSegment[] {
+  const tex = sanitizeInlineText(source);
+  const canUseImage = Boolean(tex) && math.enabled !== false;
+  const cached = canUseImage ? getCachedMarkdownMathImage(tex, "display", math) : null;
+
+  if (canUseImage && cached) {
+    return [
+      {
+        text: raw,
+        style: theme.math,
+        graphic: {
+          kind: "math",
+          tex,
+          raw,
+          base64: cached.base64,
+          displayWidth: cached.widthCells,
+          displayHeight: cached.heightCells,
+        },
+        mathAction: { source: tex, raw, rendered: true },
+      },
+    ];
+  }
+
+  const maxWidth = Math.max(8, Math.floor(math.maxWidthCells ?? 0) || 40);
+  const rawCells = textCellWidth(raw);
+  const inner = Math.min(Math.max(1, rawCells + 2), maxWidth);
+  const pad = Math.max(0, inner - rawCells);
+  return [
+    { text: `┌${"─".repeat(inner)}┐`, style: theme.math },
+    HARD_BREAK_SEGMENT,
+    {
+      text: `│ ${raw}${" ".repeat(pad)}│`,
+      style: theme.math,
+      mathAction: { source: tex, raw, rendered: false, pendingImage: true },
+    },
+    HARD_BREAK_SEGMENT,
+    { text: `└${"─".repeat(inner)}┘`, style: theme.math },
+  ];
+}
+
 function nodeToBlocks(
   node: TuiMarkdownNode,
   context: BlockContext,
@@ -711,6 +797,19 @@ function nodeToBlocks(
           prefixSegments: context.prefixSegments,
         },
       ];
+    case "math_block":
+      return [
+        inlineBlock(
+          keyPrefix,
+          blockMathSegments(
+            stringProp(node, "content"),
+            stringProp(node, "raw") || `$${stringProp(node, "content")}$`,
+            context.math ?? { enabled: true },
+            theme,
+          ),
+          context,
+        ),
+      ];
     case "blockquote": {
       const quoteSegment: TuiMarkdownInlineSegment = {
         text: "│ ",
@@ -721,6 +820,7 @@ function nodeToBlocks(
         continuationPrefixSegments: [...context.continuationPrefixSegments, quoteSegment],
         imageResolver: context.imageResolver,
         imageSize: context.imageSize,
+        math: context.math,
       };
       return childSequenceToBlocks(nodeChildren(node), quoteContext, theme, keyPrefix);
     }
@@ -737,6 +837,7 @@ function nodeToBlocks(
           inlineNodeSegments(nodeChildren(node), theme, undefined, {
             imageResolver: context.imageResolver,
             imageSize: context.imageSize,
+            math: context.math,
           }),
           context,
         ),
@@ -748,7 +849,10 @@ function nodeToBlocks(
       return [
         inlineBlock(
           keyPrefix,
-          inlineNodeSegments([node], theme, undefined, { imageResolver: context.imageResolver }),
+          inlineNodeSegments([node], theme, undefined, {
+            imageResolver: context.imageResolver,
+            math: context.math,
+          }),
           context,
         ),
       ];
@@ -758,7 +862,10 @@ function nodeToBlocks(
   return [
     inlineBlock(
       keyPrefix,
-      inlineNodeSegments([node], theme, undefined, { imageResolver: context.imageResolver }),
+      inlineNodeSegments([node], theme, undefined, {
+        imageResolver: context.imageResolver,
+        math: context.math,
+      }),
       context,
     ),
   ];
@@ -770,6 +877,7 @@ export function markdownAstToBlocks(
   options: Readonly<{
     imageResolver?: TuiMarkdownImageResolver;
     imageSize?: TuiMarkdownImageSize;
+    math?: TuiMarkdownMathOptions;
   }> = {},
 ): readonly TuiMarkdownBlock[] {
   const blocks = trimBlockArray(
@@ -780,6 +888,7 @@ export function markdownAstToBlocks(
         continuationPrefixSegments: EMPTY_PREFIX,
         imageResolver: options.imageResolver,
         imageSize: options.imageSize,
+        math: options.math,
       },
       theme,
       "md",

--- a/src/vue/markdown/document.ts
+++ b/src/vue/markdown/document.ts
@@ -1,5 +1,5 @@
 import type { TuiMarkdownImageResolver, TuiMarkdownImageSize } from "./types.js";
-import { markdownAstToBlocks } from "./ast.js";
+import { markdownAstToBlocks, type TuiMarkdownMathOptions } from "./ast.js";
 import { layoutMarkdownBlocks } from "./layout.js";
 import { type TuiMarkdownParser } from "./parser.js";
 import { resolveTuiMarkdownTheme, type TuiMarkdownThemeOverrides } from "./theme.js";
@@ -19,6 +19,7 @@ export function buildMarkdownBlocks(
     theme?: TuiMarkdownThemeOverrides;
     imageResolver?: TuiMarkdownImageResolver;
     imageSize?: TuiMarkdownImageSize;
+    math?: TuiMarkdownMathOptions;
   }>,
 ): Readonly<{
   nodes: readonly TuiMarkdownNode[];
@@ -30,6 +31,7 @@ export function buildMarkdownBlocks(
     const blocks = markdownAstToBlocks(nodes, theme, {
       imageResolver: options?.imageResolver,
       imageSize: options?.imageSize,
+      math: options?.math,
     });
     return { nodes, blocks };
   } catch (error) {
@@ -51,6 +53,7 @@ export function buildMarkdownVisualRows(
     widthProvider?: WidthProvider;
     imageResolver?: TuiMarkdownImageResolver;
     imageSize?: TuiMarkdownImageSize;
+    math?: TuiMarkdownMathOptions;
   }>,
 ): readonly TuiMarkdownVisualRow[] {
   const { blocks } = buildMarkdownBlocks(content, parser, options);

--- a/src/vue/markdown/layout.ts
+++ b/src/vue/markdown/layout.ts
@@ -222,6 +222,7 @@ function wrapLineSegments(
         cells,
         graphic: segment.graphic,
         fallbackText: segment.text,
+        ...(segment.mathAction ? { mathAction: segment.mathAction } : {}),
       });
 
       row.remaining -= cells;
@@ -578,7 +579,8 @@ function inlineSegmentSignature(segment: TuiMarkdownInlineSegment): string {
   const graphic = segment.graphic
     ? [
         segment.graphic.kind,
-        segment.graphic.src,
+        segment.graphic.src ?? "",
+        segment.graphic.tex ?? "",
         segment.graphic.alt ?? "",
         segment.graphic.mime ?? "",
         segment.graphic.base64 ?? "",

--- a/src/vue/markdown/math-actions.ts
+++ b/src/vue/markdown/math-actions.ts
@@ -39,11 +39,14 @@ export function findMarkdownMathActionAt(
 
       const visibleStart = Math.max(segmentStart, clipStart);
       const visibleEnd = Math.min(segmentEnd, clipEnd);
+      const graphicHeight = segment.graphic
+        ? Math.max(1, Math.floor(segment.graphic.displayHeight ?? 1))
+        : 1;
       const rect = {
         x: r.x + visibleStart - clipStart,
         y: r.y + rowIndex - firstRow,
         w: visibleEnd - visibleStart,
-        h: 1,
+        h: graphicHeight,
       };
       if (
         point.cellX < rect.x ||

--- a/src/vue/markdown/math-image.ts
+++ b/src/vue/markdown/math-image.ts
@@ -315,6 +315,14 @@ function extractSvgMarkup(containerMarkup: string): string {
   return containerMarkup.slice(start, end + "</svg>".length);
 }
 
+/**
+ * resvg is a Node-only native addon. Keeping the specifier in a variable (a
+ * non-literal dynamic import) stops browser bundlers (vite/rolldown) from
+ * statically resolving it and failing on its platform `.node` binding; at
+ * runtime a browser load fails and the rasterizer falls back to raw text.
+ */
+const RESVG_MODULE_ID = "@resvg/resvg-js";
+
 function loadBuiltinMathRasterizer(): Promise<TuiMarkdownMathRasterizer | null> {
   if (!builtinRasterizerLoad) {
     builtinRasterizerLoad = (async () => {
@@ -334,7 +342,7 @@ function loadBuiltinMathRasterizer(): Promise<TuiMarkdownMathRasterizer | null> 
           import("mathjax-full/js/adaptors/liteAdaptor.js"),
           import("mathjax-full/js/handlers/html.js"),
           import("mathjax-full/js/input/tex/AllPackages.js"),
-          import("@resvg/resvg-js"),
+          import(RESVG_MODULE_ID),
         ]);
 
         const adaptor = liteAdaptor();

--- a/src/vue/markdown/math-image.ts
+++ b/src/vue/markdown/math-image.ts
@@ -1,0 +1,445 @@
+import type { TuiMarkdownVisualRow } from "./types.js";
+
+export type TuiMarkdownMathMode = "inline" | "display";
+
+export type TuiMarkdownMathImageCells = Readonly<{
+  base64: string;
+  widthCells: number;
+  heightCells: number;
+}>;
+
+export type TuiMarkdownMathImageOptions = Readonly<{
+  cellWidthPx?: number;
+  cellHeightPx?: number;
+  scale?: number;
+  color?: string;
+  maxWidthCells?: number;
+  /**
+   * Vertical position of the text baseline inside a terminal cell, as a
+   * fraction of the cell height (0 = top, 1 = bottom). Inline formula images
+   * are padded so their baseline lands here. Defaults to 0.78.
+   */
+  baselineRatio?: number;
+}>;
+
+export type TuiMarkdownMathRasterizer = (
+  tex: string,
+  mode: TuiMarkdownMathMode,
+  options: Required<TuiMarkdownMathImageOptions>,
+) => Promise<TuiMarkdownMathImageCells | null>;
+
+type RequiredMathImageOptions = Required<TuiMarkdownMathImageOptions>;
+
+const DEFAULT_MATH_IMAGE_OPTIONS: RequiredMathImageOptions = Object.freeze({
+  cellWidthPx: 8,
+  cellHeightPx: 16,
+  scale: 2,
+  color: "#f8f8f2",
+  maxWidthCells: 0,
+  baselineRatio: 0.78,
+});
+
+const MAX_CACHE_ENTRIES = 64;
+const MAX_FAILED_ENTRIES = 128;
+const mathImageCache = new Map<string, TuiMarkdownMathImageCells>();
+const mathImageFailed = new Set<string>();
+const mathImageInflight = new Map<string, Promise<TuiMarkdownMathImageCells | null>>();
+const mathImageListeners = new Set<() => void>();
+
+let customRasterizer: TuiMarkdownMathRasterizer | null = null;
+let builtinRasterizerLoad: Promise<TuiMarkdownMathRasterizer | null> | null = null;
+let builtinRasterizerReady = false;
+
+/**
+ * Map common terminal foreground style values to hex so rasterized formulas
+ * stay readable on any theme (a light formula on a light background would be
+ * invisible). Unknown values resolve to `undefined` and the caller falls back
+ * to a neutral default.
+ */
+const NAMED_STYLE_FG_HEX: Readonly<Record<string, string>> = Object.freeze({
+  black: "#000000",
+  red: "#e53935",
+  green: "#43a047",
+  yellow: "#fdd835",
+  blue: "#1e88e5",
+  magenta: "#d81b60",
+  cyan: "#00acc1",
+  white: "#ffffff",
+  gray: "#9e9e9e",
+  grey: "#9e9e9e",
+  blackBright: "#4a4a4a",
+  redBright: "#ff6e6e",
+  greenBright: "#69db7c",
+  yellowBright: "#ffe066",
+  blueBright: "#74c0fc",
+  magentaBright: "#f783ac",
+  cyanBright: "#3bc9db",
+  whiteBright: "#f8f8f2",
+  grayBright: "#bdbdbd",
+  greyBright: "#bdbdbd",
+});
+
+export function resolveMarkdownMathColor(fg: unknown): string | undefined {
+  if (typeof fg !== "string" || !fg) return undefined;
+  const trimmed = fg.trim();
+  if (trimmed.startsWith("#") && /^#[0-9a-f]{3,8}$/i.test(trimmed)) return trimmed.toLowerCase();
+  return NAMED_STYLE_FG_HEX[trimmed.toLowerCase()];
+}
+
+export function normalizeMathImageOptions(
+  options?: TuiMarkdownMathImageOptions,
+): RequiredMathImageOptions {
+  return {
+    cellWidthPx: Math.max(
+      1,
+      Math.floor(options?.cellWidthPx ?? DEFAULT_MATH_IMAGE_OPTIONS.cellWidthPx),
+    ),
+    cellHeightPx: Math.max(
+      1,
+      Math.floor(options?.cellHeightPx ?? DEFAULT_MATH_IMAGE_OPTIONS.cellHeightPx),
+    ),
+    scale: Math.max(1, Math.floor(options?.scale ?? DEFAULT_MATH_IMAGE_OPTIONS.scale)),
+    color: options?.color ?? DEFAULT_MATH_IMAGE_OPTIONS.color,
+    maxWidthCells: Math.max(0, Math.floor(options?.maxWidthCells ?? 0)),
+    baselineRatio: clamp01(options?.baselineRatio ?? DEFAULT_MATH_IMAGE_OPTIONS.baselineRatio),
+  };
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0.78;
+  return Math.min(1, Math.max(0, value));
+}
+
+/**
+ * Install a custom TeX -> PNG rasterizer (e.g. consumers that already have a
+ * katex/mathjax pipeline). Passing `null` restores the built-in lazy loader.
+ */
+export function setMarkdownMathRasterizer(rasterizer: TuiMarkdownMathRasterizer | null): void {
+  customRasterizer = rasterizer;
+}
+
+export function subscribeMarkdownMathImage(listener: () => void): () => void {
+  mathImageListeners.add(listener);
+  return () => mathImageListeners.delete(listener);
+}
+
+/**
+ * True when a rasterizer is confirmed available (a custom one was installed or
+ * the built-in MathJax+resvg stack finished loading). Components should gate
+ * image production on this so they never spend time rasterizing formulas while
+ * the math engine is still loading or missing.
+ */
+export function isMarkdownMathImageRendererReady(): boolean {
+  return customRasterizer != null || builtinRasterizerReady;
+}
+
+/**
+ * Ensure the math image rasterizer is loaded (or resolved as unavailable).
+ * Resolves `true` once a rasterizer is usable. Safe to call repeatedly; the
+ * underlying load is shared and its outcome is cached.
+ */
+export async function loadMarkdownMathImageRenderer(): Promise<boolean> {
+  if (isMarkdownMathImageRendererReady()) return true;
+  const rasterizer = customRasterizer ?? (await loadBuiltinMathRasterizer());
+  builtinRasterizerReady = rasterizer != null;
+  return builtinRasterizerReady;
+}
+
+function hashMathImageKey(value: string): string {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function mathImageCacheKey(
+  tex: string,
+  mode: TuiMarkdownMathMode,
+  options: RequiredMathImageOptions,
+): string {
+  return hashMathImageKey(
+    [
+      mode,
+      tex,
+      options.cellWidthPx,
+      options.cellHeightPx,
+      options.scale,
+      options.maxWidthCells,
+      options.color,
+      options.baselineRatio,
+    ].join("\x1F"),
+  );
+}
+
+function notifyMathImageListeners(): void {
+  for (const listener of mathImageListeners) {
+    try {
+      listener();
+    } catch {
+      // Listener errors must not break the raster pipeline.
+    }
+  }
+}
+
+/** Synchronous cache lookup used by the markdown AST/layout phase. */
+export function getCachedMarkdownMathImage(
+  tex: string,
+  mode: TuiMarkdownMathMode,
+  options?: TuiMarkdownMathImageOptions,
+): TuiMarkdownMathImageCells | null {
+  return (
+    mathImageCache.get(mathImageCacheKey(tex, mode, normalizeMathImageOptions(options))) ?? null
+  );
+}
+
+/**
+ * Drop all cached rasterized formulas (PNG + failed lookups). Useful for long
+ * running processes that change cell metrics, and for tests.
+ */
+export function clearMarkdownMathImageCache(): void {
+  mathImageCache.clear();
+  mathImageFailed.clear();
+}
+
+function evictOldestMathImageEntry(): void {
+  const oldest = mathImageCache.keys().next().value;
+  if (oldest != null) mathImageCache.delete(oldest);
+}
+
+/**
+ * Resolve a TeX formula to a PNG base64 + cell size. Cached per
+ * (tex, mode, cell metrics, color). In-flight requests are deduped. When a new
+ * image finishes, `subscribeMarkdownMathImage` listeners are notified so
+ * components can rebuild/re-paint with the real size.
+ */
+export async function getMarkdownMathImage(
+  tex: string,
+  mode: TuiMarkdownMathMode,
+  options?: TuiMarkdownMathImageOptions,
+): Promise<TuiMarkdownMathImageCells | null> {
+  const source = String(tex ?? "").trim();
+  if (!source) return null;
+  const normalized = normalizeMathImageOptions(options);
+  const key = mathImageCacheKey(source, mode, normalized);
+
+  const cached = mathImageCache.get(key);
+  if (cached) return cached;
+  if (mathImageFailed.has(key)) return null;
+
+  const inflight = mathImageInflight.get(key);
+  if (inflight) return inflight;
+
+  const pending = (async () => {
+    try {
+      const rasterizer = customRasterizer ?? (await loadBuiltinMathRasterizer());
+      if (!rasterizer) return null;
+      const result = await rasterizer(source, mode, normalized);
+      if (result && result.base64) {
+        mathImageCache.set(key, result);
+        if (mathImageCache.size > MAX_CACHE_ENTRIES) evictOldestMathImageEntry();
+        notifyMathImageListeners();
+      } else if (result === null) {
+        // The engine was available but could not render this formula; remember
+        // the failure so rebuilds do not re-rasterize it over and over.
+        mathImageFailed.add(key);
+        if (mathImageFailed.size > MAX_FAILED_ENTRIES) {
+          const oldest = mathImageFailed.values().next().value;
+          if (oldest != null) mathImageFailed.delete(oldest);
+        }
+      }
+      return result;
+    } catch {
+      return null;
+    } finally {
+      mathImageInflight.delete(key);
+    }
+  })();
+  mathImageInflight.set(key, pending);
+  return pending;
+}
+
+/**
+ * Kick off rasterization for every math graphic segment in the given row range
+ * that does not have a cached PNG yet. Safe to call after every row rebuild;
+ * in-flight and cached requests are deduped inside getMarkdownMathImage. Pass a
+ * viewport to avoid rasterizing off-screen formulas (e.g. virtualized views).
+ */
+export function enqueueMarkdownMathImages(
+  rows: readonly TuiMarkdownVisualRow[],
+  options?: TuiMarkdownMathImageOptions,
+  viewport?: Readonly<{ firstRow: number; lastRow: number }>,
+): void {
+  const first = Math.max(0, Math.floor(viewport?.firstRow ?? 0));
+  const last = Math.min(rows.length, Math.max(first, Math.ceil(viewport?.lastRow ?? rows.length)));
+  for (let index = first; index < last; index++) {
+    const row = rows[index];
+    if (!row) continue;
+    for (const segment of row.segments) {
+      const graphic = segment.graphic;
+      if (graphic?.kind === "math") {
+        if (!graphic.base64 && graphic.tex) {
+          void getMarkdownMathImage(graphic.tex, "display", options);
+        }
+        continue;
+      }
+      // Boxed block-math fallback / raw inline math: the formula still needs
+      // rasterization (mode tells us inline vs display).
+      const pending = segment.mathAction?.pendingImage;
+      if (pending && segment.mathAction?.source) {
+        void getMarkdownMathImage(
+          segment.mathAction.source,
+          segment.mathAction.mode ?? "display",
+          options,
+        );
+      }
+    }
+  }
+}
+
+function base64FromBytes(bytes: Uint8Array): string {
+  const chunk = 0x8000;
+  let binary = "";
+  for (let offset = 0; offset < bytes.length; offset += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunk));
+  }
+  return typeof btoa === "function" ? btoa(binary) : Buffer.from(bytes).toString("base64");
+}
+
+function extractSvgMarkup(containerMarkup: string): string {
+  const start = containerMarkup.indexOf("<svg");
+  if (start < 0) return "";
+  const end = containerMarkup.lastIndexOf("</svg>");
+  if (end < start) return "";
+  return containerMarkup.slice(start, end + "</svg>".length);
+}
+
+function loadBuiltinMathRasterizer(): Promise<TuiMarkdownMathRasterizer | null> {
+  if (!builtinRasterizerLoad) {
+    builtinRasterizerLoad = (async () => {
+      try {
+        const [
+          { mathjax },
+          { TeX },
+          { SVG },
+          { liteAdaptor },
+          { RegisterHTMLHandler },
+          { AllPackages },
+          { Resvg },
+        ] = await Promise.all([
+          import("mathjax-full/js/mathjax.js"),
+          import("mathjax-full/js/input/tex.js"),
+          import("mathjax-full/js/output/svg.js"),
+          import("mathjax-full/js/adaptors/liteAdaptor.js"),
+          import("mathjax-full/js/handlers/html.js"),
+          import("mathjax-full/js/input/tex/AllPackages.js"),
+          import("@resvg/resvg-js"),
+        ]);
+
+        const adaptor = liteAdaptor();
+        RegisterHTMLHandler(adaptor);
+        // Malformed TeX must throw so it falls back to raw text instead of
+        // rendering MathJax's inline error markup as an image.
+        const texInput = new TeX({
+          packages: AllPackages,
+          formatError: () => {
+            throw new Error("Malformed TeX");
+          },
+        });
+        const svgOutput = new SVG({ fontCache: "none" });
+        const document = mathjax.document("", { InputJax: texInput, OutputJax: svgOutput });
+
+        return async (source, mode, options) => {
+          const node = document.convert(source, { display: mode === "display" });
+          let svg = extractSvgMarkup(adaptor.outerHTML(node));
+          if (!svg) return null;
+
+          const widthEx = Number(/width="([\d.]+)ex"/.exec(svg)?.[1] ?? 0);
+          const heightEx = Number(/height="([\d.]+)ex"/.exec(svg)?.[1] ?? 0);
+          if (!(widthEx > 0) || !(heightEx > 0)) return null;
+
+          // 1ex ≈ half of the em box: a single-line formula (~2ex) then maps to
+          // roughly one terminal cell.
+          const exPx = (options.cellHeightPx / 2) * options.scale;
+
+          if (mode === "inline") {
+            // Inline formulas are placed inside the current text row, so they
+            // must fit one cell row and align their baseline with the text
+            // baseline. Formulas taller than ~2 rows (matrices, stacked cases)
+            // stay as raw TeX instead of being crushed into one line; common
+            // single-line formulas (fractions with digits, radicals,
+            // superscripts, limits) stay well below this and render normally.
+            const naturalH = heightEx * exPx;
+            const naturalW = widthEx * exPx;
+            if (naturalH > options.cellHeightPx * options.scale * 2) return null;
+
+            const rectH = options.cellHeightPx * options.scale;
+            const k = rectH / naturalH;
+            const contentW = Math.max(1, Math.round(naturalW * k));
+            // Round UP to whole cells and letterbox the raster to the exact
+            // placement-rect aspect, so the terminal never stretches the image
+            // (an aspect mismatch would squeeze/deform the glyphs).
+            const widthCells = Math.max(
+              1,
+              Math.ceil(contentW / (options.cellWidthPx * options.scale)),
+            );
+            const rectW = widthCells * options.cellWidthPx * options.scale;
+            const verticalAlignEx = Number(/vertical-align:\s*(-?[\d.]+)ex/.exec(svg)?.[1] ?? 0);
+            const formulaBaseline = (heightEx - Math.abs(verticalAlignEx)) * exPx * k;
+            const terminalBaseline = options.baselineRatio * rectH;
+            const offsetY = terminalBaseline - formulaBaseline;
+
+            // Inner MathJax SVG keeps its original viewBox; we only set the
+            // pixel size so the glyphs scale uniformly (no distortion).
+            const inner = svg
+              .replace(/style="vertical-align:[^"]*"/, "")
+              .replace(/width="[\d.]+ex"/, `width="${contentW}px"`)
+              .replace(/height="[\d.]+ex"/, `height="${rectH}px"`);
+            const wrapped = `<svg xmlns="http://www.w3.org/2000/svg" color="${options.color}" width="${rectW}px" height="${rectH}px" viewBox="0 0 ${rectW} ${rectH}"><g transform="translate(0 ${offsetY.toFixed(2)})">${inner}</g></svg>`;
+
+            const renderedInline = new Resvg(wrapped, { background: "rgba(0,0,0,0)" }).render();
+            const pngInline = renderedInline.asPng();
+            if (!pngInline || pngInline.length < 8) return null;
+
+            return {
+              base64: base64FromBytes(pngInline),
+              widthCells,
+              heightCells: 1,
+            };
+          }
+
+          let widthPx = Math.max(1, Math.round(widthEx * exPx));
+          let heightPx = Math.max(1, Math.round(heightEx * exPx));
+
+          if (options.maxWidthCells > 0) {
+            const maxPx = options.maxWidthCells * options.cellWidthPx * options.scale;
+            if (widthPx > maxPx) {
+              heightPx = Math.max(1, Math.round(heightPx * (maxPx / widthPx)));
+              widthPx = maxPx;
+            }
+          }
+
+          svg = svg
+            .replace(/style="vertical-align:[^"]*"/, "")
+            .replace(/width="[\d.]+ex"/, `width="${widthPx}px"`)
+            .replace(/height="[\d.]+ex"/, `height="${heightPx}px"`)
+            .replace(/<svg/, `<svg color="${options.color}"`);
+
+          const rendered = new Resvg(svg, { background: "rgba(0,0,0,0)" }).render();
+          const png = rendered.asPng();
+          if (!png || png.length < 8) return null;
+
+          return {
+            base64: base64FromBytes(png),
+            widthCells: Math.max(1, Math.round(widthPx / (options.cellWidthPx * options.scale))),
+            heightCells: Math.max(1, Math.round(heightPx / (options.cellHeightPx * options.scale))),
+          };
+        };
+      } catch {
+        return null;
+      }
+    })();
+  }
+  return builtinRasterizerLoad;
+}

--- a/src/vue/markdown/render.ts
+++ b/src/vue/markdown/render.ts
@@ -52,7 +52,7 @@ export function markdownImageGraphicId(
   identity: string,
 ): string {
   return `md-image:${stableTerminalGraphicNumericId(
-    `${identity}:${segment.src}:${segment.displayWidth ?? 0}:${segment.displayHeight ?? 0}:${segment.base64 ?? ""}`,
+    `${identity}:${segment.src ?? segment.tex ?? ""}:${segment.displayWidth ?? 0}:${segment.displayHeight ?? 0}:${segment.base64 ?? ""}`,
   )}`;
 }
 
@@ -97,7 +97,7 @@ function canAttemptMarkdownImageGraphic(
   terminal: Terminal,
   segment: NonNullable<TuiMarkdownVisualRow["segments"][number]["graphic"]>,
 ): boolean {
-  if (segment.kind !== "image" || !segment.base64) return false;
+  if (!segment.base64) return false;
   const output = getTerminalGraphicsOutput(terminal);
   const protocol = output?.capabilities.preferredProtocol;
   return Boolean(output?.capabilities.supported && isTerminalGraphicsProtocol(protocol));
@@ -129,7 +129,7 @@ function queueMarkdownImageGraphic(
   identity: string,
   rect: Readonly<{ x: number; y: number; w: number }>,
 ): MarkdownImageGraphicQueueResult {
-  if (segment.kind !== "image" || !segment.base64) return "unavailable";
+  if (!segment.base64) return "unavailable";
   const output = getTerminalGraphicsOutput(terminal);
   const protocol = output?.capabilities.preferredProtocol;
   if (!output?.capabilities.supported || !isTerminalGraphicsProtocol(protocol)) {
@@ -186,7 +186,8 @@ function queueMarkdownImageGraphic(
     sequence,
     resizeSequence,
     clearSequence,
-    fallbackText: segment.alt ?? "image",
+    fallbackText:
+      segment.alt ?? (segment.kind === "math" ? (segment.raw ?? segment.tex ?? "math") : "image"),
   });
   markdownImageDebug(
     `queue id=${id}`,
@@ -346,7 +347,11 @@ export function paintMarkdownVisualRow(
         suppressFallback
           ? spaces(visibleCells)
           : sliceByCellsRange(
-              segment.fallbackText ?? segment.graphic.alt ?? "image",
+              segment.fallbackText ??
+                segment.graphic.alt ??
+                (segment.graphic.kind === "math"
+                  ? (segment.graphic.raw ?? segment.graphic.tex ?? "math")
+                  : "image"),
               0,
               visibleCells,
             ) || spaces(visibleCells),

--- a/src/vue/markdown/theme.ts
+++ b/src/vue/markdown/theme.ts
@@ -12,6 +12,7 @@ export type TuiMarkdownTheme = Readonly<{
   codeBlock: Style;
   thematicBreak: Style;
   html: Style;
+  math: Style;
 }>;
 
 export type TuiMarkdownThemeOverrides = Readonly<
@@ -27,6 +28,7 @@ export type TuiMarkdownThemeOverrides = Readonly<
     codeBlock: Partial<Style>;
     thematicBreak: Partial<Style>;
     html: Partial<Style>;
+    math: Partial<Style>;
   }>
 >;
 
@@ -60,6 +62,7 @@ export const DEFAULT_TUI_MARKDOWN_THEME = Object.freeze({
   codeBlock: freezeStyle({ fg: "yellowBright" }),
   thematicBreak: freezeStyle({ dim: true }),
   html: freezeStyle({ dim: true }),
+  math: freezeStyle({ fg: "cyanBright" }),
 } satisfies TuiMarkdownTheme);
 
 function stableSerialize(value: unknown): string {
@@ -99,5 +102,6 @@ export function resolveTuiMarkdownTheme(overrides?: TuiMarkdownThemeOverrides): 
       overrides.thematicBreak,
     ),
     html: mergeFrozenStyle(DEFAULT_TUI_MARKDOWN_THEME.html, overrides.html),
+    math: mergeFrozenStyle(DEFAULT_TUI_MARKDOWN_THEME.math, overrides.math),
   });
 }

--- a/src/vue/markdown/types.ts
+++ b/src/vue/markdown/types.ts
@@ -16,9 +16,11 @@ export type TuiMarkdownImageSize = Readonly<{
 }>;
 
 export type TuiMarkdownGraphicSegment = Readonly<{
-  kind: "image";
-  src: string;
+  kind: "image" | "math";
+  src?: string;
   alt?: string;
+  tex?: string;
+  raw?: string;
   mime?: string;
   base64?: string;
   originalBase64?: string;
@@ -67,6 +69,14 @@ export type TuiMarkdownMathSegment = Readonly<{
   source: string;
   raw: string;
   rendered: boolean;
+  /**
+   * Set on the boxed fallback of block-level math / raw inline math: the
+   * formula still needs to be rasterized once the graphics/raster stack is
+   * available. `mode` tells the rasterizer whether to render inline (fits one
+   * line, baseline-aligned) or display style.
+   */
+  pendingImage?: boolean;
+  mode?: "inline" | "display";
 }>;
 
 export type TuiMarkdownMathActionPayload = Readonly<{

--- a/test/api-surface.test.ts
+++ b/test/api-surface.test.ts
@@ -182,11 +182,19 @@ describe("public API surface", () => {
         "TVirtualMarkdown",
         "buildMarkdownBlocks",
         "buildMarkdownVisualRows",
+        "clearMarkdownMathImageCache",
         "createMarkdownBlockSource",
         "createTuiMarkdownParser",
+        "enqueueMarkdownMathImages",
+        "getCachedMarkdownMathImage",
+        "getMarkdownMathImage",
+        "isMarkdownMathImageRendererReady",
         "isSafeMarkdownLink",
         "layoutMarkdownBlocks",
+        "loadMarkdownMathImageRenderer",
         "loadMarkdownMathRenderer",
+        "setMarkdownMathRasterizer",
+        "subscribeMarkdownMathImage",
       ]
     `);
   });

--- a/test/fixtures/package-types/index.ts
+++ b/test/fixtures/package-types/index.ts
@@ -440,6 +440,7 @@ const stdoutRendererMock: StdoutRenderer = {
     domRows: false,
   },
   render: () => {},
+  forceRender: () => {},
   dispose: () => {},
   setCursor: () => {},
   showCursor: () => {},

--- a/test/package-exports.test.ts
+++ b/test/package-exports.test.ts
@@ -393,11 +393,19 @@ describe("package exports", () => {
       "TVirtualMarkdown",
       "buildMarkdownBlocks",
       "buildMarkdownVisualRows",
+      "clearMarkdownMathImageCache",
       "createMarkdownBlockSource",
       "createTuiMarkdownParser",
+      "enqueueMarkdownMathImages",
+      "getCachedMarkdownMathImage",
+      "getMarkdownMathImage",
+      "isMarkdownMathImageRendererReady",
       "isSafeMarkdownLink",
       "layoutMarkdownBlocks",
+      "loadMarkdownMathImageRenderer",
       "loadMarkdownMathRenderer",
+      "setMarkdownMathRasterizer",
+      "subscribeMarkdownMathImage",
     ]);
     expect(Object.keys(experimental).sort()).toEqual([
       "T3DViewport",
@@ -817,7 +825,7 @@ describe("package exports", () => {
       write: false,
       platform: "browser",
       format: "esm",
-      external: ["vue", "beautiful-mermaid", "katex"],
+      external: ["vue", "beautiful-mermaid", "katex", "mathjax-full", "@resvg/resvg-js"],
       plugins: [forbidNodeBuiltins],
     });
     const output = result.outputFiles
@@ -860,7 +868,7 @@ describe("package exports", () => {
         write: false,
         platform: "browser",
         format: "esm",
-        external: ["vue", "beautiful-mermaid", "katex"],
+        external: ["vue", "beautiful-mermaid", "katex", "mathjax-full", "@resvg/resvg-js"],
         plugins: [forbidNodeBuiltins],
       });
       const output = result.outputFiles

--- a/test/stdout-renderer-bottom-anchor.test.ts
+++ b/test/stdout-renderer-bottom-anchor.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, it } from "vitest";
+import { createTerminal } from "../src/index.js";
+import { createStdoutRenderer } from "../src/cli.js";
+
+/**
+ * Minimal ANSI screen simulator for verifying bottom-anchored (REPL bar)
+ * rendering: absolute cursor positioning (H/f), erase-in-line (K), scroll
+ * regions (r) and scrolls (S/T), CR/LF and printable cells.
+ */
+function applyAnsiToScreen(output: string, cols: number, rows: number): readonly string[] {
+  const grid = Array.from({ length: rows }, () => Array.from({ length: cols }, () => " "));
+  let cursorX = 0;
+  let cursorY = 0;
+  let scrollTop = 0;
+  let scrollBottom = rows;
+
+  const scrollUp = (count: number) => {
+    for (let i = 0; i < count; i++) {
+      for (let y = scrollTop; y < scrollBottom - 1; y++) grid[y] = grid[y + 1]!;
+      grid[scrollBottom - 1] = Array.from({ length: cols }, () => " ");
+    }
+  };
+  const scrollDown = (count: number) => {
+    for (let i = 0; i < count; i++) {
+      for (let y = scrollBottom - 1; y > scrollTop; y--) grid[y] = grid[y - 1]!;
+      grid[scrollTop] = Array.from({ length: cols }, () => " ");
+    }
+  };
+
+  let i = 0;
+  while (i < output.length) {
+    const ch = output[i]!;
+    if (ch === "\u001B") {
+      const next = output[i + 1];
+      if (next === "[") {
+        let j = i + 2;
+        while (j < output.length && !/[A-Za-z]/.test(output[j]!)) j++;
+        if (j >= output.length) break;
+        const final = output[j]!;
+        const raw = output.slice(i + 2, j);
+        const params = raw.replace(/^\?/, "");
+        const parts = params ? params.split(";").map((part) => Number(part || "0")) : [];
+        if (final === "H" || final === "f") {
+          cursorY = Math.max(0, Math.min(rows - 1, (parts[0] || 1) - 1));
+          cursorX = Math.max(0, Math.min(cols, (parts[1] || 1) - 1));
+        } else if (final === "K") {
+          for (let x = cursorX; x < cols; x++) grid[cursorY]![x] = " ";
+        } else if (final === "r") {
+          if (parts.length >= 2) {
+            scrollTop = Math.max(0, Math.min(rows - 1, (parts[0] || 1) - 1));
+            scrollBottom = Math.max(scrollTop + 1, Math.min(rows, parts[1] || rows));
+          } else {
+            scrollTop = 0;
+            scrollBottom = rows;
+          }
+        } else if (final === "S") {
+          scrollUp(Math.max(1, parts[0] || 1));
+        } else if (final === "T") {
+          scrollDown(Math.max(1, parts[0] || 1));
+        }
+        i = j + 1;
+        continue;
+      }
+      if (next === "]") {
+        const end = output.indexOf("\u0007", i + 2);
+        i = end >= 0 ? end + 1 : output.length;
+        continue;
+      }
+      i += 2;
+      continue;
+    }
+
+    if (ch === "\r") {
+      cursorX = 0;
+      i++;
+      continue;
+    }
+    if (ch === "\n") {
+      cursorX = 0;
+      if (cursorY === scrollBottom - 1) scrollUp(1);
+      else cursorY = Math.min(rows - 1, cursorY + 1);
+      i++;
+      continue;
+    }
+
+    if (cursorY >= 0 && cursorY < rows && cursorX >= 0 && cursorX < cols) {
+      grid[cursorY]![cursorX] = ch;
+      cursorX = Math.min(cols, cursorX + 1);
+    }
+    i++;
+  }
+
+  return grid.map((row) => row.join(""));
+}
+
+function createCapturingOutput(): {
+  output: {
+    isTTY: boolean;
+    chunks: string[];
+    write(chunk: string): void;
+  };
+  text(): string;
+} {
+  const output = {
+    isTTY: true,
+    chunks: [] as string[],
+    write(chunk: string) {
+      this.chunks.push(chunk);
+    },
+  };
+  return {
+    output,
+    text: () => output.chunks.join(""),
+  };
+}
+
+describe("stdout renderer bottom anchor (REPL bar)", () => {
+  it("pins the bar to the bottom and never touches the output area above", () => {
+    const terminal = createTerminal({ cols: 20, rows: 3 });
+    const { output, text } = createCapturingOutput();
+    const renderer = createStdoutRenderer(terminal, {
+      output,
+      clear: false,
+      hideCursor: false,
+      altScreen: false,
+      anchor: "bottom",
+      screenRows: () => 10,
+    });
+
+    try {
+      terminal.write("hello", { x: 0, y: 0 });
+      terminal.write("world", { x: 0, y: 1 });
+      terminal.commit({ sync: true });
+
+      const frame = text();
+      // The renderer establishes a scroll region that excludes the bar.
+      expect(frame).toContain("\u001B[1;7r");
+      // Buffer rows are addressed at their absolute screen positions (rows 8-10,
+      // 1-based) and no CUP ever targets the rows above the bar. Consecutive
+      // rows may use the \r\n fast path instead of a second CUP.
+      expect(frame).toContain("\u001B[8;1H");
+      expect(frame).not.toContain("\u001B[1;1H");
+      expect(frame).not.toContain("\u001B[5;");
+
+      const screen = applyAnsiToScreen(frame, 20, 10);
+      expect(screen[7]!.trimEnd()).toBe("hello");
+      expect(screen[8]!.trimEnd()).toBe("world");
+      for (let y = 0; y < 7; y++) {
+        expect(screen[y]!.trim()).toBe("");
+      }
+    } finally {
+      renderer.dispose();
+      terminal.dispose();
+    }
+  });
+
+  it("repaints the whole bar and re-anchors when the screen height changes", () => {
+    const terminal = createTerminal({ cols: 20, rows: 3 });
+    let screenRows = 10;
+    const { output, text } = createCapturingOutput();
+    const renderer = createStdoutRenderer(terminal, {
+      output,
+      clear: false,
+      hideCursor: false,
+      altScreen: false,
+      anchor: "bottom",
+      screenRows: () => screenRows,
+    });
+
+    try {
+      terminal.write("hello", { x: 0, y: 0 });
+      terminal.commit({ sync: true });
+      expect(text()).toContain("\u001B[8;1H");
+
+      // Screen grows: the bar must move down and the region must narrow.
+      screenRows = 12;
+      output.chunks.length = 0;
+      terminal.write("hi", { x: 0, y: 2 });
+      terminal.commit({ sync: true });
+
+      const frame = text();
+      expect(frame).toContain("\u001B[1;9r");
+      expect(frame).toContain("\u001B[10;1H");
+
+      // All three bar rows are repainted at their new anchored position so a
+      // resized/scrolled screen can never leave stale bar rows behind.
+      const screen = applyAnsiToScreen(frame, 20, 12);
+      expect(screen[9]!.trimEnd()).toBe("hello");
+      expect(screen[10]!.trim()).toBe("");
+      expect(screen[11]!.trimEnd()).toBe("hi");
+    } finally {
+      renderer.dispose();
+      terminal.dispose();
+    }
+  });
+
+  it("never clears the whole screen even when clear is true", () => {
+    const terminal = createTerminal({ cols: 20, rows: 3 });
+    const { output, text } = createCapturingOutput();
+    const renderer = createStdoutRenderer(terminal, {
+      output,
+      clear: true,
+      hideCursor: false,
+      altScreen: false,
+      anchor: "bottom",
+      screenRows: () => 10,
+    });
+
+    try {
+      terminal.write("hi", { x: 0, y: 0 });
+      terminal.commit({ sync: true });
+      expect(text()).not.toContain("\u001B[2J");
+    } finally {
+      renderer.dispose();
+      terminal.dispose();
+    }
+  });
+
+  it("restores the full-screen scroll region on dispose", () => {
+    const terminal = createTerminal({ cols: 20, rows: 3 });
+    const { output, text } = createCapturingOutput();
+    const renderer = createStdoutRenderer(terminal, {
+      output,
+      clear: false,
+      hideCursor: false,
+      altScreen: false,
+      anchor: "bottom",
+      screenRows: () => 10,
+    });
+
+    terminal.write("hi", { x: 0, y: 0 });
+    terminal.commit({ sync: true });
+    expect(text()).toContain("\u001B[1;7r");
+
+    renderer.dispose();
+    expect(text()).toContain("\u001B[r");
+    terminal.dispose();
+  });
+
+  it("reserves a blank gap between the output region and the pinned bar", () => {
+    const terminal = createTerminal({ cols: 20, rows: 3 });
+    const { output, text } = createCapturingOutput();
+    const renderer = createStdoutRenderer(terminal, {
+      output,
+      clear: false,
+      hideCursor: false,
+      altScreen: false,
+      anchor: "bottom",
+      barGap: 2,
+      screenRows: () => 10,
+    });
+
+    try {
+      terminal.write("bar", { x: 0, y: 0 });
+      terminal.commit({ sync: true });
+      const frame = text();
+      // Region excludes the 2-row gap: 10 - 3 (bar) - 2 (gap) = 5.
+      expect(frame).toContain("\u001B[1;5r");
+      // The bar itself still hugs the very bottom (rows 8-10, 1-based).
+      expect(frame).toContain("\u001B[8;1H");
+
+      // Caller output written at the region bottom (row 5) scrolls inside the
+      // region; the gap rows (6-7) and the bar (8-10) stay untouched.
+      const screen = applyAnsiToScreen(frame + "\u001B[5;1Hline a\nline b\n", 20, 10);
+      expect(screen[2]!.trimEnd()).toBe("line a");
+      expect(screen[3]!.trimEnd()).toBe("line b");
+      expect(screen[4]!.trim()).toBe("");
+      expect(screen[5]!.trim()).toBe("");
+      expect(screen[6]!.trim()).toBe("");
+      expect(screen[7]!.trimEnd()).toBe("bar");
+      expect(screen[8]!.trim()).toBe("");
+      expect(screen[9]!.trim()).toBe("");
+    } finally {
+      renderer.dispose();
+      terminal.dispose();
+    }
+  });
+
+  it("leaves top-anchored rendering unchanged when anchor is unset", () => {
+    const terminal = createTerminal({ cols: 20, rows: 3 });
+    const { output, text } = createCapturingOutput();
+    const renderer = createStdoutRenderer(terminal, {
+      output,
+      clear: false,
+      hideCursor: false,
+      altScreen: false,
+    });
+
+    try {
+      terminal.write("hi", { x: 0, y: 0 });
+      terminal.commit({ sync: true });
+      const frame = text();
+      expect(frame).toContain("\u001B[1;1H");
+      expect(frame).not.toContain("\u001B[1;7r");
+    } finally {
+      renderer.dispose();
+      terminal.dispose();
+    }
+  });
+
+  it("keeps the bar pinned while caller output scrolls natively above it", () => {
+    const terminal = createTerminal({ cols: 20, rows: 3 });
+    const { output, text } = createCapturingOutput();
+    const renderer = createStdoutRenderer(terminal, {
+      output,
+      clear: false,
+      hideCursor: false,
+      altScreen: false,
+      anchor: "bottom",
+      screenRows: () => 10,
+    });
+
+    try {
+      terminal.write("abc", { x: 0, y: 0 });
+      terminal.commit({ sync: true });
+      const initial = applyAnsiToScreen(text(), 20, 10);
+      expect(initial[7]!.trimEnd()).toBe("abc");
+      expect(initial[6]!.trim()).toBe("");
+
+      // Simulate the caller writing native output into the scroll region the
+      // renderer established (rows 1..7). More than 7 lines forces the region
+      // to scroll; the bar rows (8..10, 1-based) must never be touched.
+      const appOut: string[] = [`\u001B[7;1H`];
+      for (let i = 1; i <= 8; i++) appOut.push(`line ${i}\n`);
+      const screen = applyAnsiToScreen(text() + appOut.join(""), 20, 10);
+      // The 8th line ends one row above the region bottom; the region bottom
+      // row is the fresh blank line created by the final scroll.
+      expect(screen[5]!.trimEnd()).toBe("line 8");
+      expect(screen[6]!.trim()).toBe("");
+      // The bar is untouched and still shows its TUI content.
+      expect(screen[7]!.trimEnd()).toBe("abc");
+      expect(screen[8]!.trim()).toBe("");
+      expect(screen[9]!.trim()).toBe("");
+
+      // A bar-only update repaints the pinned bar, not the output area.
+      output.chunks.length = 0;
+      terminal.write("def", { x: 0, y: 0 });
+      terminal.commit({ sync: true });
+      const barFrame = text();
+      expect(barFrame).toContain("\u001B[8;1H");
+      const after = applyAnsiToScreen(barFrame, 20, 10);
+      expect(after[7]!.trimEnd()).toBe("def");
+    } finally {
+      renderer.dispose();
+      terminal.dispose();
+    }
+  });
+});

--- a/test/stdout-renderer-bottom-anchor.test.ts
+++ b/test/stdout-renderer-bottom-anchor.test.ts
@@ -276,6 +276,55 @@ describe("stdout renderer bottom anchor (REPL bar)", () => {
     }
   });
 
+  it("preserves existing output before reserving the gap and bar rows", () => {
+    const terminal = createTerminal({ cols: 20, rows: 3 });
+    const { output, text } = createCapturingOutput();
+    const renderer = createStdoutRenderer(terminal, {
+      output,
+      clear: false,
+      hideCursor: false,
+      altScreen: false,
+      anchor: "bottom",
+      barGap: 2,
+      screenRows: () => 15,
+    });
+
+    try {
+      terminal.write("bar", { x: 0, y: 0 });
+      terminal.commit({ sync: true });
+
+      const frame = text();
+      // Before narrowing the scroll region, the renderer moves existing screen
+      // contents up by 3 bar rows + 2 gap rows + 1 fresh output row.
+      expect(frame).toContain(`\u001B[r\u001B[15;1H${"\n".repeat(6)}`);
+      expect(frame).toContain("\u001B[1;10r");
+
+      const existingOutput = "\u001B[12;1Hbuild 1\nbuild 2";
+      const nativeOutput = "\u001B[10;1H❯ hi\n\u001B[10;1Hecho: hi\n";
+      const screen = applyAnsiToScreen(existingOutput + frame + nativeOutput, 20, 15);
+
+      // Older output remains above newer caller output instead of being frozen
+      // below it in the reserved gap.
+      expect(screen[3]!.trimEnd()).toBe("build 1");
+      expect(screen[4]!.trimEnd()).toBe("build 2");
+      expect(screen[7]!.trimEnd()).toBe("❯ hi");
+      expect(screen[8]!.trimEnd()).toBe("echo: hi");
+      expect(screen[9]!.trim()).toBe("");
+      expect(screen[10]!.trim()).toBe("");
+      expect(screen[11]!.trim()).toBe("");
+      expect(screen[12]!.trimEnd()).toBe("bar");
+
+      // Repainting the bar must not reserve rows or scroll history again.
+      output.chunks.length = 0;
+      renderer.forceRender();
+      expect(text()).not.toContain(`\u001B[r\u001B[15;1H`);
+      expect(text()).not.toContain("\n".repeat(6));
+    } finally {
+      renderer.dispose();
+      terminal.dispose();
+    }
+  });
+
   it("leaves top-anchored rendering unchanged when anchor is unset", () => {
     const terminal = createTerminal({ cols: 20, rows: 3 });
     const { output, text } = createCapturingOutput();

--- a/test/stdout-renderer-ime-anchor-clamp.test.ts
+++ b/test/stdout-renderer-ime-anchor-clamp.test.ts
@@ -29,6 +29,36 @@ describe("stdout renderer (IME anchor clamping)", () => {
     expect(frame).toContain("\u001B[5;10H");
   });
 
+  it("maps a bottom-anchored IME cursor to its absolute screen row", () => {
+    const terminal = createTerminal({ cols: 10, rows: 3 });
+    terminal.commit();
+
+    let frame = "";
+    const renderer = createStdoutRenderer(terminal, {
+      output: {
+        isTTY: true,
+        write: (chunk) => {
+          frame += chunk;
+        },
+      },
+      clear: false,
+      hideCursor: true,
+      altScreen: false,
+      trackResize: false,
+      anchor: "bottom",
+      screenRows: () => 10,
+      getImeAnchor: () => ({ cellX: 4, cellY: 1 }),
+    });
+
+    renderer.render();
+    renderer.dispose();
+
+    // The 3-row bar occupies screen rows 8..10 (1-based). Its local row 2
+    // (cellY=1) maps to absolute row 9; cellX=4 maps to column 5.
+    expect(frame).toContain("\u001B[9;5H");
+    expect(frame).not.toContain("\u001B[2;5H");
+  });
+
   it("clamps explicit setCursor calls to the viewport", () => {
     const terminal = createTerminal({ cols: 10, rows: 5 });
     terminal.commit();

--- a/test/tmarkdown-components.test.ts
+++ b/test/tmarkdown-components.test.ts
@@ -951,13 +951,13 @@ describe("markdown components", () => {
 
     await nextTick();
     clickCell(mounted, 12, 1);
-    clickCell(mounted, 25, 1);
+    clickCell(mounted, 30, 1);
 
     expect(actions).toHaveLength(2);
     expect(actions[0]).toMatchObject({
       cellX: 12,
       cellY: 1,
-      math: { raw: "$\\frac{a}{b}$", source: "\\frac{a}{b}", rendered: true },
+      math: { raw: "$\\frac{a}{b}$", source: "\\frac{a}{b}", rendered: false },
     });
     expect(actions[1]).toMatchObject({
       cellY: 1,

--- a/test/tmarkdown-image-fallback.test.ts
+++ b/test/tmarkdown-image-fallback.test.ts
@@ -691,7 +691,7 @@ describe("markdown image fallback and sizing", () => {
       createTuiMarkdownParser({ streaming: false }),
       {
         imageResolver: (image) => {
-          seen.push(image.src);
+          seen.push(image.src ?? "");
           return TINY_PNG_BASE64;
         },
         imageSize: { minWidth: 4, maxWidth: 8, minHeight: 1, maxHeight: 1 },

--- a/test/tmarkdown-kitty-image-katex.test.ts
+++ b/test/tmarkdown-kitty-image-katex.test.ts
@@ -98,7 +98,7 @@ describe("markdown kitty images and optional KaTeX rendering", () => {
     );
   });
 
-  it("loads optional KaTeX on demand and replaces raw syntax", async () => {
+  it("keeps inline math raw text while loading KaTeX", async () => {
     const mounted = await mountTerminal(
       () =>
         h(TMarkdownText, {
@@ -121,9 +121,8 @@ describe("markdown kitty images and optional KaTeX rendering", () => {
       mounted.scheduler()?.flushNow();
       const visible = [0, 1, 2, 3].map((y) => rowText(mounted, y)).join("\n");
       expect(visible).toContain("Euler");
-      expect(visible).not.toContain("$e^{i\\pi}+1=0$");
-      expect(visible).not.toContain("$\\frac{a}{b}$");
-      expect(visible).toMatch(/π|pi/i);
+      expect(visible).toContain("$e^{i\\pi}+1=0$");
+      expect(visible).toContain("$\\frac{a}{b}$");
     } finally {
       mounted.unmount();
     }

--- a/test/tmarkdown-math-image.test.ts
+++ b/test/tmarkdown-math-image.test.ts
@@ -1,0 +1,336 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createStdoutRenderer } from "../src/cli.js";
+import {
+  TMarkdownText,
+  clearMarkdownMathImageCache,
+  getMarkdownMathImage,
+  loadMarkdownMathImageRenderer,
+  setMarkdownMathRasterizer,
+} from "../src/markdown.js";
+import { h, mountTerminal, nextTick } from "./ui-regressions-support.js";
+
+type MountedTerminal = Awaited<ReturnType<typeof mountTerminal>>;
+
+function rowText(mounted: MountedTerminal, y: number): string {
+  return mounted.terminal
+    .getRow(y)
+    .map((cell) => cell.ch)
+    .join("")
+    .trimEnd();
+}
+
+function clickCell(mounted: MountedTerminal, cellX: number, cellY: number): void {
+  mounted
+    .container()
+    ?.dispatchEvent(new MouseEvent("click", { clientX: cellX, clientY: cellY, bubbles: true }));
+}
+
+async function withEnv<T>(
+  updates: Record<string, string | undefined>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const previous = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(updates)) {
+    previous.set(key, process.env[key]);
+    if (value == null) delete process.env[key];
+    else process.env[key] = value;
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value == null) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+const FAKE_PNG_DATA_URL =
+  "data:image/png;base64," +
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+const FAKE_PNG_B64 = FAKE_PNG_DATA_URL.slice("data:image/png;base64,".length);
+
+const KITTY_ENV: Record<string, string | undefined> = {
+  KITTY_WINDOW_ID: "vue-tui-test",
+  TERM: "xterm-kitty",
+  TERM_PROGRAM: "kitty",
+  CI: undefined,
+  TMUX: undefined,
+  VUE_TUI_GRAPHICS_FORCE: "1",
+};
+
+afterEach(() => {
+  setMarkdownMathRasterizer(null);
+  clearMarkdownMathImageCache();
+});
+
+/** Mount TMarkdownText plus a forced-kitty stdout renderer under kitty env. */
+async function mountWithGraphics(
+  children: () => any,
+  cols = 40,
+  rows = 10,
+): Promise<{
+  mounted: MountedTerminal;
+  stdout: () => string;
+  renderer: ReturnType<typeof createStdoutRenderer>;
+}> {
+  const mounted = await mountTerminal(children, cols, rows);
+  let stdout = "";
+  const renderer = createStdoutRenderer(mounted.terminal, {
+    output: {
+      isTTY: true,
+      write(chunk: string) {
+        stdout += chunk;
+      },
+    },
+    clear: false,
+    hideCursor: false,
+    altScreen: false,
+    terminalGraphics: { protocol: "kitty", force: true },
+  });
+  await nextTick();
+  await nextTick();
+  await nextTick();
+  mounted.scheduler()?.flushNow();
+  (renderer as any).render(undefined, true);
+  return { mounted, stdout: () => stdout, renderer };
+}
+
+describe("markdown block math images", () => {
+  it("renders $$ block math as a Kitty graphics frame after async rasterization", async () => {
+    setMarkdownMathRasterizer(async (tex, mode) => {
+      expect(tex).toBe("\\frac{a}{b}");
+      expect(mode).toBe("display");
+      return { base64: FAKE_PNG_B64, widthCells: 14, heightCells: 3 };
+    });
+
+    await withEnv(KITTY_ENV, async () => {
+      const { mounted, stdout, renderer } = await mountWithGraphics(
+        () =>
+          h(TMarkdownText, {
+            x: 0,
+            y: 0,
+            w: 40,
+            h: 8,
+            content: "before\n\n$$\n\\frac{a}{b}\n$$\n\nafter",
+          }),
+        40,
+        10,
+      );
+
+      try {
+        expect(stdout()).toContain("\u001B_G");
+        expect(stdout()).toContain("\u001B\\");
+        // The rendered formula replaced the box.
+        expect(rowText(mounted, 2)).not.toContain("frac");
+        expect(rowText(mounted, 2)).not.toContain("┌");
+      } finally {
+        renderer.dispose();
+        mounted.unmount();
+      }
+    });
+  });
+
+  it("shows a boxed raw formula when the rasterizer cannot render it", async () => {
+    setMarkdownMathRasterizer(async () => null);
+
+    await withEnv(KITTY_ENV, async () => {
+      const { mounted, stdout, renderer } = await mountWithGraphics(
+        () =>
+          h(TMarkdownText, {
+            x: 0,
+            y: 0,
+            w: 40,
+            h: 8,
+            content: "before\n\n$$\n\\frac{a}{b}\n$$\n\nafter",
+          }),
+        40,
+        10,
+      );
+
+      try {
+        expect(stdout()).not.toContain("\u001B_G");
+        expect(rowText(mounted, 2)).toContain("┌");
+        expect(rowText(mounted, 3)).toContain("$$\\frac{a}{b}$$");
+        expect(rowText(mounted, 4)).toContain("└");
+      } finally {
+        renderer.dispose();
+        mounted.unmount();
+      }
+    });
+  });
+
+  it("shows a boxed raw formula when graphics are unsupported", async () => {
+    const mounted = await mountTerminal(
+      () =>
+        h(TMarkdownText, {
+          x: 0,
+          y: 0,
+          w: 40,
+          h: 8,
+          content: "before\n\n$$\n\\int_0^1 x^2\\,dx\n$$\n\nafter",
+        }),
+      40,
+      10,
+    );
+
+    try {
+      await nextTick();
+      mounted.scheduler()?.flushNow();
+      expect(rowText(mounted, 0)).toBe("before");
+      expect(rowText(mounted, 2)).toContain("┌");
+      expect(rowText(mounted, 3)).toContain("$$\\int_0^1 x^2\\,dx$$");
+      expect(rowText(mounted, 4)).toContain("└");
+      expect(rowText(mounted, 6)).toBe("after");
+    } finally {
+      mounted.unmount();
+    }
+  });
+
+  it("emits mathAction with original TeX when a rendered block formula is clicked", async () => {
+    setMarkdownMathRasterizer(async () => ({
+      base64: FAKE_PNG_B64,
+      widthCells: 14,
+      heightCells: 3,
+    }));
+
+    const actions: unknown[] = [];
+    await withEnv(KITTY_ENV, async () => {
+      const { mounted, renderer } = await mountWithGraphics(
+        () =>
+          h(TMarkdownText, {
+            x: 0,
+            y: 0,
+            w: 40,
+            h: 8,
+            content: "before\n\n$$\n\\frac{a}{b}\n$$\n\nafter",
+            mathActions: true,
+            onMathAction: (payload: unknown) => actions.push(payload),
+          }),
+        40,
+        10,
+      );
+
+      try {
+        // Click inside the second row of the rendered formula image.
+        clickCell(mounted, 4, 3);
+
+        expect(actions).toHaveLength(1);
+        expect(actions[0]).toMatchObject({
+          cellX: 4,
+          cellY: 3,
+          math: { raw: "$$\\frac{a}{b}$$", source: "\\frac{a}{b}", rendered: true },
+        });
+      } finally {
+        renderer.dispose();
+        mounted.unmount();
+      }
+    });
+  });
+
+  it("rasterizes once and reuses the cache on rebuilds", async () => {
+    let calls = 0;
+    setMarkdownMathRasterizer(async () => {
+      calls++;
+      return { base64: FAKE_PNG_B64, widthCells: 14, heightCells: 3 };
+    });
+
+    await withEnv(KITTY_ENV, async () => {
+      const { renderer, mounted } = await mountWithGraphics(
+        () =>
+          h(TMarkdownText, {
+            x: 0,
+            y: 0,
+            w: 40,
+            h: 10,
+            content: "$$\n\\frac{a}{b}\n$$\n\nafter",
+          }),
+        40,
+        10,
+      );
+
+      try {
+        expect(calls).toBe(1);
+
+        mounted.scheduler()?.flushNow();
+        await nextTick();
+        mounted.scheduler()?.flushNow();
+        (renderer as any).render(undefined, true);
+        expect(calls).toBe(1);
+      } finally {
+        renderer.dispose();
+        mounted.unmount();
+      }
+    });
+  });
+
+  it("rasterizes short inline math into the text row; tall inline stays raw", async () => {
+    let rasterized = 0;
+    setMarkdownMathRasterizer(async (tex, mode) => {
+      expect(mode).toBe("inline");
+      if (tex.includes("begin")) return null;
+      rasterized++;
+      return { base64: FAKE_PNG_B64, widthCells: tex.length, heightCells: 1 };
+    });
+
+    const actions: unknown[] = [];
+    await withEnv(KITTY_ENV, async () => {
+      const { mounted, stdout, renderer } = await mountWithGraphics(
+        () =>
+          h(TMarkdownText, {
+            x: 0,
+            y: 0,
+            w: 80,
+            h: 4,
+            content:
+              "inline $e^{i\\pi}+1=0$ here and $\\begin{bmatrix}1&2\\\\3&4\\end{bmatrix}$ raw",
+            mathActions: true,
+            onMathAction: (payload: unknown) => actions.push(payload),
+          }),
+        80,
+        6,
+      );
+
+      try {
+        // Only the short formula is rasterized; the matrix stays raw.
+        expect(rasterized).toBe(1);
+        expect(stdout()).toContain("\u001B_G");
+        const visible = [0, 1].map((y) => rowText(mounted, y)).join(" ");
+        expect(visible).toContain("inline");
+        expect(visible).not.toContain("$e^{i\\pi}+1=0$");
+        expect(visible).toContain("here");
+        expect(visible).toContain("$\\begin{bmatrix}1&2\\\\3&4\\end{bmatrix}$");
+
+        clickCell(mounted, 7, 0);
+        expect(actions).toHaveLength(1);
+        expect(actions[0]).toMatchObject({
+          math: { raw: "$e^{i\\pi}+1=0$", rendered: true },
+        });
+      } finally {
+        renderer.dispose();
+        mounted.unmount();
+      }
+    });
+  });
+
+  it("renders common inline formulas and falls back to raw for malformed TeX", async () => {
+    clearMarkdownMathImageCache();
+    // Builtin MathJax+resvg path (no custom rasterizer).
+    expect(await loadMarkdownMathImageRenderer()).toBe(true);
+
+    const valid = await getMarkdownMathImage("x^{2}+\\sqrt{y}", "inline", {});
+    const fraction = await getMarkdownMathImage("\\frac{1}{2}", "inline", {});
+    const matrix = await getMarkdownMathImage(
+      "\\begin{bmatrix}1&2\\\\3&4\\end{bmatrix}",
+      "inline",
+      {},
+    );
+    const malformed = await getMarkdownMathImage("\\frac{1}{", "inline", {});
+
+    expect(valid).not.toBeNull();
+    expect(fraction).not.toBeNull();
+    // Tall matrices and malformed TeX stay raw (negative-cached).
+    expect(matrix).toBeNull();
+    expect(malformed).toBeNull();
+  });
+});

--- a/tsdown.config.mjs
+++ b/tsdown.config.mjs
@@ -19,7 +19,14 @@ const nodeBuiltins = Array.from(
   ]),
 );
 
-const browserExternals = ["vue", "stream-markdown-parser", "beautiful-mermaid", "katex"];
+const browserExternals = [
+  "vue",
+  "stream-markdown-parser",
+  "beautiful-mermaid",
+  "katex",
+  "mathjax-full",
+  "@resvg/resvg-js",
+];
 
 // Production builds: strip performance instrumentation via dead-code elimination
 const productionDefine = {
@@ -104,7 +111,7 @@ export default defineConfig([
     clean: false,
     dts: false,
     platform: "node",
-    external: ["vue", "bun-webgpu", "katex", ...nodeBuiltins],
+    external: ["vue", "bun-webgpu", "katex", "mathjax-full", "@resvg/resvg-js", ...nodeBuiltins],
     define: productionDefine,
     treeshake: true,
     plugins: [instrumentationStripPlugin("esm-cli")],


### PR DESCRIPTION
## 概述

三个方向的改动，已在本地按 CI 顺序验证通过（typecheck / lint / format / test:unit / coverage / build:checked / dist 检查 / docs / api）。

### 1. Markdown 数学公式渲染为终端图形图片
- `feat(markdown): render math formulas as terminal graphics images`
- MathJax+resvg 光栅化 → Kitty/iTerm2 PNG 图片；块级公式替换 box，行内公式混排；无图形能力时回退 box/原始 TeX
- `fix: keep resvg math rasterizer out of browser bundles`：resvg 是 Node 原生模块，动态 import 改为非字面量 specifier，避免浏览器打包器去解析 `.node` 绑定（同时更新 stdout renderer 类型 fixture，补 `forceRender`）

### 2. Video/Image 终端图形序列去重
- `refactor: share PNG terminal graphic sequence generation between image renderer and TVideo`
- 新增 `createTerminalGraphicPngSequence`（`src/renderer/terminal-graphics.ts`），`createPngTerminalGraphicRenderer` 与 `TVideo` 共用 kitty/iTerm2 序列生成 + viewport 裁剪
- 纯内部重构：无公共 API 变化，输出逐字节一致（tvideo / agent-terminal-graphic 共 185 个用例通过），无性能回退（TVideo 保持同步渲染、懒 base64）

### 3. stdout renderer 底部锚定 REPL 栏
- `feat: add bottom-anchored REPL bar mode to stdout renderer` + `fix: preserve bottom REPL history and IME anchor`
- 底部锚定模式与 IME 锚点保留

### 维护
- `style`: oxfmt 格式化 docs / api metadata；`chore`: chat-cli import 格式化

## CI 相关说明
- 本地已复现 CI verify job 主要步骤并全部通过
- resvg 浏览器打包问题和 `test:types:dist` fixture 缺口已修复